### PR TITLE
recompiler: preserve dependent MIPS-I load delays

### DIFF
--- a/recompiler/src/code_generator.cpp
+++ b/recompiler/src/code_generator.cpp
@@ -1741,6 +1741,69 @@ std::string CodeGenerator::translate_basic_block(
         exit_branch_addr = block.end_addr;
     }
 
+    /* MIPS-I load-delay value semantics for ordinary in-block pairs.  The
+     * resident/full-function emitter already models these; overlay/game CFG
+     * emission must do the same.  OpenBIOS's CD/card fasttrack deliberately
+     * uses `lw k0,...; move at,k0`, where the move must observe OLD k0. */
+    auto simple_load_dest = [](uint32_t w) -> int {
+        uint32_t op = w >> 26;
+        if (op == 0x20u || op == 0x21u || op == 0x23u ||
+            op == 0x24u || op == 0x25u) {
+            uint32_t rt = (w >> 16) & 31u;
+            return rt ? static_cast<int>(rt) : -1;
+        }
+        return -1;
+    };
+    auto reads_gpr = [](uint32_t w, uint32_t r) -> bool {
+        if (r == 0u || w == 0u) return false;
+        uint32_t op = w >> 26, rs = (w >> 21) & 31u;
+        uint32_t rt = (w >> 16) & 31u, fn = w & 63u;
+        if (op == 0u) {
+            if (fn == 0x08u || fn == 0x09u) return rs == r;
+            if (fn == 0x0Cu || fn == 0x0Du || fn == 0x10u || fn == 0x12u)
+                return false;
+            return rs == r || rt == r;
+        }
+        if (op == 0x02u || op == 0x03u || op == 0x0Fu) return false;
+        if (op == 0x01u || op == 0x06u || op == 0x07u) return rs == r;
+        if (op == 0x04u || op == 0x05u) return rs == r || rt == r;
+        if (op >= 0x08u && op <= 0x0Eu) return rs == r;
+        if (op == 0x10u) return ((w >> 21) & 31u) == 0x04u && rt == r;
+        if (op == 0x12u) {
+            uint32_t f = (w >> 21) & 31u;
+            return (f == 0x04u || f == 0x06u) && rt == r;
+        }
+        if (op == 0x22u || op == 0x26u ||
+            (op >= 0x28u && op <= 0x2Eu))
+            return rs == r || rt == r;
+        return rs == r;
+    };
+    auto writes_gpr = [](uint32_t w, uint32_t r) -> bool {
+        if (r == 0u || w == 0u) return false;
+        uint32_t op = w >> 26, rt = (w >> 16) & 31u;
+        uint32_t rd = (w >> 11) & 31u, fn = w & 63u;
+        if (op == 0u) {
+            if (fn == 0x08u || fn == 0x0Cu || fn == 0x0Du || fn == 0x0Fu ||
+                fn == 0x11u || fn == 0x13u ||
+                (fn >= 0x18u && fn <= 0x1Bu)) return false;
+            return rd == r;
+        }
+        if (op == 0x03u) return r == 31u;
+        if (op == 0x01u) return (rt == 0x10u || rt == 0x11u) && r == 31u;
+        if (op == 0x02u || (op >= 0x04u && op <= 0x07u) ||
+            (op >= 0x28u && op <= 0x2Eu) || op == 0x32u || op == 0x3Au)
+            return false;
+        if (op == 0x10u) return ((w >> 21) & 31u) == 0u && rt == r;
+        if (op == 0x12u) {
+            uint32_t f = (w >> 21) & 31u;
+            return (f == 0u || f == 2u) && rt == r;
+        }
+        return rt == r;
+    };
+    uint32_t delayed_load_addr = 0u;
+    uint32_t delayed_load_dest = 0u;
+    bool delayed_load_active = false;
+
     while (addr <= block.end_addr) {
         auto instr_opt = exe_.read_word(addr);
         if (!instr_opt.has_value()) {
@@ -1773,7 +1836,42 @@ std::string CodeGenerator::translate_basic_block(
         if (!is_cf) {
             if (cycle_per_insn) emit_pre_icache(addr, config_.indent);
             if (cycle_per_insn) emit_pre_timing(instr, config_.indent);
-            ss << translate_instruction(addr, instr) << "\n";
+            std::string emitted = translate_instruction(addr, instr);
+            int load_dest = simple_load_dest(instr);
+            bool defer_load = false;
+            if (!delayed_load_active && load_dest > 0 && addr + 4u <= block.end_addr &&
+                !extra_labels_.count(addr + 4u)) {
+                auto next = exe_.read_word(addr + 4u);
+                defer_load = next.has_value() &&
+                    !ControlFlowAnalyzer::is_control_flow(*next) &&
+                    reads_gpr(*next, static_cast<uint32_t>(load_dest));
+            }
+            if (defer_load) {
+                const std::string lhs = fmt::format("cpu->gpr[{}] =", load_dest);
+                const size_t pos = emitted.find(lhs);
+                if (pos != std::string::npos) {
+                    const std::string temp = fmt::format("psx_ldd_{:08X}", addr);
+                    emitted.replace(pos, lhs.size(), "uint32_t " + temp + " =");
+                    ss << config_.indent << "{ /* MIPS-I load-delay pair */\n";
+                    delayed_load_addr = addr;
+                    delayed_load_dest = static_cast<uint32_t>(load_dest);
+                    delayed_load_active = true;
+                }
+            }
+            ss << emitted << "\n";
+            if (delayed_load_active && addr == delayed_load_addr + 4u) {
+                if (writes_gpr(instr, delayed_load_dest)) {
+                    ss << config_.indent << fmt::format(
+                        "(void)psx_ldd_{:08X};  /* successor write wins */\n",
+                        delayed_load_addr);
+                } else {
+                    ss << config_.indent << fmt::format(
+                        "cpu->gpr[{}] = psx_ldd_{:08X};  /* load-delay writeback */\n",
+                        delayed_load_dest, delayed_load_addr);
+                }
+                ss << config_.indent << "}\n";
+                delayed_load_active = false;
+            }
             emit_cosim_instr(addr, config_.indent);
         } else {
             // Control flow is handled at block exit

--- a/recompiler/tests/recompiler_patch_test.cpp
+++ b/recompiler/tests/recompiler_patch_test.cpp
@@ -931,6 +931,38 @@ void jump_table_producer_codegen_test() {
           "alias regression fixture reaches the table when ownership is absent");
 }
 
+void cfg_codegen_load_delay_test() {
+    constexpr uint32_t base = 0x80003590u;
+    PSXRecomp::PS1Executable exe{};
+    exe.header.load_address = base;
+    exe.header.initial_pc = base;
+    exe.header.file_size = 20u;
+    append_word(exe.code_data, 0x8F5A4C38u); // lw k0,0x4c38(k0)
+    append_word(exe.code_data, 0x03400825u); // move at,k0 (must see old k0)
+    append_word(exe.code_data, 0xAC3A4C38u); // sw k0,0x4c38(at)
+    append_word(exe.code_data, 0x03E00008u); // jr ra
+    append_word(exe.code_data, 0x00000000u); // delay-slot nop
+
+    PSXRecomp::Function function{};
+    function.start_addr = base;
+    function.end_addr = base + 20u;
+    function.size = 20u;
+    function.name = "cfg_load_delay";
+    PSXRecomp::ControlFlowAnalyzer analyzer(exe);
+    const auto cfg = analyzer.analyze_function(function);
+    PSXRecomp::CodeGenerator generator(exe);
+    const std::string code = generator.generate_function(function, cfg).full_code;
+
+    const size_t deferred = code.find("uint32_t psx_ldd_80003590 =");
+    const size_t successor = code.find("cpu->gpr[1] = cpu->gpr[26]");
+    const size_t writeback = code.find(
+        "cpu->gpr[26] = psx_ldd_80003590;  /* load-delay writeback */");
+    check(deferred != std::string::npos && successor != std::string::npos &&
+          writeback != std::string::npos && deferred < successor &&
+          successor < writeback,
+          "CFG codegen preserves MIPS-I dependent load-delay value semantics");
+}
+
 } // namespace
 
 int main() {
@@ -945,6 +977,7 @@ int main() {
         codegen_tests();
         gte_codegen_classification_tests();
         jump_table_producer_codegen_test();
+        cfg_codegen_load_delay_test();
     } catch (const std::exception& e) {
         fmt::print(stderr, "FAIL  unexpected exception: {}\n", e.what());
         ++failures;


### PR DESCRIPTION
## Summary

- preserve MIPS-I load-delay value semantics in CFG-generated code for dependent LB/LBU/LH/LHU/LW pairs
- let the immediate successor observe the destination register's old value
- commit the deferred load afterward, while preserving the rule that a successor write to the same register wins
- keep label and control-flow boundaries conservative

## Problem

The resident/full-function emitter already models dependent load delays, but the CFG emitter used by captured overlays exposed an ordinary load result immediately. A sequence such as:

```mips
lw    k0, 0x4c38(k0)
move  at, k0
```

must copy the old k0 into at on MIPS-I. The prior CFG output copied the newly loaded value instead. In an OpenBIOS fasttrack handler this corrupted a kernel queue pointer, producing a much later device/interrupt failure.

## Validation

- added a focused code-generation regression using the exact dependent load/use/store sequence
- rebuilt the recompiler
- full CTest suite passes: 38/38
- regenerated captured-overlay caches were validated in two clean processes past the former deterministic failure boundary

The patch contains only the generic recompiler change and regression test; project-specific diagnostics and documentation are intentionally excluded.

---
Developed with AI assistance; validated as described (test evidence in PR body). AI writes the code and the PR, but I always test before I send something up. Happy to iterate on this process with your feedback.