### PR TITLE
test(recompiler): register l2_structural_test and reachable_discovery_test

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,7 +139,7 @@ cmake --build recompiler/build
 cd recompiler/build && ctest --output-on-failure
 ```
 
-29 tests, under five seconds, no BIOS dump or disc image required. See
+36 tests, under five seconds, no BIOS dump or disc image required. See
 [`docs/TESTING.md`](docs/TESTING.md) for running individual tests, what the
 suite covers, and the three known-failing tests that are deliberately not
 registered.

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -135,7 +135,7 @@ After step 1 above — no BIOS or disc needed — verify the tree is sane:
 cd recompiler/build && ctest --output-on-failure
 ```
 
-29 tests, under five seconds. See [`TESTING.md`](TESTING.md).
+36 tests, under five seconds. See [`TESTING.md`](TESTING.md).
 
 On Windows with MSVC or plain MinGW makefiles, swap `-G Ninja` for your generator
 (e.g. `-G "Unix Makefiles"`); everything else is identical.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -8,7 +8,7 @@ cmake --build recompiler/build
 cd recompiler/build && ctest --output-on-failure
 ```
 
-That is the whole thing. 29 tests, under 5 seconds, and it needs **no BIOS dump,
+That is the whole thing. 36 tests, under 5 seconds, and it needs **no BIOS dump,
 no disc image, and no generated code** — a plain recompiler build is enough. This
 is the check to run before opening a PR.
 

--- a/recompiler/CMakeLists.txt
+++ b/recompiler/CMakeLists.txt
@@ -311,6 +311,11 @@ if(BUILD_TESTING)
              COMMAND bios_address_model_test
              WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/..)
 
+    # These targets were already built by every test build, but without
+    # add_test() entries ctest could neither run nor fail them.
+    add_test(NAME l2_structural_test COMMAND l2_structural_test)
+    add_test(NAME reachable_discovery_test COMMAND reachable_discovery_test)
+
     find_package(Python3 COMPONENTS Interpreter)
     if(Python3_Interpreter_FOUND)
         add_test(


### PR DESCRIPTION
`l2_structural_test` (`recompiler/CMakeLists.txt:251`) and
`reachable_discovery_test` (`:413`) are built by every build but had no
`add_test()` entry, so neither could run and neither could fail. This adds them.

Same gap the codegen tests below them had before they were wired in, and
`docs/TESTING.md:17` states the rule: "an unregistered test cannot fail, and a
test that cannot fail is not a test."

## Verification

Both were run manually first, on macOS arm64 (AppleClang 21, Ninja, Release):

```
$ ./recompiler/build/l2_structural_test        -> L2 structural: 239/239 ok
$ ./recompiler/build/reachable_discovery_test  -> ALL PASS
```

On a clean clone with only this patch, `ctest -N` goes 33 → 35 and `ctest`
reports 34/35. The one failure is `recompiler_patch_test`, already red on
unpatched `master` on POSIX and unrelated to this change; I have a separate PR
for it. With both applied the suite is 35/35.

Neither test is an always-green harness (`l2_structural_test` returns
`fail > 0 ? 1 : 0`, `reachable_discovery_test` returns 1 on failure), and
neither needs a `WORKING_DIRECTORY` — no BIOS profile, no generated C, no
`psxrecomp-game`. `-DBUILD_TESTING=OFF` still configures and registers 0 tests.

Registering these makes the count wrong in three places, so
`docs/TESTING.md:11`, `docs/BUILDING.md:134` and `CONTRIBUTING.md:142` are
updated in the same commit. They said "29", already stale at 33 before this;
I took 35 from `ctest -N`, not from 29+2.

One side effect: `ctest -R reachable_discovery` now matches two tests, the new
one and the existing `reachable_discovery_codegen`.

## Not tested

Build-system only — no regen required, no pin bump needed to consume it, and
nothing added to any shipping binary. Not built on Windows or Linux. No game
repo was built or run and no disc image or retail BIOS was used, so the
regression checklist was not performed; no Beetle oracle check, as there is no
hardware behavior here to diff. Subsystems touched: none.
