### PR TITLE
Add condition to prevent CDDA playback restart

### DIFF
--- a/runtime/src/cdrom.c
+++ b/runtime/src/cdrom.c
@@ -1429,6 +1429,7 @@ static uint32_t cdda_track_end_lba(int track) {
 }
 
 static int start_cdda_playback(int requested_track) {
+    if (cdda_playing && requested_track == 0 && iso_handle && iso_track_count(iso_handle) > 1) return 1;
     uint32_t lba;
     int track;
     if (requested_track > 0) {


### PR DESCRIPTION
This fix is ​​due to games like Tekken 1, which contains multiple discs (multiple .bin files). The problem was that the current code caused the music to repeat several times without counting each second and never allowed the music to continue, both in menus and during gameplay, and also when we paused the game, this repetition continued and did not stop...

(I would appreciate it if you could review and analyze the code. My intention is to keep it updated and improve it over time.)

This is my current possible fix:

`cdda_playing` -> "Is the music already playing?" If the game sends a "Play" command, but the music is paused, we allow the command to pass normally so that the music starts.

`requested_track == 0` -> "Does the game want to play the same track?" When Tekken 1 enters "spam" mode, it sends the pure "Play" command (0x03), without specifying a new track (which in the engine code translates to `requested_track = 0`). If you request track 4, we will allow the command to pass. Since it asks for "0", we know it's just redundancy for a song that's already playing.

`iso_handle` -> "Is there a CD inserted?" This ensures the engine doesn't try to check for phantom tracks and won't crash if there's no .cue file loaded. `iso_track_count(iso_handle) > 1` -> "Does the CD have audio tracks?" The PlayStation game format dictates that Track 1 always contains the game data. If the CD has more than one track, it means it has audio tracks (CDDA).