### PR TITLE
runtime: recognize CPU-copied overlay code

### DIFF
--- a/docs/internal/upstream/douglas-pr15-cpu-copied-overlay-discovery.md
+++ b/docs/internal/upstream/douglas-pr15-cpu-copied-overlay-discovery.md
@@ -1,0 +1,9 @@
+# CPU-copied overlay discovery experiment
+
+Source: [PSXRecomp PR #15](https://github.com/mstan/psxrecomp/pull/15),
+commit [`df7d1faa5f27be0ba357463a763c77efc43e1f91`](https://github.com/douglasjv/psxrecomp-tweaks/commit/df7d1faa5f27be0ba357463a763c77efc43e1f91).
+
+This branch isolates the broad dispatch fallback used for overlays copied by
+guest CPU stores. It is experimental because any dispatch above the configured
+overlay floor becomes interpreter-eligible; the macOS GL and debug-input parts
+of the source commit are excluded.

--- a/runtime/src/memory.c
+++ b/runtime/src/memory.c
@@ -510,6 +510,10 @@ int dirty_ram_is_dirty(uint32_t phys) {
     if (phys >= RAM_SIZE) return 0;
     if (dirty_ram_force_interp() && phys >= DIRTY_RAM_KERNEL_TRACK_BYTES) return 1;
     if (dirty_ram_shellwin_interp() && phys >= 0x00030000u && phys <= 0x0005AFFFu) return 1;
+    /* Experimental fallback for overlays copied into their final location by
+     * ordinary guest CPU stores rather than CD DMA. Dispatch above the static
+     * image floor is treated as dynamic and validated by the interpreter. */
+    if (phys >= g_overlay_region_floor) return 1;
     uint32_t page = phys >> DIRTY_RAM_PAGE_SHIFT;
     return (dirty_ram_bitmap[page >> 5] >> (page & 31u)) & 1u;
 }


### PR DESCRIPTION
Treats dispatches above the static game image floor as dynamic so overlays copied by ordinary guest CPU stores are validated correctly. Extracted from #15 with Douglas's co-authorship preserved and merged with author approval. Regression-tested in overlay-enabled Tomba 1, Tomba 2, and Mega Man X6; gameplay, saves, FMV, and transitions remained clean.