### PR TITLE
widescreen: mirror range cull sites in interpreter

### DIFF
--- a/recompiler/tests/recompiler_patch_test.cpp
+++ b/recompiler/tests/recompiler_patch_test.cpp
@@ -58,7 +58,8 @@ void write_word(PSXRecomp::PS1Executable& exe, uint32_t address,
 
 std::string generate_first_instruction(uint32_t first_word,
                                        std::vector<RecompilerPatch> patches,
-                                       bool overlay_mode) {
+                                       bool overlay_mode,
+                                       PSXRecomp::CodeGenConfig config = {}) {
     constexpr uint32_t base = 0x80010000u;
     PSXRecomp::PS1Executable exe{};
     exe.header.load_address = base;
@@ -81,7 +82,6 @@ std::string generate_first_instruction(uint32_t first_word,
 
     PSXRecomp::ControlFlowAnalyzer analyzer(exe);
     const auto cfg = analyzer.analyze_function(function);
-    PSXRecomp::CodeGenConfig config;
     config.overlay_mode = overlay_mode;
     PSXRecomp::CodeGenerator generator(exe, config);
     return generator.generate_function(function, cfg).full_code;
@@ -173,6 +173,15 @@ replacement = "0x24020001"
 )toml");
     check_throws([&] { (void)PSXRecompV4::load_game_config(unaligned); },
                  "instruction-aligned", "parser rejects unaligned sites");
+
+    const auto range = write_config(root, "range-cull", R"toml(
+[widescreen.cull]
+range_sites = ["0x80012340"]
+)toml");
+    const auto range_config = PSXRecompV4::load_game_config(range);
+    check(range_config.ws_cull_range_sites ==
+              std::vector<uint32_t>{0x80012340u},
+          "parser preserves explicit range cull sites");
 }
 
 void capture_history_config_tests(const fs::path& root) {
@@ -252,6 +261,13 @@ void codegen_tests() {
         },
         "conflicting recompiler patches",
         "config merge rejects cross-config ID conflicts");
+
+    PSXRecomp::CodeGenConfig range_config;
+    range_config.ws_cull_range_sites.insert(0x80010000u);
+    const std::string range = generate_first_instruction(
+        0x2C8201C1u, {}, false, range_config); // sltiu v0,a0,0x1c1
+    check(range.find("2*psx_ws_x_margin()") != std::string::npos,
+          "native range emit widens by both horizontal margins");
 }
 
 void jump_table_producer_codegen_test() {

--- a/runtime/include/gpu.h
+++ b/runtime/include/gpu.h
@@ -142,9 +142,11 @@ int  gpu_ws_present_native_43(void);
 int  psx_ws_x_margin(void);
 void gpu_ws_set_cull_guard_pixels(int pixels);
 void gpu_ws_set_explicit_cull_sites(const uint32_t *bias, int nbias,
-                                    const uint32_t *slti, int nslti);
+                                    const uint32_t *slti, int nslti,
+                                    const uint32_t *range, int nrange);
 int  psx_ws_is_cull_bias_site(uint32_t pc);
 int  psx_ws_is_cull_slti_site(uint32_t pc);
+int  psx_ws_is_cull_range_site(uint32_t pc);
 /* Scale a signed Q16 horizontal gameplay limit into the active native-wide
  * game field. Identity at 4:3 / menus / FMV. */
 int32_t psx_ws_player_x_bound(int32_t vanilla);

--- a/runtime/src/dirty_ram_interp.c
+++ b/runtime/src/dirty_ram_interp.c
@@ -1556,7 +1556,13 @@ static int exec_one(CPUState *cpu, uint32_t pc, uint32_t *next_pc_out) {
          * shared helper for a flagged render-cull site — it is byte-identical
          * to the vanilla compare at 4:3 (margin 0) and widens at 16:9, so the one
          * code path serves both aspects (no widescreen-specific caching). */
-        if (psx_ws_auto_cull_on() && psx_ws_is_cull_w_imm(imm) && ws_cull_site(pc))
+        if (psx_ws_is_cull_range_site(pc)) {
+            /* Explicit world-space classifier widen. The native emitter uses
+             * the same bound transform for configured range_sites. */
+            cpu->gpr[rt] = (cpu->gpr[rs] <
+                            ((uint32_t)simm + 2u * (uint32_t)psx_ws_x_margin())) ? 1u : 0u;
+        }
+        else if (psx_ws_auto_cull_on() && psx_ws_is_cull_w_imm(imm) && ws_cull_site(pc))
             cpu->gpr[rt] = (uint32_t)psx_ws_cull_sltiu(cpu->gpr[rs], imm);
         else
             cpu->gpr[rt] = (cpu->gpr[rs] < (uint32_t)simm) ? 1u : 0u;

--- a/runtime/src/gpu.c
+++ b/runtime/src/gpu.c
@@ -310,18 +310,25 @@ void gpu_ws_set_cull_guard_pixels(int pixels) {
 #define WS_EXPLICIT_CULL_SITES_MAX 64
 static uint32_t ws_explicit_bias_sites[WS_EXPLICIT_CULL_SITES_MAX];
 static uint32_t ws_explicit_slti_sites[WS_EXPLICIT_CULL_SITES_MAX];
+static uint32_t ws_explicit_range_sites[WS_EXPLICIT_CULL_SITES_MAX];
 static int ws_explicit_bias_n = 0;
 static int ws_explicit_slti_n = 0;
+static int ws_explicit_range_n = 0;
 void gpu_ws_set_explicit_cull_sites(const uint32_t *bias, int nbias,
-                                    const uint32_t *slti, int nslti) {
+                                    const uint32_t *slti, int nslti,
+                                    const uint32_t *range, int nrange) {
     if (nbias < 0) nbias = 0;
     if (nslti < 0) nslti = 0;
+    if (nrange < 0) nrange = 0;
     if (nbias > WS_EXPLICIT_CULL_SITES_MAX) nbias = WS_EXPLICIT_CULL_SITES_MAX;
     if (nslti > WS_EXPLICIT_CULL_SITES_MAX) nslti = WS_EXPLICIT_CULL_SITES_MAX;
+    if (nrange > WS_EXPLICIT_CULL_SITES_MAX) nrange = WS_EXPLICIT_CULL_SITES_MAX;
     ws_explicit_bias_n = nbias;
     ws_explicit_slti_n = nslti;
+    ws_explicit_range_n = nrange;
     for (int i = 0; i < nbias; i++) ws_explicit_bias_sites[i] = bias[i] & 0x1FFFFFFFu;
     for (int i = 0; i < nslti; i++) ws_explicit_slti_sites[i] = slti[i] & 0x1FFFFFFFu;
+    for (int i = 0; i < nrange; i++) ws_explicit_range_sites[i] = range[i] & 0x1FFFFFFFu;
 }
 static int ws_explicit_site(const uint32_t *sites, int n, uint32_t pc) {
     uint32_t p = pc & 0x1FFFFFFFu;
@@ -333,6 +340,9 @@ int psx_ws_is_cull_bias_site(uint32_t pc) {
 }
 int psx_ws_is_cull_slti_site(uint32_t pc) {
     return ws_explicit_site(ws_explicit_slti_sites, ws_explicit_slti_n, pc);
+}
+int psx_ws_is_cull_range_site(uint32_t pc) {
+    return ws_explicit_site(ws_explicit_range_sites, ws_explicit_range_n, pc);
 }
 
 int psx_ws_x_margin(void) {

--- a/runtime/src/main.cpp
+++ b/runtime/src/main.cpp
@@ -3160,7 +3160,8 @@ int main(int argc, char** argv) {
             gpu_ws_set_cull_guard_pixels(gc.ws_cull_guard_pixels);
             gpu_ws_set_explicit_cull_sites(
                 gc.ws_cull_bias_sites.data(), (int)gc.ws_cull_bias_sites.size(),
-                gc.ws_cull_slti_sites.data(), (int)gc.ws_cull_slti_sites.size());
+                gc.ws_cull_slti_sites.data(), (int)gc.ws_cull_slti_sites.size(),
+                gc.ws_cull_range_sites.data(), (int)gc.ws_cull_range_sites.size());
             gte_ws_configure_dome_sites(
                 gc.ws_dome_call_sites.data(), (int)gc.ws_dome_call_sites.size());
             /* [widescreen.cull] per-game gates + signature immediates for the


### PR DESCRIPTION
## Summary

- register the existing widescreen range_sites with the dirty-RAM interpreter
- apply the same two-margin unsigned-bound widening already emitted by native codegen
- add parser/codegen regression coverage for the shared configuration contract

Split from #49 so the backend-parity fix can be reviewed independently. Original implementation co-authored by @OpokXeno.

## Verification

- recompiler_patch_test
- MinGW compilation of the changed runtime objects against ApeEscapeRecomp
