### PR TITLE
Add Linux macOS dev setup helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,16 @@ python tools/build_cli.py release
 The ready-to-use CLI archive is written to `dist/`. To package debug binaries
 instead, run `python tools/build_cli.py debug`.
 
+On Linux/macOS source checkouts, the same development setup can be driven by:
+
+```sh
+sh tools/setup_dev.sh
+```
+
+That script builds the CLI/recompiler tools and, when BIOS/generated sources are
+available, the BIOS-only runtime. Game projects should still be generated with
+`psxrecomp build` and built from their generated `build.sh`.
+
 > **Where the project is headed.** Development so far has been **breadth-first**:
 > stand up as many games as possible and get them into a playable alpha, proving
 > the framework generalizes. That phase has largely delivered — seven titles now

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -83,6 +83,18 @@ cmake -S runtime -B runtime/build -G Ninja -DCMAKE_BUILD_TYPE=Release
 cmake --build runtime/build --target psx-runtime
 ```
 
+On Linux/macOS, `tools/setup_dev.sh` performs the same source-checkout setup:
+
+```sh
+sh tools/setup_dev.sh
+```
+
+It checks for the native toolchain and SDL2 development package, builds the CLI
+and recompiler tools, refreshes generated BIOS C when `bios/SCPH1001.BIN` is
+present, and builds the BIOS-only runtime when BIOS/generated sources are
+available. It does not create per-game runtime targets; use the CLI generator
+for game projects.
+
 On Windows with MSVC or plain MinGW makefiles, swap `-G Ninja` for your generator
 (e.g. `-G "Unix Makefiles"`); everything else is identical.
 

--- a/tools/setup_dev.sh
+++ b/tools/setup_dev.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env sh
+# Bootstrap a source checkout for local PSXRecomp development on Linux/macOS.
+#
+# This builds the CLI/recompiler tools from source. If bios/SCPH1001.BIN is
+# present, it also refreshes generated BIOS C before building the BIOS-only
+# runtime target. Game projects should be generated with the CLI; this script
+# intentionally does not patch runtime/CMakeLists.txt with per-game targets.
+
+set -eu
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+BUILD_TYPE=${BUILD_TYPE:-Release}
+CLI_BUILD_DIR=${CLI_BUILD_DIR:-recompiler/build-cli}
+RUNTIME_BUILD_DIR=${RUNTIME_BUILD_DIR:-runtime/build-dev}
+
+cd "$ROOT"
+
+missing=""
+
+need_cmd() {
+    if command -v "$1" >/dev/null 2>&1; then
+        printf '  [ok]      %s\n' "$1"
+    else
+        printf '  [missing] %s\n' "$1"
+        missing="$missing $1"
+    fi
+}
+
+printf '%s\n' '== Checking host tools =='
+need_cmd cmake
+need_cmd python3
+need_cmd pkg-config
+
+if command -v ninja >/dev/null 2>&1; then
+    printf '%s\n' '  [ok]      ninja'
+else
+    printf '%s\n' '  [warn]    ninja not found; CMake will use its default generator'
+fi
+
+if command -v cc >/dev/null 2>&1 || command -v gcc >/dev/null 2>&1 || command -v clang >/dev/null 2>&1; then
+    printf '%s\n' '  [ok]      C compiler'
+else
+    printf '%s\n' '  [missing] C compiler'
+    missing="$missing c-compiler"
+fi
+
+if command -v c++ >/dev/null 2>&1 || command -v g++ >/dev/null 2>&1 || command -v clang++ >/dev/null 2>&1; then
+    printf '%s\n' '  [ok]      C++ compiler'
+else
+    printf '%s\n' '  [missing] C++ compiler'
+    missing="$missing cxx-compiler"
+fi
+
+if command -v pkg-config >/dev/null 2>&1 && pkg-config --exists sdl2; then
+    printf '  [ok]      SDL2 %s\n' "$(pkg-config --modversion sdl2)"
+else
+    printf '%s\n' '  [missing] SDL2 development package'
+    missing="$missing sdl2"
+fi
+
+if [ -n "$missing" ]; then
+    cat <<EOF
+
+Missing prerequisites:$missing
+
+Debian/Ubuntu:
+  sudo apt install build-essential cmake ninja-build pkg-config libsdl2-dev python3
+
+Fedora:
+  sudo dnf install gcc gcc-c++ cmake ninja-build pkgconf-pkg-config SDL2-devel python3
+
+macOS/Homebrew:
+  brew install cmake ninja pkg-config sdl2 python3
+EOF
+    exit 1
+fi
+
+printf '\n%s\n' '== Building CLI/recompiler tools =='
+python3 tools/build_cli.py release --build-dir "$CLI_BUILD_DIR"
+
+can_build_runtime=0
+
+if [ -f bios/SCPH1001.BIN ]; then
+    printf '\n%s\n' '== Regenerating BIOS C =='
+    sh tools/regen_bios.sh
+    can_build_runtime=1
+elif [ -f generated/SCPH1001_full.c ] && [ -f generated/SCPH1001_dispatch.c ]; then
+    printf '\n%s\n' '== Using existing generated BIOS C =='
+    printf '%s\n' 'bios/SCPH1001.BIN was not found; building with existing generated/SCPH1001_*.c.'
+    can_build_runtime=1
+else
+    printf '\n%s\n' '== Skipping BIOS regeneration =='
+    printf '%s\n' 'bios/SCPH1001.BIN and generated/SCPH1001_*.c were not found.'
+    printf '%s\n' 'The CLI/recompiler tools are ready; add the BIOS and rerun to build psx-runtime.'
+fi
+
+if [ "$can_build_runtime" -eq 1 ]; then
+    printf '\n%s\n' '== Building BIOS-only runtime =='
+    generator_args=""
+    if command -v ninja >/dev/null 2>&1; then
+        generator_args="-G Ninja"
+    fi
+
+    # shellcheck disable=SC2086
+    cmake -S runtime -B "$RUNTIME_BUILD_DIR" $generator_args -DCMAKE_BUILD_TYPE="$BUILD_TYPE"
+    cmake --build "$RUNTIME_BUILD_DIR" --target psx-runtime --parallel
+fi
+
+cat <<EOF
+
+Setup complete.
+
+CLI package:
+  dist/psxrecomp-cli-*
+
+BIOS runtime:
+  $RUNTIME_BUILD_DIR/psx-runtime
+  (built only when bios/SCPH1001.BIN or generated/SCPH1001_*.c is present)
+
+Generate a game project with the CLI, then build the generated project's build.sh
+on Linux/macOS.
+EOF


### PR DESCRIPTION
## Summary
- add a conservative Linux/macOS source-checkout setup helper under `tools/setup_dev.sh`
- document the helper in README and BUILDING docs
- keep game project creation on the existing `psxrecomp build` CLI path rather than patching framework runtime CMake files

## Validation
- `sh -n tools/setup_dev.sh`
- `git diff --check`
- WSL Ubuntu: `sh tools/setup_dev.sh` built/packaged `dist/psxrecomp-cli-linux-x86_64.zip` and cleanly skipped BIOS runtime build when BIOS/generated sources were absent

## Credit
Extracted from the Linux setup intent in PR #54. Keeganator is included as co-author on the commit.