### PR TITLE
debug: preserve one-frame input pulses

### DIFF
--- a/docs/internal/upstream/douglas-pr15-one-frame-press.md
+++ b/docs/internal/upstream/douglas-pr15-one-frame-press.md
@@ -1,0 +1,8 @@
+# One-frame debug input pulse
+
+Source: [PSXRecomp PR #15](https://github.com/mstan/psxrecomp/pull/15),
+commit [`f44f365eb91a30396f05f0f52529d4b01b026099`](https://github.com/douglasjv/psxrecomp-tweaks/commit/f44f365eb91a30396f05f0f52529d4b01b026099).
+
+This branch isolates the fix that returns an armed input pulse before consuming
+its final frame. Widescreen signed bounds and unrelated debug tooling from the
+source commit are excluded.

--- a/runtime/src/debug_server.c
+++ b/runtime/src/debug_server.c
@@ -12916,11 +12916,12 @@ int debug_server_is_connected(void)
 
 int debug_server_get_input_override(void)
 {
+    int current = s_input_override;
     if (s_input_override >= 0 && s_input_frames > 0) {
         if (--s_input_frames == 0)
             s_input_override = -1;
     }
-    return s_input_override;
+    return current;
 }
 
 int debug_server_get_axis_override(unsigned char st[4])


### PR DESCRIPTION
Returns the armed input override before consuming its final frame, so a one-frame debug pulse reaches one guest poll. Extracted from #15 with Douglas's co-authorship preserved and merged with author approval. Verified end-to-end in Tomba 2: a one-frame Cross pulse produced exactly one jump and then cleared.