### PR TITLE
Add config-driven guarded MIPS patches

### DIFF
--- a/docs/config_schema.md
+++ b/docs/config_schema.md
@@ -86,12 +86,44 @@ bios_thunks = "seeds/tomba_bios_thunks.txt"                # game-only
 out_dir     = "generated"                                  # both
 strict      = true                                         # both — currently always true
 out_stem    = "SCPH1001"                                   # optional; overrides the auto-derived stem
+
+[[recompiler.patch]]
+id          = "descriptive-policy-name"
+address     = "0x80012340"
+expected    = "0x24020002"
+replacement = "0x24020001"
+note        = "Why this game-owned instruction change is required" # optional
 ```
 
 Output filenames: `<out_dir>/<out_stem>_full.c` and
 `<out_dir>/<out_stem>_dispatch.c`. If `out_stem` is omitted, it's derived
 from the `rom`/`exe` file basename with the trailing `.BIN` or `.EXE`
 stripped (`Path.stem` is NOT used because it mishandles `SCUS_942.36`).
+
+Each `[[recompiler.patch]]` replaces one exact 32-bit MIPS word before function
+discovery, control-flow analysis, and normal translation. It is intended for
+small, understood game-code changes whose
+addresses, opcodes, and policy remain in the game repository. The framework
+does not contain title IDs or title-specific addresses.
+
+- `id`, `address`, `expected`, and `replacement` are required hex/string
+  fields; `note` is optional.
+- IDs are case-sensitive and unique within one config.
+- Addresses must be four-byte aligned and are unique by the PSX 29-bit physical
+  address. Thus `0x00012340`, `0x80012340`, and `0xA0012340` are aliases of one
+  site and cannot define separate patches.
+- Main-EXE generation fails if the word at the target site is not `expected`.
+  This catches a wrong disc revision or stale patch instead of guessing.
+- Captured overlays may place unrelated variants at one virtual address. In
+  overlay mode, a patch is applied only to a variant whose word is `expected`;
+  a nonmatching variant is translated unchanged.
+- When `--config` and `--ws-config` supply the same byte-identical patch it is
+  deduplicated. Reusing an ID or physical address for different patch data is
+  an error.
+
+Patches are build-time inputs, not runtime memory writes or live toggles.
+Regenerate the affected main executable or captured overlays after changing
+them.
 
 ## Runtime block
 

--- a/docs/internal/upstream/guarded_mips_patches.md
+++ b/docs/internal/upstream/guarded_mips_patches.md
@@ -1,0 +1,33 @@
+# Guarded MIPS patch upstream provenance
+
+This focused implementation was rebuilt for current `mstan/psxrecomp` from
+Douglas's declarative-patch work in
+[`mstan/psxrecomp` PR #15](https://github.com/mstan/psxrecomp/pull/15), exact
+source commit
+[`19001c0a383edde439988b93eb2385e2d789d350`](https://github.com/douglasjv/psxrecomp-tweaks/commit/19001c0a383edde439988b93eb2385e2d789d350).
+The implementation keeps the original design: game-owned instruction data,
+an exact opcode guard, replacement before ordinary MIPS-to-C translation, and
+guarded overlay variants. This rebuild applies replacements before discovery
+and control-flow analysis as well, so patched branches cannot leave the
+generated graph based on stale bytes.
+
+The upstreaming scope intentionally includes only:
+
+- the typed `[[recompiler.patch]]` schema and loader;
+- physical-alias-aware uniqueness and lookup;
+- main-EXE failure on an opcode mismatch;
+- overlay nonmatch pass-through;
+- focused parser/code-generation tests and schema documentation.
+
+It intentionally excludes all other work from PR #15 and subsequent Douglas
+branches: signed widescreen bounds, textured-edge expansion, full-mirror
+rendering, OpenGL context changes, CPU-copied-overlay fallback, debug/input
+controls, and every game repository or title-specific address. Those concerns
+require independent review and validation before any separate upstreaming.
+
+Authorship from the source implementation is retained in the integrating
+commit with:
+
+```text
+Co-authored-by: douglasjv <vanderveerdouglas@gmail.com>
+```

--- a/recompiler/CMakeLists.txt
+++ b/recompiler/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.20)
 project(PSXRecomp C CXX)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+include(CTest)
 
 add_subdirectory(lib/fmt)
 
@@ -72,6 +73,7 @@ set(PSXRECOMP_GAME_SOURCES
     src/code_generator.cpp
     src/annotations.cpp
     src/config_loader.cpp
+    src/recompiler_patch.cpp
     src/main_psx.cpp
 )
 
@@ -160,6 +162,7 @@ add_executable(psxrecomp-bios
     src/function_discovery.cpp
     src/full_function_emitter.cpp
     src/config_loader.cpp
+    src/recompiler_patch.cpp
     src/main_bios.cpp
 )
 target_include_directories(psxrecomp-bios PRIVATE
@@ -206,3 +209,28 @@ target_include_directories(l2_structural_test PRIVATE
     lib/fmt/include
 )
 target_link_libraries(l2_structural_test PRIVATE fmt rabbitizer)
+
+if(BUILD_TESTING)
+    add_executable(recompiler_patch_test
+        tests/recompiler_patch_test.cpp
+        src/ps1_exe_parser.cpp
+        src/mips_decoder.cpp
+        src/control_flow.cpp
+        src/function_analysis.cpp
+        src/code_generator.cpp
+        src/annotations.cpp
+        src/config_loader.cpp
+        src/recompiler_patch.cpp
+    )
+    target_include_directories(recompiler_patch_test PRIVATE
+        include
+        src
+        lib/rabbitizer/include
+        lib/rabbitizer/cplusplus/include
+        lib/fmt/include
+        lib/toml11
+        lib/ELFIO
+    )
+    target_link_libraries(recompiler_patch_test PRIVATE fmt rabbitizer)
+    add_test(NAME recompiler_patch_test COMMAND recompiler_patch_test)
+endif()

--- a/recompiler/CMakeLists.txt
+++ b/recompiler/CMakeLists.txt
@@ -233,4 +233,15 @@ if(BUILD_TESTING)
     )
     target_link_libraries(recompiler_patch_test PRIVATE fmt rabbitizer)
     add_test(NAME recompiler_patch_test COMMAND recompiler_patch_test)
+
+    add_executable(recompiler_patch_cxx17_header_test
+        tests/recompiler_patch_cxx17_header_test.cpp
+    )
+    target_include_directories(recompiler_patch_cxx17_header_test PRIVATE src)
+    set_target_properties(recompiler_patch_cxx17_header_test PROPERTIES
+        CXX_STANDARD 17
+        CXX_STANDARD_REQUIRED ON
+    )
+    add_test(NAME recompiler_patch_cxx17_header_test
+             COMMAND recompiler_patch_cxx17_header_test)
 endif()

--- a/recompiler/src/config_loader.cpp
+++ b/recompiler/src/config_loader.cpp
@@ -4,6 +4,7 @@
 
 #include <cctype>
 #include <fstream>
+#include <set>
 #include <stdexcept>
 #include <string>
 
@@ -709,6 +710,52 @@ GameConfig load_game_config(const fs::path& config_path_in) {
         out_stem = derive_out_stem(fs::path(exe_field).filename().string());
     }
 
+    std::vector<RecompilerPatch> recompiler_patches;
+    if (recomp.contains("patch")) {
+        const auto& patches = toml::find<toml::array>(recomp, "patch");
+        std::set<std::string> seen_ids;
+        std::set<uint32_t> seen_addresses;
+        for (const auto& item : patches) {
+            RecompilerPatch patch;
+            patch.id = toml::find<std::string>(item, "id");
+            patch.address = parse_hex(toml::find<std::string>(item, "address"),
+                                      "recompiler.patch.address");
+            patch.expected = parse_hex(toml::find<std::string>(item, "expected"),
+                                       "recompiler.patch.expected");
+            patch.replacement = parse_hex(
+                toml::find<std::string>(item, "replacement"),
+                "recompiler.patch.replacement");
+            if (item.contains("note")) {
+                patch.note = toml::find<std::string>(item, "note");
+            }
+
+            if (patch.id.empty()) {
+                throw std::runtime_error(
+                    "recompiler.patch.id must not be empty");
+            }
+            if ((patch.address & 3u) != 0u) {
+                throw std::runtime_error(fmt::format(
+                    "{}: recompiler patch '{}' address 0x{:08X} is not "
+                    "instruction-aligned",
+                    config_path.string(), patch.id, patch.address));
+            }
+            if (!seen_ids.insert(patch.id).second) {
+                throw std::runtime_error(fmt::format(
+                    "{}: duplicate [[recompiler.patch]] id '{}'",
+                    config_path.string(), patch.id));
+            }
+            const uint32_t address_key =
+                recompiler_patch_address_key(patch.address);
+            if (!seen_addresses.insert(address_key).second) {
+                throw std::runtime_error(fmt::format(
+                    "{}: duplicate [[recompiler.patch]] physical address "
+                    "0x{:08X} (KUSEG/KSEG aliases are one site)",
+                    config_path.string(), address_key));
+            }
+            recompiler_patches.push_back(std::move(patch));
+        }
+    }
+
     // Optional [widescreen] block — per-game hooks for the widescreen hack.
     std::vector<uint32_t> ws_sprite_tag_funcs;
     uint32_t ws_sprite_anchor_addr = 0;
@@ -940,6 +987,7 @@ GameConfig load_game_config(const fs::path& config_path_in) {
         /*out_dir*/          out_dir,
         /*strict*/           strict,
         /*out_stem*/         out_stem,
+        /*recompiler_patches*/ recompiler_patches,
         /*runtime*/          parse_runtime_block(cfg, root),
         /*ws_sprite_tag_funcs*/   ws_sprite_tag_funcs,
         /*ws_sprite_anchor_addr*/ ws_sprite_anchor_addr,

--- a/recompiler/src/config_loader.h
+++ b/recompiler/src/config_loader.h
@@ -23,6 +23,8 @@
 #include <string>
 #include <vector>
 
+#include "recompiler_patch.h"
+
 namespace PSXRecompV4 {
 
 // Pad input mode (per player). Replaces the old analog on/off boolean.
@@ -387,6 +389,9 @@ struct GameConfig {
     std::filesystem::path out_dir;
     bool                  strict;
     std::string           out_stem;       // derived if not explicit
+    // Game-owned, exact MIPS word replacements. IDs and physical instruction
+    // addresses are unique within a config; see docs/config_schema.md.
+    std::vector<RecompilerPatch> recompiler_patches;
 
     // [runtime] block (optional)
     RuntimeConfig         runtime;

--- a/recompiler/src/main_psx.cpp
+++ b/recompiler/src/main_psx.cpp
@@ -129,6 +129,7 @@ int main(int argc, char** argv) {
     std::set<uint32_t>    ws_backdrop_unsquash; // [widescreen.backdrop] unsquash_funcs
     bool                  ws_auto_screen_x_cull = false; // [widescreen.cull] auto_screen_x
     std::set<uint32_t>    persist_init_sites;   // [persist_options] init-store hooks (game_options.toml)
+    std::vector<PSXRecompV4::RecompilerPatch> instruction_patches;
     bool                  ws_auto_backdrop_preload = false; // [widescreen.cull] auto_backdrop
     uint32_t              ws_bg2d_count_site = 0, ws_bg2d_startcol_site = 0,
                           ws_bg2d_startx_site = 0,
@@ -145,6 +146,7 @@ int main(int argc, char** argv) {
         extra_funcs_storage  = cfg.seeds_path.string();
         extra_funcs_path     = extra_funcs_storage.c_str();
         out_dir              = cfg.out_dir;
+        instruction_patches  = cfg.recompiler_patches;
         ws_tag_funcs.insert(cfg.ws_sprite_tag_funcs.begin(),
                             cfg.ws_sprite_tag_funcs.end());
         ws_cull_bias.insert(cfg.ws_cull_bias_sites.begin(), cfg.ws_cull_bias_sites.end());
@@ -237,6 +239,8 @@ int main(int argc, char** argv) {
         ws_backdrop_unsquash.insert(wscfg.ws_backdrop_unsquash_funcs.begin(), wscfg.ws_backdrop_unsquash_funcs.end());
         ws_auto_screen_x_cull = ws_auto_screen_x_cull || wscfg.ws_auto_screen_x_cull;
         ws_auto_backdrop_preload = ws_auto_backdrop_preload || wscfg.ws_auto_backdrop_preload;
+        PSXRecompV4::merge_recompiler_patches(
+            instruction_patches, wscfg.recompiler_patches);
         if (wscfg.ws_bg2d_init_func) ws_bg2d_init_func = wscfg.ws_bg2d_init_func;
         fmt::print("ws-config:      {} (backdrop_x sites={}, unsquash funcs={})\n",
                    ws_config_path.string(), ws_backdrop_x.size(), ws_backdrop_unsquash.size());
@@ -252,6 +256,11 @@ int main(int argc, char** argv) {
         fmt::print(stderr, "Failed to parse PS1-EXE: {}\n", error_msg);
         return 1;
     }
+
+    // Patch the parsed image before discovery/CFG analysis so replacements of
+    // control-flow instructions cannot disagree with the generated graph.
+    PSXRecompV4::apply_recompiler_patches_to_executable(
+        *exe, instruction_patches, overlay_mode);
 
     fmt::print("✓ Successfully parsed PS1-EXE!\n\n");
 

--- a/recompiler/src/recompiler_patch.cpp
+++ b/recompiler/src/recompiler_patch.cpp
@@ -23,10 +23,6 @@ uint32_t apply_one_recompiler_patch(const RecompilerPatch& patch,
 
 } // namespace
 
-uint32_t recompiler_patch_address_key(uint32_t address) {
-    return address & 0x1FFFFFFFu;
-}
-
 uint32_t apply_recompiler_patch(const std::vector<RecompilerPatch>& patches,
                                 uint32_t address,
                                 uint32_t observed,

--- a/recompiler/src/recompiler_patch.cpp
+++ b/recompiler/src/recompiler_patch.cpp
@@ -7,30 +7,41 @@
 
 namespace PSXRecompV4 {
 
+namespace {
+
+uint32_t apply_one_recompiler_patch(const RecompilerPatch& patch,
+                                    uint32_t address,
+                                    uint32_t observed,
+                                    bool overlay_mode) {
+    if (observed == patch.expected) return patch.replacement;
+    if (overlay_mode) return observed;
+    throw std::runtime_error(fmt::format(
+        "recompiler patch '{}' expected 0x{:08X} at 0x{:08X}, found "
+        "0x{:08X}; wrong game revision or stale patch",
+        patch.id, patch.expected, address, observed));
+}
+
+} // namespace
+
 uint32_t recompiler_patch_address_key(uint32_t address) {
     return address & 0x1FFFFFFFu;
 }
 
-uint32_t apply_recompiler_patch(std::span<const RecompilerPatch> patches,
+uint32_t apply_recompiler_patch(const std::vector<RecompilerPatch>& patches,
                                 uint32_t address,
                                 uint32_t observed,
                                 bool overlay_mode) {
     const uint32_t address_key = recompiler_patch_address_key(address);
     for (const auto& patch : patches) {
         if (recompiler_patch_address_key(patch.address) != address_key) continue;
-        if (observed == patch.expected) return patch.replacement;
-        if (overlay_mode) return observed;
-        throw std::runtime_error(fmt::format(
-            "recompiler patch '{}' expected 0x{:08X} at 0x{:08X}, found "
-            "0x{:08X}; wrong game revision or stale patch",
-            patch.id, patch.expected, address, observed));
+        return apply_one_recompiler_patch(patch, address, observed, overlay_mode);
     }
     return observed;
 }
 
 void apply_recompiler_patches_to_executable(
     PSXRecomp::PS1Executable& executable,
-    std::span<const RecompilerPatch> patches,
+    const std::vector<RecompilerPatch>& patches,
     bool overlay_mode) {
     const uint32_t load_key =
         recompiler_patch_address_key(executable.load_address());
@@ -49,9 +60,8 @@ void apply_recompiler_patches_to_executable(
             (static_cast<uint32_t>(executable.code_data[offset + 1]) << 8) |
             (static_cast<uint32_t>(executable.code_data[offset + 2]) << 16) |
             (static_cast<uint32_t>(executable.code_data[offset + 3]) << 24);
-        const uint32_t resolved = apply_recompiler_patch(
-            std::span<const RecompilerPatch>(&patch, 1), patch.address,
-            observed, overlay_mode);
+        const uint32_t resolved = apply_one_recompiler_patch(
+            patch, patch.address, observed, overlay_mode);
         if (resolved == observed) continue;
 
         executable.code_data[offset] = static_cast<uint8_t>(resolved);
@@ -62,7 +72,7 @@ void apply_recompiler_patches_to_executable(
 }
 
 void merge_recompiler_patches(std::vector<RecompilerPatch>& destination,
-                              std::span<const RecompilerPatch> incoming) {
+                              const std::vector<RecompilerPatch>& incoming) {
     for (const auto& candidate : incoming) {
         bool repeated = false;
         for (const auto& existing : destination) {

--- a/recompiler/src/recompiler_patch.cpp
+++ b/recompiler/src/recompiler_patch.cpp
@@ -1,0 +1,93 @@
+#include "recompiler_patch.h"
+
+#include <stdexcept>
+
+#include "fmt/format.h"
+#include "ps1_exe_parser.h"
+
+namespace PSXRecompV4 {
+
+uint32_t recompiler_patch_address_key(uint32_t address) {
+    return address & 0x1FFFFFFFu;
+}
+
+uint32_t apply_recompiler_patch(std::span<const RecompilerPatch> patches,
+                                uint32_t address,
+                                uint32_t observed,
+                                bool overlay_mode) {
+    const uint32_t address_key = recompiler_patch_address_key(address);
+    for (const auto& patch : patches) {
+        if (recompiler_patch_address_key(patch.address) != address_key) continue;
+        if (observed == patch.expected) return patch.replacement;
+        if (overlay_mode) return observed;
+        throw std::runtime_error(fmt::format(
+            "recompiler patch '{}' expected 0x{:08X} at 0x{:08X}, found "
+            "0x{:08X}; wrong game revision or stale patch",
+            patch.id, patch.expected, address, observed));
+    }
+    return observed;
+}
+
+void apply_recompiler_patches_to_executable(
+    PSXRecomp::PS1Executable& executable,
+    std::span<const RecompilerPatch> patches,
+    bool overlay_mode) {
+    const uint32_t load_key =
+        recompiler_patch_address_key(executable.load_address());
+    const uint64_t image_end =
+        static_cast<uint64_t>(load_key) + executable.code_data.size();
+
+    for (const auto& patch : patches) {
+        const uint32_t patch_key = recompiler_patch_address_key(patch.address);
+        if (patch_key < load_key || static_cast<uint64_t>(patch_key) + 4u > image_end) {
+            continue; // The patch may target a different captured overlay image.
+        }
+
+        const size_t offset = static_cast<size_t>(patch_key - load_key);
+        const uint32_t observed =
+            static_cast<uint32_t>(executable.code_data[offset]) |
+            (static_cast<uint32_t>(executable.code_data[offset + 1]) << 8) |
+            (static_cast<uint32_t>(executable.code_data[offset + 2]) << 16) |
+            (static_cast<uint32_t>(executable.code_data[offset + 3]) << 24);
+        const uint32_t resolved = apply_recompiler_patch(
+            std::span<const RecompilerPatch>(&patch, 1), patch.address,
+            observed, overlay_mode);
+        if (resolved == observed) continue;
+
+        executable.code_data[offset] = static_cast<uint8_t>(resolved);
+        executable.code_data[offset + 1] = static_cast<uint8_t>(resolved >> 8);
+        executable.code_data[offset + 2] = static_cast<uint8_t>(resolved >> 16);
+        executable.code_data[offset + 3] = static_cast<uint8_t>(resolved >> 24);
+    }
+}
+
+void merge_recompiler_patches(std::vector<RecompilerPatch>& destination,
+                              std::span<const RecompilerPatch> incoming) {
+    for (const auto& candidate : incoming) {
+        bool repeated = false;
+        for (const auto& existing : destination) {
+            const bool same_id = existing.id == candidate.id;
+            const bool same_address =
+                recompiler_patch_address_key(existing.address) ==
+                recompiler_patch_address_key(candidate.address);
+            if (!same_id && !same_address) continue;
+
+            const bool identical = same_id && same_address &&
+                existing.expected == candidate.expected &&
+                existing.replacement == candidate.replacement &&
+                existing.note == candidate.note;
+            if (!identical) {
+                throw std::runtime_error(fmt::format(
+                    "conflicting recompiler patches '{}' at 0x{:08X} and '{}' "
+                    "at 0x{:08X}",
+                    existing.id, existing.address, candidate.id,
+                    candidate.address));
+            }
+            repeated = true;
+            break;
+        }
+        if (!repeated) destination.push_back(candidate);
+    }
+}
+
+} // namespace PSXRecompV4

--- a/recompiler/src/recompiler_patch.h
+++ b/recompiler/src/recompiler_patch.h
@@ -21,7 +21,9 @@ struct RecompilerPatch {
     std::string note;
 };
 
-uint32_t recompiler_patch_address_key(uint32_t address);
+inline uint32_t recompiler_patch_address_key(uint32_t address) {
+    return address & 0x1FFFFFFFu;
+}
 
 // Apply the patch targeting address, if any. A main-EXE guard mismatch throws;
 // an overlay mismatch is an expected different variant and leaves the observed

--- a/recompiler/src/recompiler_patch.h
+++ b/recompiler/src/recompiler_patch.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <cstdint>
+#include <span>
+#include <string>
+#include <vector>
+
+namespace PSXRecomp {
+class PS1Executable;
+}
+
+namespace PSXRecompV4 {
+
+// One game-owned, opcode-verified instruction replacement. Addresses use PSX
+// virtual-address spelling in TOML but compare by their 29-bit physical key, so
+// KUSEG/KSEG0/KSEG1 aliases refer to the same instruction site.
+struct RecompilerPatch {
+    std::string id;
+    uint32_t address = 0;
+    uint32_t expected = 0;
+    uint32_t replacement = 0;
+    std::string note;
+};
+
+uint32_t recompiler_patch_address_key(uint32_t address);
+
+// Apply the patch targeting address, if any. A main-EXE guard mismatch throws;
+// an overlay mismatch is an expected different variant and leaves the observed
+// instruction unchanged.
+uint32_t apply_recompiler_patch(std::span<const RecompilerPatch> patches,
+                                uint32_t address,
+                                uint32_t observed,
+                                bool overlay_mode);
+
+// Apply every in-range patch directly to the parsed image before discovery and
+// CFG analysis. This keeps control-flow replacements and emitted code in sync.
+void apply_recompiler_patches_to_executable(
+    PSXRecomp::PS1Executable& executable,
+    std::span<const RecompilerPatch> patches,
+    bool overlay_mode);
+
+// Merge patches received through --config and --ws-config. Byte-identical
+// repeats are deduplicated; conflicting IDs or aliased addresses throw.
+void merge_recompiler_patches(std::vector<RecompilerPatch>& destination,
+                              std::span<const RecompilerPatch> incoming);
+
+} // namespace PSXRecompV4

--- a/recompiler/src/recompiler_patch.h
+++ b/recompiler/src/recompiler_patch.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <cstdint>
-#include <span>
 #include <string>
 #include <vector>
 
@@ -27,7 +26,7 @@ uint32_t recompiler_patch_address_key(uint32_t address);
 // Apply the patch targeting address, if any. A main-EXE guard mismatch throws;
 // an overlay mismatch is an expected different variant and leaves the observed
 // instruction unchanged.
-uint32_t apply_recompiler_patch(std::span<const RecompilerPatch> patches,
+uint32_t apply_recompiler_patch(const std::vector<RecompilerPatch>& patches,
                                 uint32_t address,
                                 uint32_t observed,
                                 bool overlay_mode);
@@ -36,12 +35,12 @@ uint32_t apply_recompiler_patch(std::span<const RecompilerPatch> patches,
 // CFG analysis. This keeps control-flow replacements and emitted code in sync.
 void apply_recompiler_patches_to_executable(
     PSXRecomp::PS1Executable& executable,
-    std::span<const RecompilerPatch> patches,
+    const std::vector<RecompilerPatch>& patches,
     bool overlay_mode);
 
 // Merge patches received through --config and --ws-config. Byte-identical
 // repeats are deduplicated; conflicting IDs or aliased addresses throw.
 void merge_recompiler_patches(std::vector<RecompilerPatch>& destination,
-                              std::span<const RecompilerPatch> incoming);
+                              const std::vector<RecompilerPatch>& incoming);
 
 } // namespace PSXRecompV4

--- a/recompiler/tests/recompiler_patch_cxx17_header_test.cpp
+++ b/recompiler/tests/recompiler_patch_cxx17_header_test.cpp
@@ -5,5 +5,9 @@
 int main() {
     std::vector<PSXRecompV4::RecompilerPatch> patches;
     patches.push_back({"header-smoke", 0x80010000u, 0u, 0u, {}});
-    return patches.front().id == "header-smoke" ? 0 : 1;
+    return patches.front().id == "header-smoke" &&
+                   PSXRecompV4::recompiler_patch_address_key(
+                       patches.front().address) == 0x00010000u
+               ? 0
+               : 1;
 }

--- a/recompiler/tests/recompiler_patch_cxx17_header_test.cpp
+++ b/recompiler/tests/recompiler_patch_cxx17_header_test.cpp
@@ -1,0 +1,9 @@
+#include "recompiler_patch.h"
+
+#include <vector>
+
+int main() {
+    std::vector<PSXRecompV4::RecompilerPatch> patches;
+    patches.push_back({"header-smoke", 0x80010000u, 0u, 0u, {}});
+    return patches.front().id == "header-smoke" ? 0 : 1;
+}

--- a/recompiler/tests/recompiler_patch_test.cpp
+++ b/recompiler/tests/recompiler_patch_test.cpp
@@ -200,7 +200,7 @@ void codegen_tests() {
           "patch is applied before control-flow analysis");
 
     std::vector<RecompilerPatch> merged{physical_alias};
-    PSXRecompV4::merge_recompiler_patches(merged, {&physical_alias, 1});
+    PSXRecompV4::merge_recompiler_patches(merged, {physical_alias});
     check(merged.size() == 1,
           "config merge deduplicates an identical patch");
 
@@ -208,8 +208,7 @@ void codegen_tests() {
         "gameplay-rate", 0x00010004u, original, replacement, ""};
     check_throws(
         [&] {
-            PSXRecompV4::merge_recompiler_patches(
-                merged, {&conflicting_id, 1});
+            PSXRecompV4::merge_recompiler_patches(merged, {conflicting_id});
         },
         "conflicting recompiler patches",
         "config merge rejects cross-config ID conflicts");

--- a/recompiler/tests/recompiler_patch_test.cpp
+++ b/recompiler/tests/recompiler_patch_test.cpp
@@ -1,0 +1,239 @@
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <functional>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "code_generator.h"
+#include "config_loader.h"
+#include "control_flow.h"
+#include "fmt/format.h"
+#include "recompiler_patch.h"
+
+namespace fs = std::filesystem;
+using PSXRecompV4::RecompilerPatch;
+
+namespace {
+
+int failures = 0;
+
+void check(bool condition, const std::string& name) {
+    if (condition) {
+        fmt::print("PASS  {}\n", name);
+    } else {
+        fmt::print(stderr, "FAIL  {}\n", name);
+        ++failures;
+    }
+}
+
+template <typename Fn>
+void check_throws(Fn&& fn, const std::string& needle,
+                  const std::string& name) {
+    try {
+        fn();
+        check(false, name + " (did not throw)");
+    } catch (const std::exception& e) {
+        check(std::string(e.what()).find(needle) != std::string::npos,
+              name + " (" + e.what() + ")");
+    }
+}
+
+void append_word(std::vector<uint8_t>& bytes, uint32_t word) {
+    bytes.push_back(static_cast<uint8_t>(word));
+    bytes.push_back(static_cast<uint8_t>(word >> 8));
+    bytes.push_back(static_cast<uint8_t>(word >> 16));
+    bytes.push_back(static_cast<uint8_t>(word >> 24));
+}
+
+std::string generate_first_instruction(uint32_t first_word,
+                                       std::vector<RecompilerPatch> patches,
+                                       bool overlay_mode) {
+    constexpr uint32_t base = 0x80010000u;
+    PSXRecomp::PS1Executable exe{};
+    exe.header.load_address = base;
+    exe.header.initial_pc = base;
+    exe.header.file_size = 20;
+    append_word(exe.code_data, first_word);
+    append_word(exe.code_data, 0x00000000u); // branch/nonbranch delay-slot nop
+    append_word(exe.code_data, 0x24030001u); // addiu v1, zero, 1
+    append_word(exe.code_data, 0x03E00008u); // jr ra
+    append_word(exe.code_data, 0x00000000u); // return delay-slot nop
+
+    PSXRecompV4::apply_recompiler_patches_to_executable(
+        exe, patches, overlay_mode);
+
+    PSXRecomp::Function function{};
+    function.start_addr = base;
+    function.end_addr = base + 20;
+    function.size = 20;
+    function.name = "patch_test";
+
+    PSXRecomp::ControlFlowAnalyzer analyzer(exe);
+    const auto cfg = analyzer.analyze_function(function);
+    PSXRecomp::CodeGenConfig config;
+    config.overlay_mode = overlay_mode;
+    PSXRecomp::CodeGenerator generator(exe, config);
+    return generator.generate_function(function, cfg).full_code;
+}
+
+std::string base_config() {
+    return R"toml([game]
+name = "Patch Test"
+id = "TEST-00000"
+exe = "TEST.EXE"
+load_address = "0x80010000"
+entry_pc = "0x80010000"
+text_size = "0x1000"
+stack_base = "0x801FFFF0"
+
+[recompiler]
+seeds = "seeds.txt"
+out_dir = "generated"
+)toml";
+}
+
+fs::path write_config(const fs::path& root, const std::string& suffix,
+                      const std::string& patch_tables) {
+    const fs::path path = root / ("game-" + suffix + ".toml");
+    std::ofstream file(path, std::ios::binary);
+    file << base_config() << patch_tables;
+    file.close();
+    return path;
+}
+
+void parser_tests(const fs::path& root) {
+    const auto valid = write_config(root, "valid", R"toml(
+[[recompiler.patch]]
+id = "gameplay-rate"
+address = "0x80012340"
+expected = "0x24020002"
+replacement = "0x24020001"
+note = "Test-only fixture"
+)toml");
+    const auto config = PSXRecompV4::load_game_config(valid);
+    check(config.recompiler_patches.size() == 1,
+          "parser accepts one guarded patch");
+    check(config.recompiler_patches[0].id == "gameplay-rate" &&
+          config.recompiler_patches[0].address == 0x80012340u &&
+          config.recompiler_patches[0].expected == 0x24020002u &&
+          config.recompiler_patches[0].replacement == 0x24020001u,
+          "parser preserves patch fields");
+
+    const auto duplicate_address = write_config(root, "duplicate-address", R"toml(
+[[recompiler.patch]]
+id = "first"
+address = "0x80012340"
+expected = "0x24020002"
+replacement = "0x24020001"
+
+[[recompiler.patch]]
+id = "alias"
+address = "0xA0012340"
+expected = "0x24020002"
+replacement = "0x24020001"
+)toml");
+    check_throws(
+        [&] { (void)PSXRecompV4::load_game_config(duplicate_address); },
+        "physical address", "parser rejects duplicate aliased addresses");
+
+    const auto duplicate_id = write_config(root, "duplicate-id", R"toml(
+[[recompiler.patch]]
+id = "same-id"
+address = "0x80012340"
+expected = "0x24020002"
+replacement = "0x24020001"
+
+[[recompiler.patch]]
+id = "same-id"
+address = "0x80012344"
+expected = "0x24030002"
+replacement = "0x24030001"
+)toml");
+    check_throws([&] { (void)PSXRecompV4::load_game_config(duplicate_id); },
+                 "duplicate [[recompiler.patch]] id",
+                 "parser rejects duplicate IDs");
+
+    const auto unaligned = write_config(root, "unaligned", R"toml(
+[[recompiler.patch]]
+id = "unaligned"
+address = "0x80012342"
+expected = "0x24020002"
+replacement = "0x24020001"
+)toml");
+    check_throws([&] { (void)PSXRecompV4::load_game_config(unaligned); },
+                 "instruction-aligned", "parser rejects unaligned sites");
+}
+
+void codegen_tests() {
+    constexpr uint32_t original = 0x24020002u;    // addiu v0, zero, 2
+    constexpr uint32_t replacement = 0x24020001u; // addiu v0, zero, 1
+    const RecompilerPatch physical_alias{
+        "gameplay-rate", 0x00010000u, original, replacement, ""};
+
+    const std::string applied =
+        generate_first_instruction(original, {physical_alias}, false);
+    check(applied.find("0x24020001") != std::string::npos &&
+          applied.find("cpu->gpr[2] = 1;") != std::string::npos,
+          "codegen applies exact patch through physical alias");
+
+    check_throws(
+        [&] { (void)generate_first_instruction(0x24020003u,
+                                               {physical_alias}, false); },
+        "wrong game revision or stale patch",
+        "main codegen fails on stale opcode guard");
+
+    const std::string overlay =
+        generate_first_instruction(0x24020003u, {physical_alias}, true);
+    check(overlay.find("0x24020003") != std::string::npos &&
+          overlay.find("0x24020001") == std::string::npos,
+          "overlay nonmatching variant remains unchanged");
+
+    constexpr uint32_t beq_v0_zero = 0x10400002u;
+    constexpr uint32_t bne_v0_zero = 0x14400002u;
+    const RecompilerPatch branch_patch{
+        "feature-branch", 0x80010000u, beq_v0_zero, bne_v0_zero, ""};
+    const std::string branch =
+        generate_first_instruction(beq_v0_zero, {branch_patch}, false);
+    check(branch.find("cpu->gpr[2] != cpu->gpr[0]") != std::string::npos,
+          "patch is applied before control-flow analysis");
+
+    std::vector<RecompilerPatch> merged{physical_alias};
+    PSXRecompV4::merge_recompiler_patches(merged, {&physical_alias, 1});
+    check(merged.size() == 1,
+          "config merge deduplicates an identical patch");
+
+    const RecompilerPatch conflicting_id{
+        "gameplay-rate", 0x00010004u, original, replacement, ""};
+    check_throws(
+        [&] {
+            PSXRecompV4::merge_recompiler_patches(
+                merged, {&conflicting_id, 1});
+        },
+        "conflicting recompiler patches",
+        "config merge rejects cross-config ID conflicts");
+}
+
+} // namespace
+
+int main() {
+    const fs::path root = fs::temp_directory_path() /
+        fmt::format("psxrecomp-patch-test-{}", reinterpret_cast<uintptr_t>(&failures));
+    fs::remove_all(root);
+    fs::create_directories(root);
+
+    try {
+        parser_tests(root);
+        codegen_tests();
+    } catch (const std::exception& e) {
+        fmt::print(stderr, "FAIL  unexpected exception: {}\n", e.what());
+        ++failures;
+    }
+
+    std::error_code ec;
+    fs::remove_all(root, ec);
+    fmt::print("\nGuarded recompiler patches: {}\n",
+               failures == 0 ? "all tests passed" : "failures detected");
+    return failures == 0 ? 0 : 1;
+}

--- a/runtime/codegen_hash_sources.cmake
+++ b/runtime/codegen_hash_sources.cmake
@@ -22,6 +22,8 @@ set(PSXRECOMP_CODEGEN_HASH_SRCS
     ${PSXRECOMP_CODEGEN_HASH_ROOT}/recompiler/src/control_flow.cpp
     ${PSXRECOMP_CODEGEN_HASH_ROOT}/recompiler/src/basic_block.cpp
     ${PSXRECOMP_CODEGEN_HASH_ROOT}/recompiler/src/function_analysis.cpp
+    ${PSXRECOMP_CODEGEN_HASH_ROOT}/recompiler/src/recompiler_patch.cpp
+    ${PSXRECOMP_CODEGEN_HASH_ROOT}/recompiler/src/recompiler_patch.h
     ${PSXRECOMP_CODEGEN_HASH_ROOT}/recompiler/src/full_function_emitter.cpp
     ${PSXRECOMP_CODEGEN_HASH_ROOT}/recompiler/src/full_function_emitter.h
     ${PSXRECOMP_CODEGEN_HASH_ROOT}/recompiler/src/strict_translator.cpp


### PR DESCRIPTION
## Summary

Add game-owned `[[recompiler.patch]]` entries with exact opcode guards. Patches are alias-aware, validated for duplicate IDs/sites, and applied before discovery and CFG construction. Main-image mismatches fail; unrelated overlay variants pass through unchanged.

## Source and credit

Rebuilt from Douglas Vanderveer's [PR #15](https://github.com/mstan/psxrecomp/pull/15), exact source commit [19001c0a383edde439988b93eb2385e2d789d350](https://github.com/douglasjv/psxrecomp-tweaks/commit/19001c0a383edde439988b93eb2385e2d789d350). Douglas has an exact `Co-authored-by` trailer.

## Deliberately excluded

Signed widescreen bounds, textured edges/full mirror, OpenGL context changes, copied-overlay fallback, debug/input controls, game repositories, and title-specific addresses.

## Validation

- Patch CTest suite: 2/2, including a C++17 public-header consumer
- L2 structural suite: 44/44
- MinGW Debug recompiler/runtime targets: PASS
- Combined four-game regeneration/build and manual smoke pass: PASS
- `git diff --check`: PASS

Author approval: confirmed.