### PR TITLE
widescreen: [widescreen] stretch_2d / stretch_fmv (opt-in fill-the-screen)

### DIFF
--- a/recompiler/src/config_loader.cpp
+++ b/recompiler/src/config_loader.cpp
@@ -876,6 +876,8 @@ GameConfig load_game_config(const fs::path& config_path_in) {
     bool ws_full_2d = false;
     bool ws_gte_game_mode = false;
     bool ws_native_wide = true;
+    bool ws_stretch_2d  = false;
+    bool ws_stretch_fmv = false;
     bool ws_nw_hud_corners = false;
     uint32_t ws_nw_left_hud_packet_lo = 0;
     uint32_t ws_nw_left_hud_packet_hi = 0;
@@ -996,6 +998,10 @@ GameConfig load_game_config(const fs::path& config_path_in) {
             ws_gte_game_mode = toml::find<bool>(ws, "gte_game_mode");
         if (ws.contains("native_wide"))
             ws_native_wide = toml::find<bool>(ws, "native_wide");
+        if (ws.contains("stretch_2d"))
+            ws_stretch_2d = toml::find<bool>(ws, "stretch_2d");
+        if (ws.contains("stretch_fmv"))
+            ws_stretch_fmv = toml::find<bool>(ws, "stretch_fmv");
         if (ws.contains("nw_hud_corners"))
             ws_nw_hud_corners = toml::find<bool>(ws, "nw_hud_corners");
         const bool has_nw_left_hud_lo = ws.contains("nw_left_hud_packet_lo");
@@ -1266,6 +1272,8 @@ GameConfig load_game_config(const fs::path& config_path_in) {
         /*ws_full_2d*/            ws_full_2d,
         /*ws_gte_game_mode*/      ws_gte_game_mode,
         /*ws_native_wide*/        ws_native_wide,
+        /*ws_stretch_2d*/         ws_stretch_2d,
+        /*ws_stretch_fmv*/        ws_stretch_fmv,
         /*ws_nw_hud_corners*/     ws_nw_hud_corners,
         /*ws_nw_left_hud_packet_lo*/ ws_nw_left_hud_packet_lo,
         /*ws_nw_left_hud_packet_hi*/ ws_nw_left_hud_packet_hi,

--- a/recompiler/src/config_loader.h
+++ b/recompiler/src/config_loader.h
@@ -637,6 +637,15 @@ struct GameConfig {
     // + stretched-present path when native-wide is not regression-free.
     bool ws_native_wide = true;
 
+    // [widescreen] stretch_2d / stretch_fmv — "fill the whole widescreen"
+    // player-preference overrides for the 4:3 pins in
+    // gpu_ws_present_native_43(). stretch_2d: menus/title/loading & 2D-only
+    // scenes present stretched to the wide aspect (2D UI warps). stretch_fmv:
+    // FMV video presents stretched (4:3 video distorts). Runtime-only; off by
+    // default so the faithful 4:3 pillarbox stays the default.
+    bool ws_stretch_2d  = false;
+    bool ws_stretch_fmv = false;
+
     // [widescreen] nw_hud_corners — in native-wide, push outer-third screen-
     // space HUD sprites out to the true wide-frame corners (they otherwise sit
     // inset by the reveal offset). Runtime-only — no regen. Off by default.

--- a/runtime/src/gpu.c
+++ b/runtime/src/gpu.c
@@ -144,6 +144,16 @@ static uint32_t ws_last_gte_stamp = (uint32_t)-1000;
 #define WS_GTE_GAME_MODE_HYSTERESIS 45u
 void gpu_ws_set_gte_game_mode(int on) { ws_gte_game_mode_cfg = on ? 1 : 0; }
 
+/* Opt-in "fill the whole widescreen" overrides for the 4:3 pins in
+ * gpu_ws_present_native_43(). These STRETCH 4:3 content to the wide aspect
+ * (2D UI warps, 4:3 FMV distorts) — a player preference, off by default so the
+ * faithful 4:3 pillarbox stays the default. stretch_2d: menus/title/loading &
+ * 2D-only scenes present wide. stretch_fmv: FMV video presents wide. */
+static int      ws_stretch_2d  = 0;
+static int      ws_stretch_fmv = 0;
+void gpu_ws_set_stretch_2d(int on)  { ws_stretch_2d  = on ? 1 : 0; }
+void gpu_ws_set_stretch_fmv(int on) { ws_stretch_fmv = on ? 1 : 0; }
+
 /* World-scale 3D signal for the 2D-only-scene classifier (sprite-tag titles).
  * Shaded-prim presence proved to be a FALSE world signal: task-clear /
  * new-task title cards are gouraud-shaded screen-space tiles animated over
@@ -250,15 +260,18 @@ static int      s_ws_fmv_cached = 0;
 
 int gpu_ws_present_native_43(void) {
     if (!ws_engaged()) return 0;
-    if (!ws_game_mode()) return 1;                 /* full-2D screen */
-    if (ws_2d_only_scene()) return 1;              /* 2D-only gameplay scene */
+    if (!ws_stretch_2d) {
+        if (!ws_game_mode()) return 1;             /* full-2D screen -> 4:3 */
+        if (ws_2d_only_scene()) return 1;          /* 2D-only gameplay scene -> 4:3 */
+    }
     uint32_t f = (uint32_t)s_frame_count;
     if (f != s_ws_fmv_frame_cache) {
         s_ws_fmv_frame_cache = f;
         GpuDisplayInfo di; gpu_get_display_info(&di);
         s_ws_fmv_cached = di.depth24 || mdec_recently_active(WS_FMV_HYSTERESIS);
     }
-    return s_ws_fmv_cached;
+    if (s_ws_fmv_cached && !ws_stretch_fmv) return 1;  /* FMV -> 4:3 (unless opted to stretch) */
+    return 0;
 }
 
 /* Squash applies only when configured AND the frame is being stretched. */

--- a/runtime/src/main.cpp
+++ b/runtime/src/main.cpp
@@ -554,6 +554,8 @@ static bool          g_ws_hud_sprt = false;
 /* Runtime-only transition cleanup; kept out of gpu.h because generated game
  * units include that ABI header and do not need this frontend-only setter. */
 extern "C" void gpu_ws_set_clear_reveal(int on);
+extern "C" void gpu_ws_set_stretch_2d(int on);
+extern "C" void gpu_ws_set_stretch_fmv(int on);
 extern "C" void gpu_ws_set_nw_textured_edges(int on, int scale_pct);
 extern "C" void gpu_ws_set_signed_x_bound_sites(const uint32_t*, const uint32_t*, int);
 /* Widescreen engages at game entry (fntrace_is_game_started): the BIOS boot
@@ -4528,6 +4530,11 @@ int main(int argc, char** argv) {
                                   gc.ws_bg2d_packet_cap);
             /* [widescreen] gte_game_mode — 3D-title gameplay detector (Ape). */
             gpu_ws_set_gte_game_mode(gc.ws_gte_game_mode ? 1 : 0);
+            /* [widescreen] stretch_2d / stretch_fmv — "fill the whole widescreen"
+             * overrides: menus/2D and FMV present stretched instead of 4:3
+             * pillarbox. Off by default (faithful). */
+            gpu_ws_set_stretch_2d(gc.ws_stretch_2d ? 1 : 0);
+            gpu_ws_set_stretch_fmv(gc.ws_stretch_fmv ? 1 : 0);
             /* Keep titles with known native-wide regressions on the original
              * projection-squash + stretched-present widescreen path. */
             g_ws_native_wide = gc.ws_native_wide ? 1 : 0;


### PR DESCRIPTION
## What & why

`gpu_ws_present_native_43()` pins menus/title/loading, 2D-only scenes, and FMV to a faithful 4:3 pillarbox (correct default — stretching 2D UI / 4:3 video distorts it). But some players/ports prefer **no black bars anywhere**, accepting the stretch. There was no opt-in for that.

## Changes

Two `[widescreen]` flags, **off by default** (the 4:3 pillarbox stays the default, so this is a no-op unless opted in):
- `stretch_2d` — menus/title/loading & 2D-only scenes present stretched to the
  wide aspect.
- `stretch_fmv` — FMV video presents stretched.

They gate the corresponding early-returns in `gpu_ws_present_native_43()` (`runtime/src/gpu.c`), plumbed through `config_loader.{h,cpp}` and applied via `gpu_ws_set_stretch_2d/fmv` from `main.cpp` config resolution.

**Game-agnostic, runtime-only (no regen).**

## Verification

On a 512-wide title (Jackie Chan Stuntmaster, SLUS-00684): with both flags on,
menus/loading/FMV fill 16:9 (stretched); with them off, the 4:3 pillarbox is
byte-identical to before. 4:3 aspect mode and 3D gameplay widescreen unaffected.

Developed with AI assistance (Claude); reviewed and tested by me.