### PR TITLE
Fix savestate restore resume state

### DIFF
--- a/runtime/include/savestate.h
+++ b/runtime/include/savestate.h
@@ -9,7 +9,7 @@ extern "C" {
 #endif
 
 /*
- * User save states (F1-F12 save, Shift+F1-F12 load; 12 slots).
+ * User save states (Shift+F1-F12 save, F1-F12 load; 12 slots).
  *
  * A thin wrapper over boot_state.c's complete full-machine serializer
  * (boot_state_save / boot_state_load — CPU/RAM/scratchpad/VRAM/SPU/CDROM/DMA/SIO/

--- a/runtime/src/boot_state.c
+++ b/runtime/src/boot_state.c
@@ -195,7 +195,8 @@ static int apply_section(uint32_t tag, const uint8_t* p, uint32_t len,
         if (len != sizeof(CpuRegs)) return 0;
         const CpuRegs* c = (const CpuRegs*)p;
         memcpy(cpu->gpr,      c->gpr,      sizeof cpu->gpr);
-        cpu->pc = entry_pc;   /* always enter at the game entry, never a mid-PC */
+        (void)entry_pc;       /* validated by the header; CPU section owns resume PC */
+        cpu->pc = c->pc;
         cpu->hi = c->hi; cpu->lo = c->lo;
         memcpy(cpu->cop0,     c->cop0,     sizeof cpu->cop0);
         memcpy(cpu->gte_data, c->gte_data, sizeof cpu->gte_data);
@@ -204,6 +205,11 @@ static int apply_section(uint32_t tag, const uint8_t* p, uint32_t len,
          * words noncanonical.  Repair once at the raw restore boundary so
          * native direct reads and interpreter helpers remain tier-identical. */
         gte_canonicalize_cpu_state(cpu);
+        /* These absolute guest-cycle deadlines are not serialized in CpuRegs.
+         * If a restore moves psx_cycle_count backward, stale live deadlines can
+         * sit far in the future and stall the next MFLO/MFHI or GTE read. */
+        cpu->muldiv_ts_done = 0;
+        cpu->gte_ts_done    = 0;
         return 1;
     }
     case BS_SEC_RAM:
@@ -318,8 +324,8 @@ int boot_state_load(const char* path, uint32_t bios_checksum,
         return 0;
     }
 
-    fprintf(stdout, "boot_state: complete snapshot restored, entering game at 0x%08X\n",
-            entry_pc);
+    fprintf(stdout, "boot_state: complete snapshot restored, resuming at 0x%08X\n",
+            cpu->pc);
     return 1;
 }
 

--- a/runtime/src/savestate.c
+++ b/runtime/src/savestate.c
@@ -1,4 +1,4 @@
-/* savestate.c — user save states (F1-F12 / Shift+F1-F12). See savestate.h.
+/* savestate.c — user save states (Shift+F1-F12 save, F1-F12 load). See savestate.h.
  *
  * Wraps boot_state.c's full-machine serializer. Requests are staged by the SDL
  * key handler / debug server and executed by savestate_poll at a block-leader
@@ -18,8 +18,13 @@ static uint32_t s_entry_pc;
 static int      s_configured   = 0;
 static int      s_save_pending = -1;   /* slot, or -1 */
 static int      s_load_pending = -1;
+static uint64_t s_load_cooldown_until_frame = 0;
+static int      s_load_cooldown_notice = 0;
 
 extern int psx_hle_scheduler_enabled(void);
+extern uint64_t s_frame_count;
+
+#define SAVESTATE_LOAD_COOLDOWN_FRAMES 60u
 
 void savestate_configure(const char* dir, uint32_t bios_checksum, uint32_t entry_pc) {
     if (dir && dir[0]) {
@@ -52,6 +57,13 @@ int savestate_request_save(int slot) {
 int savestate_request_load(int slot) {
     if (!s_configured) { fprintf(stderr, "savestate: not configured\n"); return 0; }
     if (slot < 0 || slot >= SAVESTATE_SLOTS) return 0;
+    if (s_frame_count < s_load_cooldown_until_frame) {
+        if (!s_load_cooldown_notice) {
+            fprintf(stderr, "savestate: load ignored during restore cooldown\n");
+            s_load_cooldown_notice = 1;
+        }
+        return 1;
+    }
     if (!psx_hle_scheduler_enabled()) {
         /* LLE (host-fiber) mode: the restore longjmp target lives on the
          * scheduler fiber; cross-fiber unwind is unsafe. HLE is the default. */
@@ -88,6 +100,9 @@ void savestate_poll(CPUState* cpu, uint32_t resume_pc) {
         if (!slot_path(slot, path, sizeof(path))) return;
         if (boot_state_load(path, s_bios_checksum, s_entry_pc, cpu)) {
             psx_cycles_resync_after_restore();
+            s_load_cooldown_until_frame =
+                s_frame_count + SAVESTATE_LOAD_COOLDOWN_FRAMES;
+            s_load_cooldown_notice = 0;
             fprintf(stderr, "savestate: LOADED slot %d -> resuming pc=0x%08X\n",
                     slot, (unsigned)cpu->pc);
             /* Unwind to the scheduler and re-dispatch the restored PC. Never


### PR DESCRIPTION
## Summary
- restore savestates to the saved CPU PC instead of the game entry PC
- clear non-serialized CPU/GTE completion deadlines after restore
- debounce repeated load requests briefly after a successful restore

## Testing
- Regression testing was done.

## Caveat
Restores can visibly pause, especially near CD/load transitions. Worst-case recovery may take several seconds, but observed long recovery cases resumed instead of crashing or permanently hanging.