### PR TITLE
autocompile: report a degraded (interpreter-only) run on a channel that exists

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -184,6 +184,16 @@ if(BUILD_TESTING)
             PSX_AUTOCOMPILE_TEST=1)
         add_test(NAME autocompile_publication_test
                  COMMAND autocompile_publication_test)
+
+        # A misconfigured overlay_autocompile_cmd must be reported on a channel
+        # that exists: the stdout warnings reach nobody under -mwindows, so a
+        # broken autocompile silently degrades the whole run to the interpreter.
+        add_executable(autocompile_degraded_test
+            tests/test_autocompile_degraded.c
+            src/autocompile.c)
+        target_include_directories(autocompile_degraded_test PRIVATE include)
+        add_test(NAME autocompile_degraded_test
+                 COMMAND autocompile_degraded_test)
     endif()
 endif()
 

--- a/runtime/include/autocompile.h
+++ b/runtime/include/autocompile.h
@@ -55,6 +55,18 @@ void autocompile_shutdown(void);
  * exit code, and the output tail. Returns bytes written. */
 int  autocompile_status_json(char *out, int cap);
 
+/* Why overlay autocompile cannot work, or NULL if nothing is known to be wrong.
+ *
+ * When this is non-NULL, no shard will ever be compiled and overlay execution
+ * stays in the interpreter — the run is valid but its performance is
+ * meaningless. Callers that report timings should say so rather than publish a
+ * number measured in that state.
+ *
+ * This exists because the equivalent warnings are written to stdout and the
+ * shipped runtime links -mwindows, so they reach nobody. `autocompile_status`
+ * carries this out over the TCP debug server as "degraded"/"degraded_reason". */
+const char *autocompile_degraded_reason(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/runtime/src/autocompile.c
+++ b/runtime/src/autocompile.c
@@ -4,6 +4,7 @@
 #include "autocompile.h"
 #include "overlay_loader.h"
 
+#include <stdarg.h>   /* autocompile_set_degraded takes a format + varargs */
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>   /* getenv — declared here; glibc/windows.h leak it, macOS SDK does not */
@@ -107,6 +108,37 @@ static uint32_t     s_shard_skipped    = 0;   /* last run */
 static uint32_t     s_shard_fail_total = 0;   /* accumulated across all runs */
 static int          s_shard_result_seen = 0;  /* did we parse a result line? */
 
+/* ---- Degraded-state channel (portable; read by autocompile_status_json) ----
+ *
+ * Every warning in this file goes to stdout, and the shipped runtime links
+ * `-mwindows` — a GUI-subsystem binary with NO console attached. So the careful
+ * diagnostics below are emitted into nothing on exactly the builds people run,
+ * and a broken autocompile presents only as "the game feels slow".
+ *
+ * That is not hypothetical. A fresh worktree ran 100% interpreted for an entire
+ * session — `runs=8 fails=8 shard_ok=0`, `dispatch_native=0` — because
+ * `overlay_autocompile_cmd` named a recompiler path the documented build recipe
+ * does not produce. Nothing surfaced it, and it invalidated a whole performance
+ * comparison before the counters were queried by hand.
+ *
+ * Rule 3 forbids log files and printf debugging, so the fix is not more
+ * printing: record WHY we are degraded in one string that leaves over the TCP
+ * debug server in `autocompile_status`. One queryable field, carrying the
+ * reason, instead of a state that has to be reconstructed from counters. */
+static char s_degraded[600];
+
+static void autocompile_set_degraded(const char *fmt, ...) {
+    if (s_degraded[0]) return;          /* keep the FIRST cause, not the last */
+    va_list ap;
+    va_start(ap, fmt);
+    vsnprintf(s_degraded, sizeof(s_degraded), fmt, ap);
+    va_end(ap);
+}
+
+const char *autocompile_degraded_reason(void) {
+    return s_degraded[0] ? s_degraded : NULL;
+}
+
 /* Child-output tail ring. Watcher thread writes, TCP reads — guarded by a
  * critical section on Windows. Holds the TAIL (newest bytes win). */
 #define AC_OUT_CAP 8192
@@ -157,6 +189,13 @@ static int  s_child_line_overflow = 0;
 static void autocompile_report_broken_once(void) {
     if (s_reported_broken || s_consecutive_fails < AC_LOUD_AFTER_FAILS) return;
     s_reported_broken = 1;
+    autocompile_set_degraded(
+        "overlay autocompile failed %u consecutive runs (last exit %d); "
+        "nothing is being compiled to native code, so overlay execution stays "
+        "in the interpreter. Check [runtime] overlay_autocompile_cmd in "
+        "game.toml: every path in it must resolve from the process working "
+        "directory.",
+        s_consecutive_fails, (int)s_exit_code);
     char tail[AC_OUT_CAP];
     int n = 0;
     if (s_out_lock_init) {
@@ -588,6 +627,10 @@ static void autocompile_report_interpreter(void) {
      * tokens; a token that already has a path or extension resolves as-is. */
     DWORD r = SearchPathA(NULL, tok, ".exe", sizeof(resolved), resolved, NULL);
     if (r == 0 || r >= sizeof(resolved)) {
+        autocompile_set_degraded(
+            "overlay autocompile interpreter \"%s\" does not resolve on PATH; "
+            "every compile run will fail and overlay execution will stay in "
+            "the interpreter.", tok);
         fprintf(stdout,
             "psxrecomp: overlay autocompile interpreter '%s' does not resolve "
             "on PATH — every compile run will fail.\n", tok);
@@ -606,6 +649,13 @@ static void autocompile_report_interpreter(void) {
             FILE *f = fopen(cand, "rb");
             if (f) {
                 fclose(f);
+                autocompile_set_degraded(
+                    "overlay autocompile interpreter \"%s\" is an MSYS2/Cygwin "
+                    "build (%s beside it); it crashes under the job spawn "
+                    "before producing output, so every compile fails with no "
+                    "diagnostics. Use \"py -3 ...\" in "
+                    "[runtime] overlay_autocompile_cmd.",
+                    resolved, posix_dlls[k]);
                 fprintf(stdout,
                     "psxrecomp: WARNING: that interpreter is an MSYS2/Cygwin "
                     "build (%s beside it).\n"
@@ -623,6 +673,82 @@ static void autocompile_report_interpreter(void) {
 }
 #endif
 
+/* Validate the file arguments the command names, at configure time.
+ *
+ * autocompile_report_interpreter() above resolves the FIRST token (the Python
+ * interpreter). It does not look at the rest of the command line, and the
+ * argument that actually breaks in practice is `--recompiler <path>`: the path
+ * is per-title, hardcoded in game.toml, and does not agree with where the
+ * documented build recipe puts the recompiler.
+ *
+ *   Tomba 2 names psxrecomp-v4/recompiler/build-t2/psxrecomp-game.exe, while
+ *   the recipe builds build-recompiler/ at the worktree root — never matches.
+ *   MMX6 hardcodes an ABSOLUTE path into one checkout, so it works only by
+ *   luck of local layout.
+ *
+ * When the path is wrong every compile fails identically, and because the
+ * failure is only reachable through counters nobody queries, the run silently
+ * degrades to the interpreter. Checking here turns a session-long mystery into
+ * a fact known before the first compile is ever attempted.
+ *
+ * Deliberately advisory: a missing path is recorded and reported, not fatal.
+ * The runtime still runs (interpreted) exactly as before — this only removes
+ * the silence. */
+#ifdef _WIN32
+static void autocompile_check_path_args(void) {
+    static const char *flags[] = { "--recompiler", "--runtime-include" };
+    for (size_t i = 0; i < sizeof(flags) / sizeof(flags[0]); i++) {
+        const char *at = strstr(s_cmd, flags[i]);
+        if (!at) continue;
+        const char *p = at + strlen(flags[i]);
+        while (*p == ' ' || *p == '=') p++;
+        char path[MAX_PATH];
+        size_t n = 0;
+        if (*p == '"') {
+            p++;
+            while (*p && *p != '"' && n + 1 < sizeof(path)) path[n++] = *p++;
+        } else {
+            while (*p && *p != ' ' && n + 1 < sizeof(path)) path[n++] = *p++;
+        }
+        path[n] = '\0';
+        if (!path[0]) continue;
+
+        /* Relative paths resolve against the child's working directory, which
+         * is s_cwd — not ours. Mirror that, or a correct relative path would
+         * look broken from here. */
+        /* Sized to hold s_cwd + separator + a full MAX_PATH argument, so a long
+         * working directory cannot silently truncate the path we then test. */
+        char full[sizeof(s_cwd) + MAX_PATH + 2];
+        int absolute = (path[0] == '/' || path[0] == '\\' ||
+                        (path[1] == ':' && (path[2] == '\\' || path[2] == '/')));
+        if (absolute || !s_cwd[0])
+            snprintf(full, sizeof(full), "%s", path);
+        else
+            snprintf(full, sizeof(full), "%s\\%s", s_cwd, path);
+
+        DWORD attr = GetFileAttributesA(full);
+        if (attr == INVALID_FILE_ATTRIBUTES) {
+            autocompile_set_degraded(
+                "overlay autocompile cannot start: %s \"%s\" does not exist "
+                "(resolved to \"%s\"). Every compile will fail and overlay "
+                "execution will stay in the interpreter. Fix the path in "
+                "[runtime] overlay_autocompile_cmd, or build the recompiler "
+                "where it points.",
+                flags[i], path, full);
+            fprintf(stdout,
+                "psxrecomp: WARNING: overlay autocompile %s \"%s\" does not "
+                "exist (resolved to \"%s\").\n"
+                "  Every overlay compile will fail and execution will stay in "
+                "the interpreter.\n"
+                "  Query the debug server's autocompile_status "
+                "(\"degraded_reason\") to see this without a console.\n",
+                flags[i], path, full);
+            fflush(stdout);
+        }
+    }
+}
+#endif /* _WIN32 */
+
 void autocompile_configure(const char *cmd, const char *cwd) {
     snprintf(s_cmd, sizeof(s_cmd), "%s", cmd ? cmd : "");
     snprintf(s_cwd, sizeof(s_cwd), "%s", cwd ? cwd : "");
@@ -632,7 +758,10 @@ void autocompile_configure(const char *cmd, const char *cwd) {
         InitializeConditionVariable(&s_publish_cv);
         s_out_lock_init = 1;
     }
-    if (s_cmd[0]) autocompile_report_interpreter();
+    if (s_cmd[0]) {
+        autocompile_report_interpreter();
+        autocompile_check_path_args();
+    }
 #endif
 }
 
@@ -1052,8 +1181,18 @@ int autocompile_status_json(char *out, int cap) {
     const uint64_t now_ms = autocompile_now_ms();
     if (s_retry_not_before_ms > now_ms)
         retry_ms = s_retry_not_before_ms - now_ms;
+    /* Degraded reason first, so it is the first thing a reader sees. This is
+     * the ONLY channel that works on the shipped build: the stdout warnings
+     * elsewhere in this file go nowhere under -mwindows. */
+    char degr[720];
+    degr[0] = '\0';
+    if (s_degraded[0])
+        json_escape_into(degr, (int)sizeof(degr), s_degraded,
+                         (int)strlen(s_degraded));
+
     return snprintf(out, cap,
-        "{\"configured\":%d,\"state\":\"%s\",\"runs\":%u,\"fails\":%u,"
+        "{\"degraded\":%d,\"degraded_reason\":\"%s\","
+        "\"configured\":%d,\"state\":\"%s\",\"runs\":%u,\"fails\":%u,"
         "\"rescans\":%u,\"last_exit\":%d,"
         "\"consecutive_fails\":%u,\"retry_ms\":%llu,"
         "\"shard_ok\":%u,\"shard_fail\":%u,\"shard_skipped\":%u,"
@@ -1066,8 +1205,9 @@ int autocompile_status_json(char *out, int cap) {
         "\"publish_prepare_max_us\":%llu,"
         "\"publish_prepare_last_us\":%llu,"
         "\"output_tail\":\"%s\"}",
+        s_degraded[0] ? 1 : 0, degr,
         autocompile_configured(), names[ac_state_load() & 3], s_runs, s_fails,
-        s_rescans, s_exit_code, s_consecutive_fails,
+        s_rescans, (int)s_exit_code, s_consecutive_fails,
         (unsigned long long)retry_ms,
         s_shard_ok, s_shard_fail, s_shard_skipped,
         s_shard_fail_total, s_shard_result_seen,

--- a/runtime/src/crash_trace.c
+++ b/runtime/src/crash_trace.c
@@ -33,6 +33,8 @@
 
 #include "cpu_state.h"
 #include "crash_trace.h"
+#include "autocompile.h"   /* autocompile_degraded_reason — stamp a degraded
+                            * (interpreter-only) run into its own report */
 
 /* Output path — overwritten per dump. */
 static const char *kReportPath = "psx_last_run_report.json";
@@ -265,10 +267,31 @@ void psx_crash_trace_dump(const char *reason, void *seh_info) {
         if (tm) strftime(ts, sizeof(ts), "%Y-%m-%dT%H:%M:%SZ", tm);
     }
 
+    /* Overlay autocompile health. A run whose autocompile never worked executed
+     * entirely in the interpreter, so ANY timing taken from it is meaningless —
+     * and that state is otherwise invisible (the warnings go to stdout, which
+     * does not exist under -mwindows). Stamping it into the run report makes a
+     * degraded session self-documenting rather than something the next reader
+     * has to suspect and re-derive. */
+    const char *ac_degraded = autocompile_degraded_reason();
+    char ac_escaped[640];
+    ac_escaped[0] = '\0';
+    if (ac_degraded) {
+        size_t w = 0;
+        for (const char *p = ac_degraded; *p && w + 2 < sizeof(ac_escaped); p++) {
+            if (*p == '"' || *p == '\\') ac_escaped[w++] = '\\';
+            else if ((unsigned char)*p < 0x20) { ac_escaped[w++] = ' '; continue; }
+            ac_escaped[w++] = *p;
+        }
+        ac_escaped[w] = '\0';
+    }
+
     append_fmt(buf, sizeof(buf), &pos,
         "{\n"
         "  \"reason\": \"%s\",\n"
         "  \"exit_origin\": \"%s\",\n"
+        "  \"autocompile_degraded\": %d,\n"
+        "  \"autocompile_degraded_reason\": \"%s\",\n"
         "  \"build\": \"%s\",\n"
         "  \"timestamp\": \"%s\",\n"
         "  \"frame\": %llu,\n"
@@ -291,6 +314,8 @@ void psx_crash_trace_dump(const char *reason, void *seh_info) {
         "  },\n",
         reason ? reason : "(unknown)",
         s_exit_origin,
+        ac_degraded ? 1 : 0,
+        ac_degraded ? ac_escaped : "",
         kBuildId,
         ts,
         (unsigned long long)s_frame_count,

--- a/runtime/tests/test_autocompile_degraded.c
+++ b/runtime/tests/test_autocompile_degraded.c
@@ -1,0 +1,124 @@
+/*
+ * A broken overlay autocompile must SAY SO on a channel that exists.
+ *
+ * Every diagnostic in autocompile.c is written to stdout, and the shipped
+ * runtime links -mwindows: a GUI-subsystem binary with no console. So those
+ * warnings reach nobody on the builds people actually run, and a misconfigured
+ * `overlay_autocompile_cmd` degrades the whole session to the interpreter in
+ * silence. That really happened: a fresh worktree ran with runs=8 fails=8
+ * shard_ok=0 and dispatch_native=0 for an entire session, and the only symptom
+ * was "it feels slow" - which invalidated a performance comparison.
+ *
+ * The contract under test: when the command names a file that does not exist,
+ * autocompile_configure() records WHY, and autocompile_status_json() carries it
+ * out over the TCP debug server as degraded/degraded_reason. Configure-time,
+ * not after three failed spawns - the point is to know before any compile is
+ * attempted.
+ *
+ * Build (standalone):
+ *   gcc -I ../include -o test_autocompile_degraded \
+ *       test_autocompile_degraded.c ../src/autocompile.c
+ */
+#include "autocompile.h"
+#include "overlay_loader.h"
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+
+#include <stdio.h>
+#include <string.h>
+
+/* autocompile.c calls into the overlay loader when it publishes images; none of
+ * that runs here (we never spawn a child), but the symbols must resolve.
+ * Signatures must match overlay_loader.h exactly. */
+struct OverlayPreparedImage { unsigned id; };
+OverlayPreparedImage *overlay_loader_prepare_published(const char *dll_path) {
+    (void)dll_path; return NULL;
+}
+int  overlay_loader_commit_published(OverlayPreparedImage *image) { (void)image; return 0; }
+void overlay_loader_discard_prepared(OverlayPreparedImage *image) { (void)image; }
+void overlay_loader_rescan(void) { }
+
+static int failures;
+
+#define CHECK(cond, msg) do {                                                 \
+    if (!(cond)) { fprintf(stderr, "FAIL: %s\n", (msg)); failures++; }        \
+} while (0)
+
+/* Does the status JSON advertise degraded, and mention `needle`? */
+static void expect_status(int want_degraded, const char *needle) {
+    char json[4096];
+    int n = autocompile_status_json(json, (int)sizeof json);
+    CHECK(n > 0 && n < (int)sizeof json, "status json fits");
+    const char *flag = want_degraded ? "\"degraded\":1" : "\"degraded\":0";
+    if (!strstr(json, flag)) {
+        fprintf(stderr, "FAIL: expected %s in status\n  got: %.400s\n", flag, json);
+        failures++;
+    }
+    if (needle && !strstr(json, needle)) {
+        fprintf(stderr, "FAIL: expected reason to mention '%s'\n  got: %.400s\n",
+                needle, json);
+        failures++;
+    }
+}
+
+int main(void) {
+    char cwd[MAX_PATH];
+    GetCurrentDirectoryA(sizeof cwd, cwd);
+
+    /* --- a command naming a recompiler that does not exist --------------- */
+    /* This is the exact real-world shape: the interpreter resolves fine, the
+     * script path may resolve fine, and the --recompiler argument points at a
+     * build directory the documented build recipe never produces. */
+    char cmd[2048];
+    snprintf(cmd, sizeof cmd,
+             "py -3 tools/compile_overlays.py --captures build/overlay_captures.json "
+             "--recompiler %s\\definitely_not_here\\psxrecomp-game.exe "
+             "--out-dir build/cache", cwd);
+    autocompile_configure(cmd, cwd);
+    CHECK(autocompile_degraded_reason() != NULL,
+          "a missing --recompiler path is reported as degraded");
+    if (autocompile_degraded_reason())
+        CHECK(strstr(autocompile_degraded_reason(), "--recompiler") != NULL,
+              "the reason names the offending flag");
+    expect_status(1, "--recompiler");
+
+    /* The reason must survive being read repeatedly and must not be
+     * overwritten by a later, less-specific cause - the FIRST cause is the
+     * useful one. */
+    const char *first = autocompile_degraded_reason();
+    char kept[600];
+    snprintf(kept, sizeof kept, "%s", first ? first : "");
+    autocompile_configure(cmd, cwd);
+    CHECK(autocompile_degraded_reason() != NULL &&
+          strcmp(autocompile_degraded_reason(), kept) == 0,
+          "the first recorded cause is retained");
+
+    /* --- the JSON must stay parseable even with a long reason ------------ */
+    char json[4096];
+    int n = autocompile_status_json(json, (int)sizeof json);
+    CHECK(n > 0, "status json emitted");
+    CHECK(json[0] == '{' && json[n - 1] == '}', "status json is a complete object");
+    CHECK(strstr(json, "\"degraded_reason\":\"") != NULL,
+          "degraded_reason field present");
+    /* The reason is embedded in a JSON string: it must not contain a raw quote
+     * or backslash that would break the object for every consumer. */
+    const char *r = strstr(json, "\"degraded_reason\":\"");
+    if (r) {
+        r += strlen("\"degraded_reason\":\"");
+        int escaped_ok = 1;
+        for (const char *p = r; *p; p++) {
+            if (*p == '"') break;                 /* properly terminated */
+            if (*p == '\\') { p++; continue; }    /* escape pair */
+            if ((unsigned char)*p < 0x20) { escaped_ok = 0; break; }
+        }
+        CHECK(escaped_ok, "reason contains no raw control characters");
+    }
+
+    if (failures) {
+        fprintf(stderr, "FAILED (%d)\n", failures);
+        return 1;
+    }
+    printf("test_autocompile_degraded: all checks passed\n");
+    return 0;
+}


### PR DESCRIPTION
A misconfigured `overlay_autocompile_cmd` silently degrades an entire session to
the interpreter, and nothing says so.

The diagnosis machinery already exists and is good — `autocompile_report_broken_once()`
fires after 3 consecutive failures and explains exactly what to check. But it writes to
`fprintf(stdout)`, and the shipped runtime links **`-mwindows`**: a GUI-subsystem binary
with no console attached. **The warning is emitted into nothing on exactly the builds
people run.**

### Cost, measured not hypothetical

A fresh worktree ran **100% interpreted for an entire session** —
`runs=8 fails=8 shard_ok=0`, `dispatch_native=0` — because `game.toml` named a recompiler
path the documented build recipe does not produce. The only symptom was "it feels slow".
It invalidated a whole performance A/B before the counters were queried by hand.

The paths are hardcoded per-title and inconsistent:
- **Tomba 2** expects `psxrecomp-v4/recompiler/build-t2/psxrecomp-game.exe`; the recipe
  builds `build-recompiler/` at the worktree root. Never matches.
- **MMX6** hardcodes an *absolute* path into one checkout — works only by luck of local
  layout, fails on any other machine.
- **Tomba 1** expects `psxrecomp/recompiler/build/` (its submodule is named `psxrecomp`).

### Changes

1. **Validate path arguments at configure time.** The existing check resolves only the
   first token (the interpreter) and never looked at `--recompiler` — the argument that
   actually breaks. Paths now resolve against the child's working directory and are
   checked *before any compile is attempted*, instead of the truth emerging after three
   failed spawns. Advisory, not fatal: the runtime behaves exactly as before, just not
   silently.
2. **A degraded-state channel that exists** — one string recording *why*, exposed as
   `degraded` / `degraded_reason` in `autocompile_status` over the TCP debug server.
   Rule 3's answer rather than more printing. Keeps the **first** cause.
3. **Stamped into `psx_last_run_report.json`.** This is the part that prevents a repeat:
   a field you have to query is a field nobody queries. A degraded run now says so in its
   own artifact, so *"was that measurement valid?"* is answerable after the fact.

### Test

`test_autocompile_degraded` (new, registered in CTest) builds the real failure shape — a
`--recompiler` path that does not exist — and asserts it is caught at configure time, that
the reason names the offending flag, that the first cause is retained, and that the reason
is escaped so it cannot break the JSON for every consumer. Passes; full runtime builds clean.

Also fixes a pre-existing `%d`/`LONG` mismatch on `last_exit` that this change's argument
shuffle surfaced. Warnings on `autocompile.c` go 2 → 1 (the remaining `array-bounds` one in
`watch_thread` is pre-existing and untouched).

### Deliberately not done

The underlying cause is that every title's `game.toml` hardcodes a build-directory path.
Fixing that means having CMake record the real recompiler location and touching six title
repos — its own change. This PR makes the failure impossible to miss.