### PR TITLE
runtime: accept Steam .car disc images

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -108,8 +108,8 @@ if(BUILD_TESTING)
     target_include_directories(bios_hle_plan_test PRIVATE include)
     add_test(NAME bios_hle_plan_test COMMAND bios_hle_plan_test)
 
-    # Either member of a disc dump (.cue or .bin) is a valid pick: both mount
-    # the same disc and identify off the same data track.
+    # A cue, conventional raw image, or Steam .car image is a valid pick; each
+    # must mount the same disc and identify off the same data track.
     add_executable(disc_path_resolve_test
         tests/test_disc_path_resolve.cpp
         src/disc_path.cpp

--- a/runtime/include/disc_identity.h
+++ b/runtime/include/disc_identity.h
@@ -1,7 +1,7 @@
 // disc_identity.h — disc-image identification + verification.
 //
 // Single source of truth for "is this the right disc?". Reads a .cue, raw
-// .bin/.iso, or CHD, checks for the ISO9660 PVD, extracts the volume id and the
+// .bin/.iso/.img/.car, or CHD, checks for the ISO9660 PVD, extracts the volume id and the
 // PlayStation boot serial (from SYSTEM.CNF), derives the region from the
 // serial prefix, and optionally compares against an expected serial / CRC32.
 //
@@ -40,7 +40,7 @@ struct DiscIdentity {
 };
 
 // Identify and (optionally) verify a disc image.
-//   path             : a .cue, raw .bin/.iso, or .chd image
+//   path             : a .cue, raw .bin/.iso/.img/.car, or .chd image
 //   expected_serial  : the game id, e.g. "SCUS-94236" ("" skips the serial check)
 //   expected_crc     : full-file CRC32 to match against
 //   has_expected_crc : whether expected_crc is meaningful

--- a/runtime/include/disc_path.h
+++ b/runtime/include/disc_path.h
@@ -11,9 +11,9 @@
 //
 //   picked a .cue that resolves        -> mount the cue      (keeps the TOC)
 //   picked a .cue with a missing bin   -> mount a sibling image, if one exists
-//   picked a .bin/.iso/.img owned by a cue -> mount that cue (keeps the TOC)
-//   picked a .bin/.iso/.img with no cue    -> mount it directly
-//   picked a .chd                          -> mount it directly (TOC is embedded)
+//   picked a raw .bin/.iso/.img/.car owned by a cue -> mount that cue
+//   picked a raw .bin/.iso/.img/.car with no cue    -> mount it directly
+//   picked a .chd                                  -> mount it directly (TOC embedded)
 //
 // Preferring the cue matters beyond tidiness: the cue is the only place the
 // CD-DA track layout lives. Silently swapping a cue for its same-named .bin

--- a/runtime/include/iso_reader.h
+++ b/runtime/include/iso_reader.h
@@ -84,7 +84,7 @@ public:
 
     /**
      * Open an ISO/BIN file for reading
-     * @param filename Path to .iso, .bin, .cue, or .chd file
+     * @param filename Path to .iso, .bin, .img, .car, .cue, or .chd file
      * @return true if opened successfully, false otherwise
      */
     bool Open(const std::string& filename);

--- a/runtime/src/disc_path.cpp
+++ b/runtime/src/disc_path.cpp
@@ -15,7 +15,7 @@ namespace {
 
 // Raw image extensions we are willing to mount on their own, in preference
 // order for the cue-fallback search.
-const char* const kImageExtensions[] = { ".bin", ".img", ".iso" };
+const char* const kImageExtensions[] = { ".bin", ".img", ".iso", ".car" };
 
 bool is_cue(const fs::path& p) { return path_has_extension_ci(p, ".cue"); }
 bool is_chd(const fs::path& p) { return path_has_extension_ci(p, ".chd"); }
@@ -56,7 +56,7 @@ fs::path first_existing_binary(const CueSheet& sheet) {
     return {};
 }
 
-// <stem>.bin / .img / .iso next to a cue we could not use.
+// <stem>.bin / .img / .iso / .car next to a cue we could not use.
 fs::path find_sibling_image(const fs::path& cue) {
     std::error_code ec;
     for (const char* ext : kImageExtensions) {

--- a/runtime/src/main.cpp
+++ b/runtime/src/main.cpp
@@ -1476,16 +1476,16 @@ static std::filesystem::path resolve_disc_for_runtime(const std::filesystem::pat
         (game_id.empty() ? std::string() : " (" + game_id + ")") +
         " disc image ripped from your own disc.\n\n"
         "Accepted formats: .cue (preferred, with its .bin next to it), "
-        ".bin, .iso, or .chd.\n\n"
+        ".bin, .img, .iso, .car (Steam), or .chd.\n\n"
         "(This is NOT the BIOS — the BIOS was already chosen.)");
     std::string disc_title =
         s_picker_game_name + " — Step 2 of 2: select " + s_picker_game_name +
-        " disc image (.cue / .bin / .iso / .chd)";
+        " disc image (.cue / .bin / .img / .iso / .car / .chd)";
     for (;;) {
         std::filesystem::path picked;
         if (!pick_runtime_file(
                 disc_title.c_str(),
-                "PS1 Disc Images (*.cue;*.bin;*.iso;*.chd)\0*.cue;*.bin;*.iso;*.chd\0All Files (*.*)\0*.*\0",
+                "PS1 Disc Images (*.cue;*.bin;*.img;*.iso;*.car;*.chd)\0*.cue;*.bin;*.img;*.iso;*.car;*.chd\0All Files (*.*)\0*.*\0",
                 picked, "--disc")) {
             return {};
         }

--- a/runtime/tests/test_disc_path_resolve.cpp
+++ b/runtime/tests/test_disc_path_resolve.cpp
@@ -1,7 +1,8 @@
 // test_disc_path_resolve.cpp — either member of a disc dump is a valid pick.
 //
 // The contract under test (runtime/include/disc_path.h): whichever file the
-// player hands us — the .cue or the .bin — we mount the same disc and read
+// player hands us — the .cue, a conventional raw image, or Steam's .car raw
+// image — we mount the same disc and read
 // identity/CRC from the same data track. Regression anchor for the old
 // behavior, which swapped a .cue for its same-named .bin unconditionally and
 // silently dropped the cue's CD-DA tracks.
@@ -151,6 +152,18 @@ void test_bare_image(const fs::path& root) {
     write_sectors(dir / "game2.iso", 4, 0x33);
     const auto iso = resolve_disc_path(dir / "game2.iso");
     check(same(iso.mount, dir / "game2.iso"), "bare: iso mounts itself");
+
+    // Steam ships some PlayStation games as extension-renamed raw images. The
+    // extension is packaging, not a different on-disc format: accept the file
+    // directly without requiring the player to rename t_data_u.car to .bin.
+    write_sectors(dir / "t_data_u.car", 4, 0x55);
+    const auto car = resolve_disc_path(dir / "t_data_u.car");
+    check(same(car.mount, dir / "t_data_u.car"), "bare: Steam car mounts itself");
+    check(same(car.data, dir / "t_data_u.car"), "bare: Steam car identifies itself");
+    PS1::ISOReader car_reader;
+    check(car_reader.Open(car.mount.string()), "bare: Steam car opens as a raw image");
+    check(car_reader.TrackCount() == 1, "bare: Steam car exposes one data track");
+    car_reader.Close();
 
     // A CHD embeds its own TOC. Even if a same-stem cue exists, never replace
     // the selected compressed image with that cue or its external payload.


### PR DESCRIPTION
Treat Steam's extension-renamed PlayStation raw images as supported disc media. This adds .car to raw-image resolution and the native picker, and covers direct t_data_u.car mounting with the disc-path regression test.

Context: mstan/TombaRecomp#14