### PR TITLE
Add CD-DA playback and CUE pregap support

### DIFF
--- a/docs/internal/upstream/kem0x-pr14-cdda-pregap.md
+++ b/docs/internal/upstream/kem0x-pr14-cdda-pregap.md
@@ -1,0 +1,18 @@
+# PR #14 CD-DA playback and CUE pregaps
+
+Source: [kem0x PR #14](https://github.com/mstan/psxrecomp/pull/14), commit
+[`0e9df70ca2da6ec67c8e7a1f3e5aaa025fddc369`](https://github.com/mstan/psxrecomp/commit/0e9df70ca2da6ec67c8e7a1f3e5aaa025fddc369).
+
+This branch adapts the reusable Red Book CD-DA stream, Play/GetlocP behavior,
+track-end handling, and INDEX 00 pregap model to the newer multi-file CUE reader
+on current `origin/master`. It deliberately does not replace that reader with
+the older implementation from the source commit.
+
+Excluded from this branch:
+
+- the CD interrupt work from PR #14, already handled independently by PR #20;
+- title-specific behavior or addresses;
+- the source commit's older multi-file reader implementation, superseded by the
+  reader already on master.
+
+Authorship from the source commit is retained in this branch's commit trailer.

--- a/runtime/include/iso_reader.h
+++ b/runtime/include/iso_reader.h
@@ -39,7 +39,7 @@ struct RootDirectoryInfo {
 
 /**
  * A CD track parsed from the .cue sheet (or the synthesized single data
- * track for a bare .bin/.iso). Multi-track discs (Tomba 2 etc.) carry a
+ * track for a bare .bin/.iso). Multi-track discs can carry a
  * Red Book CD-DA audio track after the data track; the CD model's TOC
  * commands (GetTN/GetTD) must report them.
  */
@@ -50,6 +50,7 @@ struct CDTrack {
                          // Single-FILE cues: equals the .bin-relative INDEX time.
                          // Multi-FILE cues (redump "(Track N).bin" dumps): the
                          // owning file's first disc sector plus its INDEX time.
+    uint32_t pregap_lba; // disc-relative INDEX 00, or INDEX 01 when absent
 };
 
 /**
@@ -132,10 +133,11 @@ public:
     /**
      * CD-track TOC accessors (multi-track .cue support).
      * TrackCount() is >= 1 (a bare image synthesizes one data track).
-     * TrackStartLBA(n)/TrackIsAudio(n) take a 1-based track number.
+     * TrackStartLBA(n)/TrackPregapLBA(n)/TrackIsAudio(n) take a 1-based track number.
      */
     int      TrackCount() const;
     uint32_t TrackStartLBA(int track) const;
+    uint32_t TrackPregapLBA(int track) const;
     bool     TrackIsAudio(int track) const;
 
     /**

--- a/runtime/src/cdrom.c
+++ b/runtime/src/cdrom.c
@@ -37,6 +37,7 @@ extern void iso_close(void* handle);
 /* Multi-track TOC accessors (CD-DA / multi-track discs). track is 1-based. */
 extern int iso_track_count(void* handle);
 extern uint32_t iso_track_start_lba(void* handle, int track);
+extern uint32_t iso_track_pregap_lba(void* handle, int track);
 extern int iso_track_is_audio(void* handle, int track);
 
 /* I_STAT owned by memory.c — set bit 2 for CDROM IRQ */
@@ -202,6 +203,19 @@ static uint8_t xa_stream_file;
 static uint8_t xa_stream_channel;
 static uint8_t xa_stream_coding;
 static int xa_stream_active;
+
+/* Red Book CD-DA playback state. One raw audio sector contains exactly 588
+ * stereo frames; at 75 sectors/second this is the SPU's native 44.1 kHz. */
+#define CDDA_SECTOR_FRAMES 588
+static int cdda_playing;
+static int cdda_track;
+static uint32_t cdda_lba;
+static int cdda_delay;
+/* Natural track-end INT4 can occur while a previous CD response is still
+ * awaiting acknowledgement. Keep it pending instead of dropping the only
+ * notification the game uses to restart looping level music. */
+static int cdda_data_end_pending;
+static uint64_t cdda_sectors_played;
 
 /* Operating divisor: 1x during BIOS boot, switches to g_game_divisor
  * when the game's entry point first fires (via cdrom_notify_game_started). */
@@ -979,6 +993,11 @@ static void cdrom_clear_pending_dataready(void) {
 }
 
 static void start_read_stream(uint8_t cmd) {
+    cdda_playing = 0;
+    cdda_track = 0;
+    cdda_delay = 0;
+    cdda_data_end_pending = 0;
+    stat_reg &= (uint8_t)~CDSTAT_PLAY;
     clear_sector_buffer();
     /* Drive-state change cancels any pended notification (Beetle clears
      * AIP on Play/Read/Pause/Stop/Seek alike). */
@@ -1005,6 +1024,127 @@ static void stop_read_stream(void) {
     read_cmd = 0;
     read_delay = 0;
     cdrom_clear_pending_dataready();
+}
+
+static void stop_cdda_playback(void) {
+    cdda_playing = 0;
+    cdda_track = 0;
+    cdda_delay = 0;
+    cdda_data_end_pending = 0;
+    stat_reg &= (uint8_t)~CDSTAT_PLAY;
+}
+
+static void deliver_cdda_data_end(void) {
+    if (!cdda_data_end_pending || irq_flag != 0) return;
+    cdda_data_end_pending = 0;
+    response_clear();
+    response_push(stat_reg);
+    set_irq(CDIRQ_DATA_END);
+    fire_cdrom_irq();
+}
+
+static int cdda_track_for_lba(uint32_t lba) {
+    int count = iso_handle ? iso_track_count(iso_handle) : 0;
+    int found = 0;
+    for (int track = 1; track <= count; ++track) {
+        if (iso_track_pregap_lba(iso_handle, track) > lba) break;
+        found = track;
+    }
+    return found;
+}
+
+static uint32_t cdda_track_end_lba(int track) {
+    int count = iso_handle ? iso_track_count(iso_handle) : 0;
+    if (track > 0 && track < count)
+        return iso_track_pregap_lba(iso_handle, track + 1);
+    return iso_handle ? iso_sector_count(iso_handle) : 0;
+}
+
+static int start_cdda_playback(int requested_track) {
+    uint32_t lba;
+    int track;
+    if (requested_track > 0) {
+        track = requested_track;
+        lba = iso_track_start_lba(iso_handle, track);
+    } else {
+        int pos = s_setloc_lba >= 0
+            ? s_setloc_lba
+            : msf_to_lba(seek_min, seek_sec, seek_sect);
+        if (pos < 0) pos = 0;
+        lba = (uint32_t)pos;
+        track = cdda_track_for_lba(lba);
+    }
+
+    if (track <= 0 || track > iso_track_count(iso_handle) ||
+        !iso_track_is_audio(iso_handle, track))
+        return 0;
+
+    stop_read_stream();
+    spu_cd_audio_reset();
+    cdda_data_end_pending = 0;
+    cdda_playing = 1;
+    cdda_track = track;
+    cdda_lba = lba;
+    cdda_delay = CDROM_SINGLE_SPEED_SECTOR_CYCLES;
+    stat_reg = (stat_reg & ~(CDSTAT_SEEK | CDSTAT_READ)) |
+               CDSTAT_MOTOR | CDSTAT_PLAY;
+    return 1;
+}
+
+static void process_cdda_stream(uint32_t cycles) {
+    if (!cdda_playing) {
+        deliver_cdda_data_end();
+        return;
+    }
+    cdda_delay -= (int)cycles;
+
+    int delivered = 0;
+    while (cdda_playing && cdda_delay <= 0 && delivered < 16) {
+        uint8_t raw[RAW_SECTOR_SIZE];
+        int16_t pcm[CDDA_SECTOR_FRAMES * 2];
+        if (!iso_read_raw_sector(iso_handle, cdda_lba, raw, sizeof(raw))) {
+            memset(pcm, 0, sizeof(pcm));
+        } else {
+            /* BIN/CUE CD-DA sectors store signed 16-bit interleaved stereo in
+             * little-endian byte order. */
+            for (int i = 0; i < CDDA_SECTOR_FRAMES * 2; ++i) {
+                uint16_t u = (uint16_t)raw[i * 2 + 0] |
+                             ((uint16_t)raw[i * 2 + 1] << 8);
+                pcm[i] = (int16_t)u;
+            }
+        }
+
+        if (cd_muted) memset(pcm, 0, sizeof(pcm));
+        cd_apply_decode_volume(pcm, CDDA_SECTOR_FRAMES);
+        spu_cd_audio_push(pcm, CDDA_SECTOR_FRAMES);
+        cdda_sectors_played++;
+        trace_cdrom('a', 0, cdda_lba, (uint32_t)cdda_track);
+
+        cdda_lba++;
+        delivered++;
+        cdda_delay += CDROM_SINGLE_SPEED_SECTOR_CYCLES;
+
+        uint32_t track_end = cdda_track_end_lba(cdda_track);
+        if (track_end == 0 || cdda_lba >= track_end) {
+            int next = cdda_track + 1;
+            int count = iso_track_count(iso_handle);
+            if ((mode_reg & 0x02u) || next > count ||
+                !iso_track_is_audio(iso_handle, next)) {
+                stop_cdda_playback();
+                cdda_data_end_pending = 1;
+                deliver_cdda_data_end();
+            } else {
+                cdda_track = next;
+            }
+        }
+    }
+
+    /* A very large host-side cycle jump must not create an unbounded catch-up
+     * burst. Resume at the authentic next-sector cadence. */
+    if (cdda_playing && cdda_delay <= 0)
+        cdda_delay = CDROM_SINGLE_SPEED_SECTOR_CYCLES;
+
+    deliver_cdda_data_end();
 }
 
 static int data_fifo_ready(void) {
@@ -1202,6 +1342,7 @@ static void exec_command(uint8_t cmd) {
                 * hangs: Tsumu Light's CD library retries Stop forever (~90-frame
                 * timeout) and never advances past its first content load. */
         stop_read_stream();
+        stop_cdda_playback();
         xa_reset_decode();
         spu_cd_audio_reset();
         stat_reg &= ~(CDSTAT_READ | CDSTAT_PLAY | CDSTAT_SEEK);
@@ -1216,9 +1357,10 @@ static void exec_command(uint8_t cmd) {
     case 0x09: { /* Pause */
         int complete_delay = pause_complete_delay_cycles();
         stop_read_stream();
+        stop_cdda_playback();
         xa_reset_decode();
         spu_cd_audio_reset();
-        stat_reg &= ~CDSTAT_READ;
+        stat_reg &= ~(CDSTAT_READ | CDSTAT_PLAY);
         response_push(stat_reg);
         set_irq(CDIRQ_ACK);
         pending.cmd = 0x09;
@@ -1230,6 +1372,7 @@ static void exec_command(uint8_t cmd) {
 
     case 0x0A: /* Init */
         stop_read_stream();
+        stop_cdda_playback();
         spu_cd_audio_reset();
         xa_reset_decode();
         stat_reg = has_disc() ? CDSTAT_MOTOR : CDSTAT_SHELL;
@@ -1308,7 +1451,13 @@ static void exec_command(uint8_t cmd) {
 
     case 0x11: { /* GetlocP */
         int lba;
-        if (reading) {
+        int track = 1;
+        int track_lba = 0;
+        if (cdda_playing) {
+            lba = (int)cdda_lba;
+            track = cdda_track;
+            track_lba = (int)iso_track_start_lba(iso_handle, track);
+        } else if (reading) {
             /* GetlocP reports the drive/sub-Q position. During a read the
              * sector stream has already advanced past the data-ready sector. */
             lba = msf_to_lba(read_min, read_sec, read_sect);
@@ -1319,9 +1468,9 @@ static void exec_command(uint8_t cmd) {
         }
         int rm, rs, rf;
         int am, as, af;
-        lba_to_msf(lba, 0, &rm, &rs, &rf);
+        lba_to_msf(lba - track_lba, 0, &rm, &rs, &rf);
         lba_to_msf(lba, 150, &am, &as, &af);
-        response_push(0x01); /* single data track */
+        response_push(bin_to_bcd(track));
         response_push(0x01);
         response_push(bin_to_bcd(rm));
         response_push(bin_to_bcd(rs));
@@ -1375,28 +1524,31 @@ static void exec_command(uint8_t cmd) {
         break;
     }
 
-    case 0x03: /* Play — start CD-DA audio playback (from SetLoc, or optional
-                * param[0] = BCD track). Multi-track / CD-DA discs (Tomba 2's
-                * Whoopee Camp jingle) issue this; an unhandled Play (default ->
-                * ERROR) stalls the boot. Ack + enter PLAY state so the game's
-                * audio sequence proceeds. (Red Book sample output is not yet
-                * decoded -- silent for now -- but the flow no longer stalls.) */
+    case 0x03: /* Play — start CD-DA audio playback from SetLoc, or from the
+                * optional BCD track number in param[0]. */
         if (!has_disc()) {
             response_push(stat_reg | CDSTAT_ERROR);
             set_irq(CDIRQ_ERROR);
             break;
         }
-        stat_reg = (stat_reg & ~(CDSTAT_SEEK | CDSTAT_READ)) | CDSTAT_MOTOR | CDSTAT_PLAY;
+        {
+            int requested_track = 0;
+            if (param_count >= 1 && param_fifo[0] != 0)
+                requested_track = bcd_to_bin(param_fifo[0]);
+            if (!start_cdda_playback(requested_track)) {
+                response_push(stat_reg | CDSTAT_ERROR);
+                response_push(0x10); /* invalid track / position */
+                set_irq(CDIRQ_ERROR);
+                break;
+            }
+        }
         response_push(stat_reg);
         set_irq(CDIRQ_ACK);
         break;
 
     case 0x15: /* SeekL (data-mode seek, uses sector headers) */
-    case 0x16: /* SeekP (audio-mode seek, uses subchannel Q) — our hw-sim seeks
-                * to the SetLoc position the same way for both. Needed for
-                * multi-track / CD-DA discs (Tomba 2): the game seeks the audio
-                * track with SeekP, and an unhandled SeekP (default -> ERROR)
-                * makes its CD setup loop forever. */
+    case 0x16: /* SeekP (audio-mode seek, uses subchannel Q) — this model seeks
+                * to the SetLoc position the same way for both commands. */
         if (!has_disc()) {
             response_push(stat_reg | CDSTAT_ERROR | CDSTAT_SEEKERR);
             set_irq(CDIRQ_ERROR);
@@ -1404,6 +1556,7 @@ static void exec_command(uint8_t cmd) {
         }
         xa_reset_decode();
         spu_cd_audio_reset();
+        stop_cdda_playback();
         stat_reg |= CDSTAT_SEEK;
         response_push(stat_reg);
         set_irq(CDIRQ_ACK);
@@ -1684,6 +1837,9 @@ void cdrom_init(const char* cue_path) {
     last_sector_xa_submode = 0;
     last_sector_xa_coding = 0;
     stop_read_stream();
+    stop_cdda_playback();
+    cdda_lba = 0;
+    cdda_sectors_played = 0;
     mode_reg = 0;
     filter_file = 0;
     filter_channel = 0;
@@ -1869,6 +2025,7 @@ void cdrom_advance(uint32_t cycles) {
     try_execute_queued_command();
     process_pending(cycles);
     process_read_stream(cycles);
+    process_cdda_stream(cycles);
     refresh_cdrom_irq_line();
 }
 
@@ -2070,6 +2227,9 @@ int cdrom_load_in_progress(void) {
     /* read stream state */ \
     X(reading) X(read_min) X(read_sec) X(read_sect) X(mode_reg) \
     X(read_cmd) X(read_delay) X(filter_file) X(filter_channel) X(cd_muted) \
+    /* Red Book CD-DA stream */ \
+    X(cdda_playing) X(cdda_track) X(cdda_lba) X(cdda_delay) \
+    X(cdda_data_end_pending) X(cdda_sectors_played) \
     /* XA ADPCM decode + active-stream identity */ \
     X(xa_hist_l) X(xa_hist_r) X(xa_stream_file) X(xa_stream_channel) \
     X(xa_stream_coding) X(xa_stream_active) \

--- a/runtime/src/iso_reader.cpp
+++ b/runtime/src/iso_reader.cpp
@@ -51,6 +51,8 @@ bool ISOReader::Open(const std::string& filename) {
         bool     is_audio;
         size_t   file_index;  // index into bin_files
         uint32_t index01;     // INDEX 01 as a file-relative LBA
+        uint32_t index00;     // INDEX 00 pregap, file-relative
+        bool     has_index00;
     };
     std::vector<PendingTrack> pending_tracks;
 
@@ -72,6 +74,8 @@ bool ISOReader::Open(const std::string& filename) {
         std::string line;
         int  cur_track_num   = -1;
         bool cur_track_audio = false;
+        uint32_t cur_index00 = 0;
+        bool cur_has_index00 = false;
         while (std::getline(cue_file, line)) {
             // FILE "filename.bin" BINARY
             size_t file_pos = line.find("FILE");
@@ -104,18 +108,29 @@ bool ISOReader::Open(const std::string& filename) {
             if (std::sscanf(line.c_str(), " TRACK %d %31s", &tn, type) == 2) {
                 cur_track_num   = tn;
                 cur_track_audio = (std::strstr(type, "AUDIO") != nullptr);
+                cur_index00 = 0;
+                cur_has_index00 = false;
                 continue;
             }
 
             // INDEX 01 MM:SS:FF — the track's start (INDEX 00 is its pregap).
             int idx = 0, mm = 0, ss = 0, ff = 0;
             if (std::sscanf(line.c_str(), " INDEX %d %d:%d:%d", &idx, &mm, &ss, &ff) == 4
-                && idx == 1 && cur_track_num >= 1 && !bin_files.empty()) {
+                && cur_track_num >= 1 && !bin_files.empty()) {
+                const uint32_t index_lba = (uint32_t)(((mm * 60 + ss) * 75) + ff);
+                if (idx == 0) {
+                    cur_index00 = index_lba;
+                    cur_has_index00 = true;
+                    continue;
+                }
+                if (idx != 1) continue;
                 PendingTrack t;
                 t.number     = cur_track_num;
                 t.is_audio   = cur_track_audio;
                 t.file_index = bin_files.size() - 1;
-                t.index01    = (uint32_t)(((mm * 60 + ss) * 75) + ff);
+                t.index01    = index_lba;
+                t.index00    = cur_index00;
+                t.has_index00 = cur_has_index00;
                 pending_tracks.push_back(t);
                 cur_track_num = -1;
             }
@@ -164,6 +179,8 @@ bool ISOReader::Open(const std::string& filename) {
         t.number    = p.number;
         t.is_audio  = p.is_audio;
         t.start_lba = segments_[p.file_index].start_lba + p.index01;
+        t.pregap_lba = segments_[p.file_index].start_lba +
+                       (p.has_index00 ? p.index00 : p.index01);
         tracks_.push_back(t);
     }
 
@@ -171,7 +188,7 @@ bool ISOReader::Open(const std::string& filename) {
     // parseable TRACK entries, so TrackCount() is always >= 1.
     if (tracks_.empty()) {
         CDTrack t;
-        t.number = 1; t.is_audio = false; t.start_lba = 0;
+        t.number = 1; t.is_audio = false; t.start_lba = 0; t.pregap_lba = 0;
         tracks_.push_back(t);
     }
 
@@ -319,6 +336,13 @@ int ISOReader::TrackCount() const {
 uint32_t ISOReader::TrackStartLBA(int track) const {
     for (const auto& t : tracks_) {
         if (t.number == track) return t.start_lba;
+    }
+    return 0;
+}
+
+uint32_t ISOReader::TrackPregapLBA(int track) const {
+    for (const auto& t : tracks_) {
+        if (t.number == track) return t.pregap_lba;
     }
     return 0;
 }

--- a/runtime/src/iso_reader_c.cpp
+++ b/runtime/src/iso_reader_c.cpp
@@ -48,6 +48,11 @@ uint32_t iso_track_start_lba(void* handle, int track) {
     return static_cast<PS1::ISOReader*>(handle)->TrackStartLBA(track);
 }
 
+uint32_t iso_track_pregap_lba(void* handle, int track) {
+    auto* reader = static_cast<PS1::ISOReader*>(handle);
+    return reader ? reader->TrackPregapLBA(track) : 0;
+}
+
 int iso_track_is_audio(void* handle, int track) {
     if (!handle) return 0;
     return static_cast<PS1::ISOReader*>(handle)->TrackIsAudio(track) ? 1 : 0;

--- a/runtime/tests/test_iso_reader_cdda.cpp
+++ b/runtime/tests/test_iso_reader_cdda.cpp
@@ -1,0 +1,51 @@
+#include "iso_reader.h"
+
+#include <cassert>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+static void write_sectors(const std::filesystem::path& path, int count, uint8_t marker) {
+    std::ofstream out(path, std::ios::binary);
+    std::vector<uint8_t> sector(2352, marker);
+    for (int i = 0; i < count; ++i) out.write(reinterpret_cast<const char*>(sector.data()), sector.size());
+}
+
+int main() {
+    const auto dir = std::filesystem::temp_directory_path() / "psxrecomp-cdda-reader-test";
+    std::filesystem::remove_all(dir);
+    std::filesystem::create_directories(dir);
+    write_sectors(dir / "data.bin", 4, 0x11);
+    write_sectors(dir / "audio.bin", 3, 0x22);
+
+    {
+        std::ofstream cue(dir / "disc.cue");
+        cue << "FILE \"data.bin\" BINARY\n"
+               "  TRACK 01 MODE2/2352\n"
+               "    INDEX 01 00:00:00\n"
+               "FILE \"audio.bin\" BINARY\n"
+               "  TRACK 02 AUDIO\n"
+               "    INDEX 00 00:00:00\n"
+               "    INDEX 01 00:00:01\n";
+    }
+
+    PS1::ISOReader reader;
+    assert(reader.Open((dir / "disc.cue").string()));
+    assert(reader.TrackCount() == 2);
+    assert(reader.TrackStartLBA(1) == 0);
+    assert(reader.TrackPregapLBA(1) == 0);
+    assert(!reader.TrackIsAudio(1));
+    assert(reader.TrackPregapLBA(2) == 4);
+    assert(reader.TrackStartLBA(2) == 5);
+    assert(reader.TrackIsAudio(2));
+    assert(reader.GetSectorCount() == 7);
+
+    uint8_t raw[2352] = {};
+    assert(reader.ReadRawSector(4, raw));
+    assert(raw[0] == 0x22);
+    reader.Close();
+    std::filesystem::remove_all(dir);
+    return 0;
+}


### PR DESCRIPTION
Adds generic Red Book CD-DA playback and INDEX 00 CUE pregap handling to the current multi-file disc reader.

Adapted from #14 with source provenance and Kareem Olim's co-authorship preserved.

The focused multi-file/pregap test passes. Vigilante 8 exercised tracks 2 and 7 from their pregaps, transitioned correctly, and produced clean music.