### PR TITLE
Credit PR16 Vulkan source developer

### DIFF
--- a/docs/ecosystem-watch.md
+++ b/docs/ecosystem-watch.md
@@ -175,6 +175,14 @@ BIOS-only framework link is reported failing.
   Keep performance/synchronization fixes separate from CRT shaders and debug
   environment flags.
 
+### Follow-up credit
+
+PR #61 reconstructed the reusable Vulkan synchronization, staging-buffer,
+command batching, present-mode, and timing work from Martin Penkava's PR #16
+branch onto current master while leaving Vulkan experimental and hidden by
+default. Martin Penkava (`shaneomac1337`) is the source developer for that
+Vulkan work.
+
 ### Reject or relocate
 
 - `4517bd5` labels the AMD corruption unresolved and carries temporary Vulkan


### PR DESCRIPTION
## Summary
- add an explicit follow-up note crediting Martin Penkava as the source developer for the Vulkan work reconstructed in PR #61
- keep the commit itself co-authored by Martin so GitHub attribution is present on top of master

## Validation
- docs-only change
- `git diff --check`