### PR TITLE
runtime: implement COP0 software interrupts (CAUSE.IP0/IP1 vs SR.IM0/IM1)

### DIFF
--- a/runtime/src/dirty_ram_interp.c
+++ b/runtime/src/dirty_ram_interp.c
@@ -1958,11 +1958,15 @@ int dirty_ram_dispatch(CPUState* cpu, uint32_t addr, uint32_t stop_addr) {
  * bit, COP0 IEc + IM2 set, and not already inside the exception handler. */
 static int precise_irq_deliverable(CPUState *cpu) {
     extern uint32_t i_stat;
-    if ((i_stat & i_mask) == 0) return 0;
-    if (psx_get_in_exception()) return 0;
     uint32_t sr = cpu->cop0[12];
+    /* COP0 software interrupts (CAUSE.IP0/IP1 & SR.IM0/IM1): guest-raised via
+     * mtc0 to CAUSE, independent of the INTC line (see psx_check_interrupts). */
+    uint32_t sw_pending = cpu->cop0[13] & sr & 0x0300u;
+    if ((i_stat & i_mask) == 0 && sw_pending == 0) return 0;
+    if (psx_get_in_exception()) return 0;
     if (!(sr & 0x1u))        return 0;   /* IEc: interrupts globally enabled */
-    if (!(sr & (1u << 10)))  return 0;   /* IM2: hardware interrupt mask bit */
+    /* INTC needs IM2; a pending software interrupt is deliverable without it. */
+    if (!(sr & (1u << 10)) && sw_pending == 0)  return 0;
     return 1;
 }
 
@@ -2507,6 +2511,29 @@ static int dirty_ram_dispatch_inner(CPUState* cpu, uint32_t addr, uint32_t stop_
         }
         g_dirty_ram_insns_run++;
         insns_executed++;
+        /* COP0 software-interrupt latency: an MTC0 to CAUSE or SR that makes a
+         * software interrupt deliverable (CAUSE.IP0/IP1 & SR.IM0/IM1 & IEc)
+         * must be taken IMMEDIATELY — real hardware vectors within the next
+         * instruction. Waiting for the next block boundary opens a window in
+         * which another hardware IRQ can re-enter the guest's (single-slot,
+         * legitimately non-reentrant) dispatcher and destroy its saved SR:
+         * Jackie Chan Stuntmaster's stage-1 handler does exactly
+         * `mtc0 CAUSE,0x100; mtc0 SR,0x101` and relies on the instant sw-int
+         * to reach its stage-2 before anything else runs. Same nested-delivery
+         * machinery as the entry poll above; EPC = the committed next pc. */
+        if ((insn & 0xFFE00000u) == 0x40800000u) { /* MTC0 */
+            uint32_t sw_rd = (insn >> 11) & 0x1Fu;
+            if ((sw_rd == 12u || sw_rd == 13u) &&
+                (cpu->cop0[13] & cpu->cop0[12] & 0x0300u) != 0u &&
+                (cpu->cop0[12] & 0x1u) != 0u) {
+                extern uint32_t g_dirty_safe_resume_pc;
+                uint32_t saved_resume = g_dirty_safe_resume_pc;
+                cpu->pc = next_pc ? next_pc : pc + 4u;
+                g_dirty_safe_resume_pc = cpu->pc;
+                psx_check_interrupts(cpu);
+                g_dirty_safe_resume_pc = saved_resume;
+            }
+        }
         if (transferred) {
             if (g_psx_call_bail) {
                 /* A bail unwind began inside a surfaced call: stop the interp

--- a/runtime/src/interrupts.c
+++ b/runtime/src/interrupts.c
@@ -39,6 +39,7 @@
 #include "psx_scheduler.h"
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <setjmp.h>
 
 /* Event-timeline ring: execution-mode flag owned by dirty_ram_interp.c. The
@@ -744,7 +745,14 @@ void psx_check_interrupts(CPUState* cpu) {
      * observed 1M+ block edges/s this is sub-frame latency. */
     static uint32_t s_fast_maintenance;
     if (g_idle_skip_enabled < 0) (void)psx_idle_skip_is_enabled();
-    if (!in_exception && (i_stat & i_mask) == 0 &&
+    /* COP0 software interrupts (CAUSE.IP0/IP1 vs SR.IM0/IM1, bits 8-9): raised
+     * purely by guest mtc0 to CAUSE, with no INTC involvement. Games use this
+     * as a re-entrant exception-dispatch mechanism (Jackie Chan Stuntmaster's
+     * handler saves SR/EPC, sets CAUSE=0x100 + SR=0x101, and relies on the
+     * immediate sw-int to chain into its second stage; without it the CD INT3
+     * ack never runs and the machine deadlocks with SR.IM2 stripped). */
+    uint32_t sw_pending = cpu->cop0[COP0_CAUSE] & cpu->cop0[COP0_SR] & 0x0300u;
+    if (!in_exception && (i_stat & i_mask) == 0 && sw_pending == 0 &&
         !s_defer_switch_pending && g_idle_skip_enabled == 0) {
         if ((++s_fast_maintenance & 0x3FFFu) == 0) {
             extern void savestate_poll(CPUState* cpu, uint32_t resume_pc);
@@ -883,8 +891,8 @@ void psx_check_interrupts(CPUState* cpu) {
         }
     }
 
-    /* Check if any interrupts are pending. */
-    if ((i_stat & i_mask) == 0) { irq_record_outcome(EV_NONE, 0, 0); PSX_CHECK_INTERRUPTS_RETURN(); }
+    /* Check if any interrupts are pending (INTC hardware or COP0 software). */
+    if ((i_stat & i_mask) == 0 && sw_pending == 0) { irq_record_outcome(EV_NONE, 0, 0); PSX_CHECK_INTERRUPTS_RETURN(); }
     /* Nested delivery (hardware semantics). Real R3000A has no 'in exception'
      * gate — delivery is governed by SR alone. The handler normally runs with
      * IEc=0 (hardware bit-shift on entry), so the SR gates below block
@@ -954,13 +962,19 @@ void psx_check_interrupts(CPUState* cpu) {
 #endif
         PSX_CHECK_INTERRUPTS_RETURN();
     }   /* Interrupts globally disabled */
-    if (!(sr & (1 << 10))) {
+    /* Deliverability per source: the INTC line needs SR.IM2; software
+     * interrupts need only their own IM bit (already folded into sw_pending,
+     * recomputed here against the CURRENT sr — the fast-path snapshot above
+     * may predate an SR write earlier in this same check). */
+    sw_pending = cpu->cop0[COP0_CAUSE] & sr & 0x0300u;
+    int hw_deliverable = ((i_stat & i_mask) != 0) && ((sr & (1 << 10)) != 0);
+    if (!hw_deliverable && sw_pending == 0) {
         irq_record_outcome(EV_IRQ_GATE, GATE_SR_IM2, 0);
 #ifdef PSX_COSIM
         COSIM_IRQ_NOTE(5u);
 #endif
         PSX_CHECK_INTERRUPTS_RETURN();
-    } /* Hardware interrupt bit not enabled */
+    } /* No deliverable interrupt source (hw masked and no sw pending) */
 
     /* Architectural take-PC = the resume PC (same selection the async-RFE block
      * below uses): the dirty-interp commits the exact interrupted instruction in
@@ -1006,9 +1020,14 @@ void psx_check_interrupts(CPUState* cpu) {
     exception_entries_total++;
     uint32_t pre_handler_istat = i_stat;  /* snapshot for cooldown decision */
 
-    /* Set COP0 Cause: ExcCode=0 (interrupt), IP2 pending. */
+    /* Set COP0 Cause: ExcCode=0 (interrupt). IP2 reflects the INTC line, so
+     * set it only when the hardware source is what's being delivered; a pure
+     * software interrupt must present the guest-written IP0/IP1 bits
+     * unmodified (the guest's dispatcher discriminates stages by exactly
+     * these bits — see sw_pending rationale at the top of this function). */
     cpu->cop0[COP0_CAUSE] = (cpu->cop0[COP0_CAUSE] & ~0x7C) | (0 << 2);
-    cpu->cop0[COP0_CAUSE] |= (1 << 10);
+    if (hw_deliverable)
+        cpu->cop0[COP0_CAUSE] |= (1 << 10);
 
     /* Push SR exception stack: shift bits [5:0] left by 2. */
     cpu->cop0[COP0_SR] = (sr & ~0x3F) | ((sr & 0x0F) << 2);
@@ -1211,6 +1230,15 @@ void psx_check_interrupts(CPUState* cpu) {
      * ("execution completed" abnormal exit). */
     int saved_dispatch_depth = g_psx_dispatch_depth;
     g_psx_dispatch_depth = 0;
+    /* Nested delivery clobber guard: exception_jmpbuf is a single global, so a
+     * nested exception's setjmp overwrites the OUTER frame's context. The outer
+     * handler's later RFE would then longjmp into the dead inner frame (host
+     * stack corruption — first hit by Jackie Chan Stuntmaster's software-
+     * interrupt dispatcher, which nests by design). Save the armed frame here
+     * and restore it in the epilogue so each nesting level's RFE lands in its
+     * own live frame. */
+    jmp_buf saved_exception_jmpbuf;
+    memcpy(&saved_exception_jmpbuf, &exception_jmpbuf, sizeof(jmp_buf));
     g_exc_setjmp_epoch++;   /* new setjmp frame armed (see decl above) */
     for (;;) {
         int jmp_val = setjmp(exception_jmpbuf);
@@ -1240,6 +1268,10 @@ void psx_check_interrupts(CPUState* cpu) {
     g_exception_owner_fiber = prev_owner_fiber;
     g_pending_exception_longjmp = prev_pending;
     g_dirty_interp_active = prev_interp_active;
+    /* Re-arm the OUTER frame's jmpbuf (see save at entry): after a nested
+     * delivery returns, the outer handler is live again and its RFE must land
+     * in the outer setjmp frame, not this exited one. */
+    memcpy(&exception_jmpbuf, &saved_exception_jmpbuf, sizeof(jmp_buf));
     /* Ape memcard fix #3: restore the resume-PC latch cleared at handler entry
      * (see above). Sits with the other post-dispatch-loop restores so an
      * RFE/RestoreState longjmp — which lands in the setjmp loop above — can't


### PR DESCRIPTION
## What & why

The runtime only delivered INTC-line interrupts (`i_stat & i_mask`) gated by
`SR.IM2`. COP0 **software interrupts** — `CAUSE.IP0/IP1` masked by
`SR.IM0/IM1` — were never delivered. That's architectural R3000A behavior
some games rely on, and its absence hard-deadlocks any title whose exception
dispatcher raises one.

Concrete failure: a game whose stage-1 exception handler saves SR/EPC and then
does `mtc0 CAUSE,0x100; mtc0 SR,0x101`, expecting the CPU to immediately
re-enter the exception vector (software interrupt) into its stage-2, which
acks the CD INT and restores the saved SR. Without software-interrupt
delivery, stage-2 never runs: the CD Init INT3 stays unacked
(`process_pending()` freezes the completion countdown while `irq_flag != 0`),
and the machine wedges with the display disabled and SR stuck at `0x101`
(IM2 stripped → all hardware interrupts dead). Audio continues b
routed to the SPU without CPU involvement.

**Game-agnostic.** No title checks, no magic PC addresses, no pe
— this models the documented COP0 interrupt mechanism for every

## Changes

2 files, +69 / −10, runtime-only:

1. **`runtime/src/interrupts.c` — `psx_check_interrupts()`**: a pending
   software interrupt (`CAUSE & SR & 0x0300`, plus `IEc`) is a d
   source in the fast-path early-out, the pending check, and the SR gate. INTC
   still requires `IM2`; the software path needs only its own IM
   Exception entry sets `CAUSE.IP2` only when the hardware line
   so a pure software interrupt presents the guest-written IP0/I
2. **`runtime/src/interrupts.c` — nested-delivery `exception_jmp
   save/restore**: the software interrupt nests inside the hardw
   window; the nested `setjmp` overwrote the single global `exce
   so the outer handler's later RFE `longjmp`'d into the exited
   (host-stack corruption → SIGSEGV). The armed frame is saved o
   restored in the epilogue.
3. **`runtime/src/dirty_ram_interp.c` — immediate delivery after an
   interpreted `MTC0` to CAUSE/SR** that makes a software interr
   deliverable (EPC = committed next PC); `precise_irq_deliverab
   same condition. Hardware vectors within the next instruction;
   the next block boundary let a second hardware IRQ re-enter th
   (non-reentrant) guest dispatcher and clobber its single-slot

No stubs, no generated-code edits, no `fprintf`. (Rules 2, 3, 5.

## Pin / regen

Runtime-only change — **no regen required**. A game consumes it by bumping its
`psxrecomp/` submodule pin.

## Verification

- Reproduced and fixed on a new bring-up (Jackie Chan Stuntmaste
  before → black screen after the intro logos; after → boots through
  BIOS → logos → intro FMV → **rendered 3D gameplay at 60 fps**,
  interactively (screenshot below). SR observed at the canonical `0x40000401`
  throughout, CD `irq_flag` acked, MDEC decoding.
- **BIOS-only LLE boot unaffected.**
- Evidence gathered via the TCP debug server (`gpu_state`, `cdro
  `irq_state`, `fmv_state`) + a gdb hardware watchpoint on COP0
  the `SR := 0x101` write and let me disassemble the guest tramp
  the software interrupt.

### Not yet done (calling out honestly, per CONTRIBUTING)

- **No Beetle cosim/oracle diff** — verified visually + interact
  against `psx-beetle`. Happy to run the cosim on request.
- **No regression pass on the known-good game repos** (Tomba!, M
  Ape Escape) — I don't have those built. This is a pure additio
  deliverability (previously-deliverable hardware IRQs are unchanged; it only
  *adds* the software-interrupt path), so regression risk is low
  claim it — a maintainer regression run would be appreciated.

The affected game repo isn't public (new title); I can share bui
full traces, or the annotated guest disassembly if useful.

---
Note:

Developed with AI assistance (Claude); reviewed and tested by me. 