### PR TITLE
fix(config): validate overlay_capture_persist_dir independent of host path grammar

### DIFF
--- a/docs/AOT_OVERLAY_PLAN.md
+++ b/docs/AOT_OVERLAY_PLAN.md
@@ -331,7 +331,10 @@ additively merging every valid snapshot.
 
 Development configs may also set a project-relative
 `overlay_capture_persist_dir`. This creates one atomically published, immutable
-JSON snapshot per changed capture. Absolute paths and `..` components are rejected.
+JSON snapshot per changed capture. Rooted, UNC, drive-qualified and
+drive-relative paths are rejected, as is any `..` component or an embedded NUL,
+under both `/` and `\` separators, so a config is accepted or rejected
+identically on every host.
 Production configs normally omit this key and retain only the naive executable-
 local addendum. Both history modes are off by default and contain game-derived
 bytes, so their outputs remain private/gitignored artifacts.

--- a/recompiler/src/config_loader.cpp
+++ b/recompiler/src/config_loader.cpp
@@ -229,6 +229,41 @@ static bool parse_aspect_ratio(const std::string& s, int* num, int* den) {
     return true;
 }
 
+// Reject a config path that is not confined to the project directory.
+//
+// A game.toml is checked in and read on every host, so a path in it must mean
+// the same thing everywhere; std::filesystem::path answers by the *host*
+// grammar, so a Windows-authored escape passes on POSIX. Scan the raw bytes
+// under both separator conventions instead. NUL is rejected outright because
+// the runtime hands this value on as a C string — anything past a NUL would
+// silently vanish between what is validated and what is used.
+static void validate_project_relative(const std::string& value,
+                                      const char* field) {
+    if (value.find('\0') != std::string::npos) {
+        throw std::runtime_error(
+            fmt::format("{} must not contain a NUL byte", field));
+    }
+    // Rooted ("/x", "\x"), UNC ("\\server\share"), drive-qualified ("C:/x",
+    // "C:\x") and drive-relative ("C:x") alike.
+    const bool rooted = !value.empty() && (value[0] == '/' || value[0] == '\\');
+    const bool drive  = value.size() >= 2 && value[1] == ':' &&
+                        std::isalpha(static_cast<unsigned char>(value[0]));
+    if (rooted || drive) {
+        throw std::runtime_error(
+            fmt::format("{} must be project-relative", field));
+    }
+    for (size_t start = 0;;) {
+        const size_t sep = value.find_first_of("/\\", start);
+        const size_t end = (sep == std::string::npos) ? value.size() : sep;
+        if (value.compare(start, end - start, "..") == 0) {
+            throw std::runtime_error(
+                fmt::format("{} must stay inside the project", field));
+        }
+        if (sep == std::string::npos) break;
+        start = sep + 1;
+    }
+}
+
 // Parse the optional [runtime] block. All fields optional; absent fields
 // leave has_* = false on the returned struct. Paths are resolved relative
 // to `root` (project root).
@@ -395,17 +430,8 @@ static RuntimeConfig parse_runtime_block(const toml::value& cfg, const fs::path&
     if (runtime.contains("overlay_capture_persist_dir")) {
         rt.overlay_capture_persist_dir =
             toml::find<std::string>(runtime, "overlay_capture_persist_dir");
-        const std::filesystem::path persist(rt.overlay_capture_persist_dir);
-        if (persist.is_absolute()) {
-            throw std::runtime_error(
-                "runtime.overlay_capture_persist_dir must be project-relative");
-        }
-        for (const auto& component : persist) {
-            if (component == "..") {
-                throw std::runtime_error(
-                    "runtime.overlay_capture_persist_dir must stay inside the project");
-            }
-        }
+        validate_project_relative(rt.overlay_capture_persist_dir,
+                                  "runtime.overlay_capture_persist_dir");
     }
     if (runtime.contains("turbo_loads")) {
         rt.turbo_loads = toml::find<bool>(runtime, "turbo_loads");

--- a/recompiler/src/config_loader.h
+++ b/recompiler/src/config_loader.h
@@ -235,9 +235,11 @@ struct RuntimeConfig {
     bool                  overlay_capture_history = false;
 
     // overlay_capture_persist_dir: optional DEV-only, project-relative safe
-    // directory for one immutable JSON file per changed snapshot. Absolute
-    // paths and `..` components are rejected. Production normally leaves this
-    // unset and retains only the addendum beside the executable.
+    // directory for one immutable JSON file per changed snapshot. Rooted,
+    // UNC, drive-qualified and drive-relative paths are rejected, as is any
+    // `..` component or an embedded NUL, under both `/` and `\` separators.
+    // Production normally leaves this unset and retains only the addendum
+    // beside the executable.
     std::string           overlay_capture_persist_dir;
 
     // turbo_loads: OPT-IN per game. While the game is loading (CD data

--- a/recompiler/tests/recompiler_patch_test.cpp
+++ b/recompiler/tests/recompiler_patch_test.cpp
@@ -466,6 +466,60 @@ overlay_capture_persist_dir = "C:/outside"
     check_throws([&] { (void)PSXRecompV4::load_game_config(absolute); },
                  "must be project-relative",
                  "parser rejects absolute capture history directory");
+
+    // A game.toml travels between hosts, so each of these must be rejected on
+    // every host, not only on the one whose path grammar it is written in.
+    // TOML literal strings ('...') are used because a backslash is an escape
+    // inside a TOML basic string. Cases marked POSIX-visible are the ones a
+    // host-native std::filesystem check silently accepted under POSIX.
+    struct RejectedDir {
+        const char* value;   // as written in game.toml
+        const char* needle;  // expected message fragment
+        const char* name;
+    };
+    static constexpr RejectedDir rejected[] = {
+        {"'/outside'", "must be project-relative",
+         "parser rejects rooted capture history directory"},
+        {R"('\outside')", "must be project-relative",
+         "parser rejects backslash-rooted capture history directory"},
+        {R"('C:\outside')", "must be project-relative",
+         "parser rejects backslash drive-qualified capture history directory"},
+        {"'C:outside'", "must be project-relative",
+         "parser rejects drive-relative capture history directory"},
+        {R"('\\server\share\outside')", "must be project-relative",
+         "parser rejects UNC capture history directory"},
+        {R"('..\outside')", "must stay inside the project",
+         "parser rejects backslash-escaping capture history directory"},
+        {R"('nested\..\..\outside')", "must stay inside the project",
+         "parser rejects nested backslash-escaping capture history directory"},
+        {"'nested/..'", "must stay inside the project",
+         "parser rejects a trailing .. component"},
+        // A basic string, not a literal one: TOML forbids a raw NUL byte but
+        // allows the \u0000 escape that produces it. The runtime passes this
+        // value on as a C string, so a NUL would truncate it after validation.
+        {R"("..\u0000keep")", "must not contain a NUL byte",
+         "parser rejects an embedded NUL escape"},
+    };
+    for (size_t i = 0; i < std::size(rejected); ++i) {
+        const auto& c = rejected[i];
+        const auto cfg_path = write_config(
+            root, fmt::format("capture-history-rejected-{}", i),
+            fmt::format("[runtime]\noverlay_capture_persist_dir = {}\n",
+                        c.value));
+        check_throws([&] { (void)PSXRecompV4::load_game_config(cfg_path); },
+                     c.needle, c.name);
+    }
+
+    // A dotfile is not a `..` component; the guard must not over-reject.
+    const auto dotted = write_config(root, "capture-history-dotted", R"toml(
+[runtime]
+overlay_capture_history = true
+overlay_capture_persist_dir = ".aot_capture_history/..keep/TEST-00000"
+)toml");
+    const auto dotted_cfg = PSXRecompV4::load_game_config(dotted);
+    check(dotted_cfg.runtime.overlay_capture_persist_dir ==
+              ".aot_capture_history/..keep/TEST-00000",
+          "parser accepts a capture history component that merely starts with dots");
 }
 
 void codegen_tests() {


### PR DESCRIPTION
`runtime.overlay_capture_persist_dir` was validated with
`std::filesystem::path::is_absolute()`, which answers by the **host** path
grammar. The contract next to the field
(`recompiler/src/config_loader.h:237-241`) is host-independent: "Absolute paths
and `..` components are rejected." A `game.toml` is checked in and read on every
host, so the two must agree. They did not. This scans the raw bytes under both
separator conventions instead.

## Why

**POSIX.** `path("C:/outside")` is a *relative* path whose first component is
literally `C:`; a backslash is an ordinary filename character, so `..\outside`
is one component and `\\server\share` is one relative component. Measured on
macOS arm64 / AppleClang 21:

```
"C:/outside"          is_absolute=false  components=['C:' 'outside']
"..\..\outside"       is_absolute=false  components=['..\..\outside']
"/outside"            is_absolute=true   components=['/' 'outside']
```

So Windows-authored absolute paths and backslash traversals passed. The consumer
(`runtime/src/main.cpp:5224-5227`) does `project_root / persist_dir` then
`create_directories`, landing a junk directory inside the project. Contained on
POSIX, but it diverges from the Windows result and it is the check the contract
says exists.

**Windows**, the platform this targets first, has the worse half. Two forms got
through, both per MSVC's own STL (`microsoft/STL`, `stl/inc/filesystem`):

- Rooted `/outside` — its `is_absolute()` comment reads *"paths with no
  root-name but a root-directory are root relative, such as \example"*, so the
  old guard accepted it. `operator/=` then takes its has-root-directory branch,
  erasing the relative path and keeping only the root name: `C:\proj / /outside`
  becomes `C:/outside`, the drive root.
- Drive-relative `C:foo` — *"a root-name that is a drive letter and no
  root-directory"* is not absolute either, but `operator/=` replaces the whole
  path when root names differ, so on `D:\proj` it resolves to `C:foo`, another
  drive's current directory.

I could not execute either on Windows; this is read from the shipping
implementation, not observed at runtime.

**Embedded NUL.** Found while testing this change, and the reason the guard
validates bytes rather than a `std::filesystem::path`. TOML forbids a raw NUL
byte but allows the `\u0000` escape that produces one, and toml11 accepts it.
The runtime passes the value on as a C string
(`runtime/src/main.cpp:5236-5241` → `overlay_capture.c:230`), so it truncates
there. Reproduced end to end against the real `load_game_config`:

```
game.toml: overlay_capture_persist_dir = "..\u0000keep"
  accepted, len=4 bytes=2E 2E 00 6B
  via c_str() -> <project>/..
  confined to project? NO - escaped
```

Validating what the consumer actually sees closes it.

## Verification

`recompiler_patch_test` is registered in `ctest` and its assertion "parser
rejects absolute capture history directory" **failed on POSIX before this**
(`did not throw`). On a clean clone with only this patch, macOS arm64, the suite
goes 32/33 → 33/33.

New cases cover every form that slipped through: rooted with `/` and with `\`,
drive-qualified, drive-relative, UNC, backslash `..` traversal including nested,
a trailing `..`, and the NUL escape. Plus a negative case (`..keep` is a normal
component) so the guard does not over-reject. I also ran the implementation
against a 26-row behavior table — `""`, `"."`, `".."`, `"..."`, `"a/"`, `"a//b"`,
`"C:"`, `"c:/x"`, `"1:/x"`, `"ab:c"`, `" .."`, `".. "` and the rest — and traced
where each accepted value lands under `project_root / value`; all stay inside
the project. Clean under `-Wall -Wextra -Wconversion -Wsign-conversion -Wshadow
-Wpedantic`. `std::isalpha` sees only `unsigned char` and there is no
`setlocale` anywhere in the tree, so the drive-letter test stays ASCII.

`overlay_capture_persist_dir` has exactly one write path (the guarded site) and
one read; no CLI flag, no env override, and `settings.toml` cannot set it — that
file parses into `UserSettings`, which does not carry the key.

The helper is named `validate_project_relative` to match the tree's existing
`validate_*` validators rather than inventing a `require_*` verb.

## Docs

Two places stated the old, narrower rule and both now match what is enforced:
`config_loader.h:238-239`, which is the contract next to the field, and
`docs/AOT_OVERLAY_PLAN.md:332-334`, the only prose statement of it. The doc
claims identical **accept/reject** across hosts, not identical meaning — a value
like `nested\dir` is accepted everywhere but still names different things.

## Not tested

Config parsing only, so no regen is required. Not built on Windows or Linux —
the POSIX reasoning applies to Linux unchanged but I have only run it on macOS
arm64. Runtime behavior not exercised (that needs a generated BIOS). No game
repo built or run, no disc image, no retail BIOS, so the regression checklist
was not performed; no Beetle oracle check, since this is config validation and
not emulated hardware. Of the subsystems the checklist names, none are touched;
overlays only in that this key names where capture history is written.

## Trade-offs

`validate_project_relative()` has one call site today. I extracted it because
`parse_runtime_block` is already 379 lines and the rationale needs somewhere to
live; happy to inline it. This also **tightens** Windows behavior — a rooted
`/x` the old check accepted is now rejected. That is the fix, but it is a change
on the primary platform from someone who cannot test there, so it wants a second
look.
