### PR TITLE
Vulkan: fix draw-area batching and enable builds by default

### DIFF
--- a/runtime/runtime.cmake
+++ b/runtime/runtime.cmake
@@ -573,11 +573,11 @@ function(psxrecomp_add_runtime_target target)
     # We need only the Vulkan HEADERS at compile time, plus glslc to build SPIR-V.
     # Both ship with the Vulkan SDK ($VULKAN_SDK) or a Vulkan-Headers package.
     #
-    # Build-EXCLUDED by default (silent WIP): the real Vulkan path compiles only
-    # with -DPSX_ENABLE_VULKAN=ON. When OFF, gpu_vk_renderer.c builds as the inert
-    # stub and the exe behaves exactly as the GL/software build — no SDK/glslc
-    # dependency, regardless of whether $VULKAN_SDK is present on the machine.
-    option(PSX_ENABLE_VULKAN "Build the experimental Vulkan renderer backend (WIP)" OFF)
+    # Build Vulkan when its SDK tools are available so release binaries can offer
+    # it without game projects opting in individually. This does not select the
+    # runtime renderer: OpenGL remains the default in config_loader.h. Builders
+    # can still use -DPSX_ENABLE_VULKAN=OFF to produce the inert stub explicitly.
+    option(PSX_ENABLE_VULKAN "Build the Vulkan renderer backend when SDK tools are available" ON)
     if(PSX_ENABLE_VULKAN)
     set(_vk_inc "")
     if(DEFINED ENV{VULKAN_SDK})

--- a/runtime/src/gpu_vk_renderer.c
+++ b/runtime/src/gpu_vk_renderer.c
@@ -2187,10 +2187,13 @@ static void vkb_set_texture_filter(int b) { s_texfilter = b ? 1 : 0; }
 static int  vkb_texture_filter(void) { return s_texfilter; }
 
 static void vkb_set_draw_area(int x1, int y1, int x2, int y2) {
-    /* scissor is per-batch (one render pass uses one scissor), so flush any
-     * pending geometry before the clip rect changes. */
-    if (x1 != s_da_x1 || y1 != s_da_y1 || x2 != s_da_x2 || y2 != s_da_y2)
+    /* Scissor is per-batch (one render pass uses one scissor), so drain both
+     * independent geometry batches before the clip rect changes. Otherwise
+     * earlier textured GP0 primitives render with the next draw area's scissor. */
+    if (x1 != s_da_x1 || y1 != s_da_y1 || x2 != s_da_x2 || y2 != s_da_y2) {
+        flush_tex_batch();
         flush_geometry();
+    }
     s_da_x1 = x1; s_da_y1 = y1; s_da_x2 = x2; s_da_y2 = y2;
 }
 static void vkb_get_draw_area(int *x1, int *y1, int *x2, int *y2) {

--- a/runtime/tests/test_vk_build_default.py
+++ b/runtime/tests/test_vk_build_default.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import re
+
+
+root = Path(__file__).parents[2]
+runtime_cmake = (root / "runtime" / "runtime.cmake").read_text()
+config_loader = (root / "recompiler" / "src" / "config_loader.h").read_text()
+
+option = re.search(
+    r'option\(PSX_ENABLE_VULKAN\s+"[^"]*"\s+(ON|OFF)\)', runtime_cmake
+)
+assert option, "PSX_ENABLE_VULKAN option not found"
+assert option.group(1) == "ON", "Vulkan backend is not compiled by default"
+assert "DEFAULT_VIDEO_RENDERER = VIDEO_RENDERER_OPENGL" in config_loader, (
+    "enabling the Vulkan build changed the runtime renderer default away from OpenGL"
+)
+
+print("Vulkan build/default-renderer policy test passed")

--- a/runtime/tests/test_vk_draw_area_batch_boundary.py
+++ b/runtime/tests/test_vk_draw_area_batch_boundary.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import re
+
+
+source = (Path(__file__).parents[1] / "src" / "gpu_vk_renderer.c").read_text()
+setter = re.search(
+    r"static void vkb_set_draw_area\(.*?\n\}", source, flags=re.DOTALL
+)
+assert setter, "vkb_set_draw_area not found"
+body = setter.group(0)
+
+tex_flush = body.find("flush_tex_batch();")
+geo_flush = body.find("flush_geometry();")
+state_write = body.find("s_da_x1 = x1;")
+
+assert tex_flush >= 0, "draw-area change does not drain textured primitives"
+assert geo_flush >= 0, "draw-area change does not drain untextured primitives"
+assert tex_flush < state_write and geo_flush < state_write, (
+    "draw-area state changes before pending primitives are drained"
+)
+
+print("Vulkan draw-area batch-boundary test passed")


### PR DESCRIPTION
## Summary
- flush pending textured geometry before Vulkan draw-area/scissor changes, preventing earlier GP0 primitives from using the next clip rectangle
- compile the Vulkan backend by default when SDK tools are available
- keep OpenGL as the runtime renderer default
- add regression coverage for the draw-area batch boundary and build/default-renderer policy

## Validation
- `python runtime/tests/test_vk_draw_area_batch_boundary.py`
- `python runtime/tests/test_vk_build_default.py`
- `python runtime/tests/test_vk_color_self_barrier.py`
- `python runtime/tests/test_vk_command_buffer_batching.py`
- fresh RelWithDebInfo Vulkan builds and live gameplay checks for Tomba 2, Tomba 1, Ape Escape, and Mega Man X6
- live renderer diagnostics reported `backend: vulkan`; Ape Escape and Mega Man X6 had zero dispatch misses

Tomba 2's inactive blackjack selector slots are clipped correctly after this change. The reported rope overlap was separately verified against Beetle and is authentic game behavior, so no game-specific rope patch is included.