### PR TITLE
gpu: native-wide host reject must union the guest draw area, not replace it

### DIFF
--- a/runtime/src/gpu.c
+++ b/runtime/src/gpu.c
@@ -2404,14 +2404,16 @@ static inline int32_t draw_area_wide_x_margin(void) {
 
 static inline void draw_area_host_x_bounds(int32_t *left, int32_t *right) {
     int32_t margin = draw_area_wide_x_margin();
+    *left  = (int32_t)draw_area_left;
+    *right = (int32_t)draw_area_right;
     if (margin > 0) {
-        /* ws_nw_sync_target uses draw_area_left as the framebuffer base and
-         * configures a surface ws_disp_w()+2*margin pixels wide. */
-        *left  = (int32_t)draw_area_left - margin;
-        *right = (int32_t)draw_area_left + (int32_t)ws_disp_w() + margin - 1;
-    } else {
-        *left  = (int32_t)draw_area_left;
-        *right = (int32_t)draw_area_right;
+        /* Use the union of the guest draw area and the widescreen mirror.
+         * Wider staging areas may share the framebuffer X origin; clamping them
+         * to the mirror width would drop valid canonical VRAM writes. */
+        int32_t wide_left  = (int32_t)draw_area_left - margin;
+        int32_t wide_right = (int32_t)draw_area_left + (int32_t)ws_disp_w() + margin - 1;
+        if (wide_left  < *left)  *left  = wide_left;
+        if (wide_right > *right) *right = wide_right;
     }
 }
 


### PR DESCRIPTION
## What

One-hunk fix to the native-wide host-side GP0 fast reject (`draw_area_host_x_bounds`, added in cece002 "feat: add adaptive native widescreen", which carries OpokXeno's PR #73 draw-area pruning fix).

When native-wide is active and `draw_area_left` matches a known framebuffer base X, the function **replaced** the guest draw area's X bounds with the wide mirror's extent. `ws_is_fb_base()` matches on the **X origin alone**, so any draw area that shares a framebuffer's X origin but is *wider than the display* gets its right bound clamped down to `base + disp_w + margin - 1`. Primitives whose bbox lies beyond that are rejected before `gr_draw_*`, so they never reach canonical VRAM — in either renderer.

The fix takes the **union**: start from the guest draw area, let the mirror extent only *extend* it.

```c
*left  = draw_area_left;
*right = draw_area_right;
if (margin > 0) {
    /* only extend, never shrink */
    if (wide_left  < *left)  *left  = wide_left;
    if (wide_right > *right) *right = wide_right;
}
```

## Why it matters / how it showed up

A 16:9 native-wide title whose text engine composes message lines in staging strips at the **bottom of VRAM**, at the same X origin (0) as its y-stacked display buffers. Its compose draw areas run out to x=511, but the clamp cut them to x=372 (320 display + 53/side reveal). Result: glyphs arrive as `GP0(A0)` CPU→VRAM uploads (transfers, never rejected) and landed fine, while the **line-clear / box-tile draws** past x=372 were silently dropped. Every new message line kept the tail of the previous, longer line — `Koh obtained 8 EXP.amage.`, and a nameplate sequence `WREATH` → `KOH` rendering as `KOHATH`. 4:3 was clean; 16:9 only.

## Behavior preserved (why this should be regression-safe)

- **Display-sized draw areas are bit-identical to before.** If `draw_area_right == base + disp_w - 1`, the union yields exactly `[base - margin, base + disp_w + margin - 1]` — the old values. The reveal margins still get their geometry; the fast reject keeps rejecting everything it rejected before.
- **`margin == 0` is byte-identical to the original pre-native-wide reject**: 4:3, FMV/menus, squash mode, and offscreen texture targets take the untouched `draw_area_left/right` path.
- The union can only ever make the accepted region *larger*, so the failure mode this removes (a valid in-area draw dropped) cannot be reintroduced; the cost is that a few primitives that would have been rejected now go to the backend and get clipped there, as they did before cece002.

## How I verified it

Diagnosis (all via the TCP debug server, no printf):

- `dump_buffer` (FBO synced down) showed the stale pixels baked into **canonical VRAM**, in *both* display bands — which ruled out the wide compositor / present path entirely and pointed at lost draws.
- `gpu_frame_dump` E3/E4 decode gave the actual staging draw-area geometry (`(0,448)-(255,463)` strips, glyph A0 uploads at `(256,448)` and `(272,511)` — i.e. content living past the clamp at the framebuffer's X origin).
- `ws_margin value=0` A/B ruled out the recompiler cull-widen emit sites (that override only feeds `psx_ws_x_margin()`; this path uses `ws_nw_offset()`).
- Bisected to the merge that brought this code in: our previous framework pin had no host fast reject at all, and its native-wide text rendering was clean.

Fix verification:

- Built and played the affected title in 16:9 native-wide (OpenGL, internal scale 4, LLE recompiled BIOS): fresh message boxes and character nameplates render clean, no stale tails; 4:3 unchanged.
- `runtime/src/gpu.c` compiles clean on this branch's base (`a8aa640`) with `-Wall -Wextra` — same two pre-existing warnings before and after the change, none added.
- Diff is one hunk in one file; no EOL churn.

## ⚠️ Tested on Azure Dreams ONLY

I only have one title in a state where I can exercise this path, so **the only game this was tested on is Azure Dreams (SLUS-00614, USA)**, on my own WIP port. I did **not** run Tomba 2, Xenogears, Mega Man X6, Ape Escape, or any other game against this branch — no boot / attract / save-create / save-load checks on them, and no Beetle oracle diff (this is a host-side draw-reject optimization; there is no guest-visible timing or semantic behavior for the oracle to compare here).

My argument that it is safe for those titles is the identity property above (display-sized draw areas ⇒ bounds unchanged; `margin == 0` ⇒ byte-identical), not observation. Worth a spot-check on a native-wide title you can run — Tomba 2 and Xenogears are the ones cece002 mentions.

Host: Windows 11, MSYS2 mingw64 GCC, Ninja, `PSX_DEBUG_TOOLS=ON`.

## Scope notes

- **Game-agnostic**: no title check, no magic address, no per-game config — the parameterization already exists (`ws_is_fb_base` / `ws_nw_offset`); this only fixes how those combine with the guest draw area.
- **Runtime-only — no regen required.** Games consume it by bumping their `psxrecomp/` submodule pointer; no recompiler/emitter change, so no generated-C regeneration.
- The game repo here is a local WIP port that is not public yet, so I can't link a game-repo branch for integration testing.
