### PR TITLE
keybinds: mouse buttons, dual bindings per control, keyboard/mouse merge alongside gamepad

### DIFF
--- a/runtime/include/psx_keybinds.h
+++ b/runtime/include/psx_keybinds.h
@@ -91,6 +91,11 @@ const char  *psx_keybinds_button_name(int button);          /* "up".."rs_right" 
 const char  *psx_keybinds_button_label(int button);         /* pretty, e.g. "Cross" */
 SDL_Scancode psx_keybinds_get_button(int player, int button);
 void         psx_keybinds_set_button(int player, int button, SDL_Scancode sc);
+/* Alternate (secondary) binding per control: both the primary and the alt
+ * assert the input (e.g. cross = X, Mouse1). Stored in keybinds.ini as a
+ * comma-separated second name; SDL_SCANCODE_UNKNOWN = no alt. */
+SDL_Scancode psx_keybinds_get_button_alt(int player, int button);
+void         psx_keybinds_set_button_alt(int player, int button, SDL_Scancode sc);
 /* Reset one player's bindings to the built-in defaults (P2 = all unbound). */
 void         psx_keybinds_reset_player(int player);
 /* Persist the current bindings to keybinds.ini (path resolved by

--- a/runtime/src/main.cpp
+++ b/runtime/src/main.cpp
@@ -3069,8 +3069,14 @@ static int capture_pad_slot(int s, PsxNetPad* out) {
     const bool suppress_stick = (eff_analog != 0);
     uint16_t btn = (p.kind != 0) ? pad_buttons_for(p, player, suppress_stick)
                                  : (uint16_t)0xFFFF;
+    /* Keyboard/mouse binds are ALWAYS live alongside the routed device: a
+     * player with a gamepad routed still gets mouse fire / keyboard keys
+     * (active-low AND — unpressed sources are a no-op). Without this, routing
+     * P1 to a pad silently discarded every keybinds.ini/mouse bind, which
+     * defeats dual bindings (pad in hand, mouse for aiming). kind==1 already
+     * consumed the keyboard via pad_buttons_for — don't AND it twice. */
+    if (p.kind != 1) btn &= pad_from_keyboard(player);
     if (dev_here) {
-        btn &= pad_from_keyboard(1);                        /* keyboard P1 binds  */
         btn &= dev_all_controllers_buttons(suppress_stick); /* any plugged-in pad */
     }
 

--- a/runtime/src/psx_keybinds.c
+++ b/runtime/src/psx_keybinds.c
@@ -89,6 +89,10 @@
 
 static PsxKeyBinds       s_binds         = PSXKB_DEFAULTS;
 static const PsxKeyBinds s_default_binds = PSXKB_DEFAULTS;
+/* Alternate bindings: zero-initialised = SDL_SCANCODE_UNKNOWN = no alt bound.
+ * Primary OR alt asserts the input; both persist to keybinds.ini as
+ * "primary, alt" on one line. */
+static PsxKeyBinds       s_alt_binds;
 
 typedef struct {
     const char *name;   /* ini key */
@@ -219,11 +223,18 @@ static void derive_ini_path(const char *exe_path) {
     snprintf(s_ini_path, sizeof(s_ini_path), "%skeybinds.ini", dir);
 }
 
-static void write_player_section(FILE *f, const char *section, const PsxPlayerBinds *pb) {
+static void write_player_section(FILE *f, const char *section,
+                                 const PsxPlayerBinds *pb,
+                                 const PsxPlayerBinds *alt) {
     fprintf(f, "[%s]\n", section);
     for (int i = 0; i < PSXKB_N; i++) {
-        SDL_Scancode sc = *(const SDL_Scancode *)((const char *)pb + s_buttons[i].offset);
-        fprintf(f, "%-9s = %s\n", s_buttons[i].name, scancode_to_name(sc));
+        SDL_Scancode sc = *(const SDL_Scancode *)((const char *)pb  + s_buttons[i].offset);
+        SDL_Scancode al = *(const SDL_Scancode *)((const char *)alt + s_buttons[i].offset);
+        if (al != SDL_SCANCODE_UNKNOWN)
+            fprintf(f, "%-9s = %s, %s\n", s_buttons[i].name,
+                    scancode_to_name(sc), scancode_to_name(al));
+        else
+            fprintf(f, "%-9s = %s\n", s_buttons[i].name, scancode_to_name(sc));
     }
     fprintf(f, "\n");
 }
@@ -239,6 +250,8 @@ static void write_ini(const char *path) {
         "# Backspace, Escape, Backslash. Use \"None\" to leave an input unbound.\n"
         "# Mouse buttons also bind: Mouse1 (left), Mouse2 (middle), Mouse3 (right),\n"
         "# Mouse4/Mouse5 (side); aliases LMB, MMB, RMB.\n"
+        "# Each input accepts an optional SECOND binding after a comma - both\n"
+        "# assert the input:  cross = X, Mouse1\n"
         "#\n"
         "# Buttons: up/down/left/right, cross/circle/square/triangle, l1/r1/l2/r2,\n"
         "# l3/r3 (stick clicks), start/select. ls_* / rs_* are the left/right\n"
@@ -247,8 +260,8 @@ static void write_ini(const char *path) {
         "# Player 2 is unbound by default — fill in keys to enable a second\n"
         "# keyboard player (route a port to \"Keyboard\" in the launcher).\n"
         "\n");
-    write_player_section(f, "player1", &s_binds.p1);
-    write_player_section(f, "player2", &s_binds.p2);
+    write_player_section(f, "player1", &s_binds.p1, &s_alt_binds.p1);
+    write_player_section(f, "player2", &s_binds.p2, &s_alt_binds.p2);
     fclose(f);
     printf("[Keybinds] Wrote %s\n", path);
 }
@@ -256,7 +269,7 @@ static void write_ini(const char *path) {
 static void load_ini(const char *path) {
     FILE *f = fopen(path, "r");
     if (!f) return;
-    PsxPlayerBinds *current = NULL;
+    PsxPlayerBinds *current = NULL, *current_alt = NULL;
     char line[256];
     while (fgets(line, sizeof(line), f)) {
         trim(line);
@@ -265,9 +278,12 @@ static void load_ini(const char *path) {
             char *end = strchr(line, ']');
             if (end) *end = '\0';
             const char *section = line + 1;
-            current = NULL;
-            if (!strcmp(section, "player1"))      current = &s_binds.p1;
-            else if (!strcmp(section, "player2")) current = &s_binds.p2;
+            current = NULL; current_alt = NULL;
+            if (!strcmp(section, "player1")) {
+                current = &s_binds.p1; current_alt = &s_alt_binds.p1;
+            } else if (!strcmp(section, "player2")) {
+                current = &s_binds.p2; current_alt = &s_alt_binds.p2;
+            }
             continue;
         }
         char *eq = strchr(line, '=');
@@ -277,9 +293,16 @@ static void load_ini(const char *path) {
         trim(key); trim(val);
         for (char *c = key; *c; c++) *c = (char)tolower((unsigned char)*c);
         if (!current) continue;
+        /* Optional alternate binding after a comma: "cross = X, Mouse1". */
+        char *comma = strchr(val, ',');
+        char *alt_val = NULL;
+        if (comma) { *comma = '\0'; alt_val = comma + 1; trim(val); trim(alt_val); }
         for (int i = 0; i < PSXKB_N; i++) {
             if (!strcmp(key, s_buttons[i].name)) {
-                *(SDL_Scancode *)((char *)current + s_buttons[i].offset) = name_to_scancode(val);
+                *(SDL_Scancode *)((char *)current + s_buttons[i].offset) =
+                    name_to_scancode(val);
+                *(SDL_Scancode *)((char *)current_alt + s_buttons[i].offset) =
+                    alt_val ? name_to_scancode(alt_val) : SDL_SCANCODE_UNKNOWN;
                 break;
             }
         }
@@ -306,16 +329,26 @@ static PsxPlayerBinds *player_binds(int player) {
     return (player == 2) ? &s_binds.p2 : &s_binds.p1;
 }
 
-/* Is the scancode at button-def index i currently held for this player?
+/* Is this single scancode (keyboard or mouse pseudo-code) currently held?
  * Mouse pseudo-scancodes MUST be checked before indexing keys[] — they sit
  * beyond the keyboard state array (SDL_NUM_SCANCODES entries). */
-static int held(const uint8_t *keys, const PsxPlayerBinds *pb, int i) {
-    SDL_Scancode sc = *(const SDL_Scancode *)((const char *)pb + s_buttons[i].offset);
+static int held_sc(const uint8_t *keys, SDL_Scancode sc) {
     if (PSXKB_IS_MOUSE_SC(sc)) {
         Uint32 m = SDL_GetMouseState(NULL, NULL);
         return (m & SDL_BUTTON((int)sc - PSXKB_MOUSE_SC_BASE)) != 0;
     }
     return sc != SDL_SCANCODE_UNKNOWN && (int)sc < SDL_NUM_SCANCODES && keys[sc];
+}
+
+/* Is the input at button-def index i held for this player, via either its
+ * primary or its alternate binding? pb must be &s_binds.p1/.p2 — the alt
+ * table is indexed by the same player slot. */
+static int held(const uint8_t *keys, const PsxPlayerBinds *pb, int i) {
+    const PsxPlayerBinds *alt =
+        (pb == &s_binds.p2) ? &s_alt_binds.p2 : &s_alt_binds.p1;
+    SDL_Scancode p = *(const SDL_Scancode *)((const char *)pb  + s_buttons[i].offset);
+    SDL_Scancode a = *(const SDL_Scancode *)((const char *)alt + s_buttons[i].offset);
+    return held_sc(keys, p) || held_sc(keys, a);
 }
 
 uint16_t psx_keybinds_pad_word(const uint8_t *keys, int player) {
@@ -372,8 +405,23 @@ void psx_keybinds_set_button(int player, int button, SDL_Scancode sc) {
     *(SDL_Scancode *)((char *)player_binds(player) + s_buttons[button].offset) = sc;
 }
 
+static PsxPlayerBinds *player_alt_binds(int player) {
+    return (player == 2) ? &s_alt_binds.p2 : &s_alt_binds.p1;
+}
+
+SDL_Scancode psx_keybinds_get_button_alt(int player, int button) {
+    if (button < 0 || button >= PSXKB_N) return SDL_SCANCODE_UNKNOWN;
+    return *(SDL_Scancode *)((char *)player_alt_binds(player) + s_buttons[button].offset);
+}
+
+void psx_keybinds_set_button_alt(int player, int button, SDL_Scancode sc) {
+    if (button < 0 || button >= PSXKB_N) return;
+    *(SDL_Scancode *)((char *)player_alt_binds(player) + s_buttons[button].offset) = sc;
+}
+
 void psx_keybinds_reset_player(int player) {
     *player_binds(player) = (player == 2) ? s_default_binds.p2 : s_default_binds.p1;
+    memset(player_alt_binds(player), 0, sizeof(PsxPlayerBinds)); /* alts: unbound */
 }
 
 void psx_keybinds_save(void) {

--- a/runtime/src/psx_keybinds.c
+++ b/runtime/src/psx_keybinds.c
@@ -8,10 +8,21 @@
  */
 #include "psx_keybinds.h"
 
+#include <SDL.h>
 #include <stdio.h>
 #include <string.h>
 #include <ctype.h>
 #include <stddef.h>
+
+/* Mouse-button pseudo-scancodes. Values sit above SDL's keyboard scancode
+ * space (SDL_NUM_SCANCODES == 512), so they flow through the existing
+ * bind/save/load/rebind machinery as ordinary SDL_Scancode values while
+ * held() resolves them against SDL_GetMouseState() instead of the keyboard
+ * array. INI names: Mouse1 (left) .. Mouse5 (X2), plus LMB/RMB/MMB aliases. */
+#define PSXKB_MOUSE_SC_BASE 512                       /* + SDL_BUTTON_* (1..5) */
+#define PSXKB_MOUSE_SC(btn) ((SDL_Scancode)(PSXKB_MOUSE_SC_BASE + (btn)))
+#define PSXKB_IS_MOUSE_SC(sc) \
+    ((int)(sc) > PSXKB_MOUSE_SC_BASE && (int)(sc) <= PSXKB_MOUSE_SC_BASE + 5)
 
 /* PSX pad word bits (active-low), standard DualShock layout. Matches the
  * PAD_* masks in main.cpp / beetle_main.cpp. */
@@ -145,11 +156,25 @@ static SDL_Scancode name_to_scancode(const char *name) {
     if (!strcmp(buf, "escape") || !strcmp(buf, "esc"))    return SDL_SCANCODE_ESCAPE;
     if (!strcmp(buf, "backspace"))                        return SDL_SCANCODE_BACKSPACE;
     if (!strcmp(buf, "none") || !strcmp(buf, ""))         return SDL_SCANCODE_UNKNOWN;
+    /* Mouse buttons: Mouse1..Mouse5 (SDL button order: 1=left, 2=middle,
+     * 3=right, 4=X1, 5=X2) plus the common aliases. */
+    if (!strncmp(buf, "mouse", 5) && buf[5] >= '1' && buf[5] <= '5' && !buf[6])
+        return PSXKB_MOUSE_SC(buf[5] - '0');
+    if (!strcmp(buf, "lmb") || !strcmp(buf, "mouse left"))   return PSXKB_MOUSE_SC(SDL_BUTTON_LEFT);
+    if (!strcmp(buf, "mmb") || !strcmp(buf, "mouse middle")) return PSXKB_MOUSE_SC(SDL_BUTTON_MIDDLE);
+    if (!strcmp(buf, "rmb") || !strcmp(buf, "mouse right"))  return PSXKB_MOUSE_SC(SDL_BUTTON_RIGHT);
+    if (!strcmp(buf, "mouse x1"))                            return PSXKB_MOUSE_SC(SDL_BUTTON_X1);
+    if (!strcmp(buf, "mouse x2"))                            return PSXKB_MOUSE_SC(SDL_BUTTON_X2);
     return SDL_SCANCODE_UNKNOWN;
 }
 
 static const char *scancode_to_name(SDL_Scancode sc) {
     if (sc == SDL_SCANCODE_UNKNOWN) return "None";
+    if (PSXKB_IS_MOUSE_SC(sc)) {
+        static const char *mouse_names[5] =
+            { "Mouse1", "Mouse2", "Mouse3", "Mouse4", "Mouse5" };
+        return mouse_names[(int)sc - PSXKB_MOUSE_SC_BASE - 1];
+    }
     const char *name = SDL_GetScancodeName(sc);
     return (name && name[0]) ? name : "None";
 }
@@ -212,6 +237,8 @@ static void write_ini(const char *path) {
         "# Use SDL key names. Common: A B C ... Z, 0-9, F1-F12, Up Down Left Right,\n"
         "# Return, Tab, Space, Left Shift, Right Shift, Left Ctrl, Right Ctrl,\n"
         "# Backspace, Escape, Backslash. Use \"None\" to leave an input unbound.\n"
+        "# Mouse buttons also bind: Mouse1 (left), Mouse2 (middle), Mouse3 (right),\n"
+        "# Mouse4/Mouse5 (side); aliases LMB, MMB, RMB.\n"
         "#\n"
         "# Buttons: up/down/left/right, cross/circle/square/triangle, l1/r1/l2/r2,\n"
         "# l3/r3 (stick clicks), start/select. ls_* / rs_* are the left/right\n"
@@ -279,10 +306,16 @@ static PsxPlayerBinds *player_binds(int player) {
     return (player == 2) ? &s_binds.p2 : &s_binds.p1;
 }
 
-/* Is the scancode at button-def index i currently held for this player? */
+/* Is the scancode at button-def index i currently held for this player?
+ * Mouse pseudo-scancodes MUST be checked before indexing keys[] — they sit
+ * beyond the keyboard state array (SDL_NUM_SCANCODES entries). */
 static int held(const uint8_t *keys, const PsxPlayerBinds *pb, int i) {
     SDL_Scancode sc = *(const SDL_Scancode *)((const char *)pb + s_buttons[i].offset);
-    return sc != SDL_SCANCODE_UNKNOWN && keys[sc];
+    if (PSXKB_IS_MOUSE_SC(sc)) {
+        Uint32 m = SDL_GetMouseState(NULL, NULL);
+        return (m & SDL_BUTTON((int)sc - PSXKB_MOUSE_SC_BASE)) != 0;
+    }
+    return sc != SDL_SCANCODE_UNKNOWN && (int)sc < SDL_NUM_SCANCODES && keys[sc];
 }
 
 uint16_t psx_keybinds_pad_word(const uint8_t *keys, int player) {


### PR DESCRIPTION
## Three keybind-layer changes (runtime counterpart of recomp-ui PR mstan/recomp-ui#19)

Screenshot of the paired launcher UI: https://raw.githubusercontent.com/Alexbeav/recomp-ui/feat/dual-bind-mouse-capture/docs/img/psx-dual-binds.jpg

1. **Mouse buttons as bindable inputs** (psx_keybinds.c): `Mouse1`..`Mouse5` (+ LMB/MMB/RMB aliases) accepted anywhere a key name goes. Implemented as pseudo-scancodes above SDL's keyboard space (512+SDL_BUTTON_*) so the existing bind/save/load machinery is untouched; `held()` resolves them via SDL_GetMouseState BEFORE indexing the keyboard array (they're out of its bounds).
2. **Dual bindings per control**: primary + alternate slot, either asserts the input. INI: `cross = X, Mouse1` — backward compatible (single-value files load with empty alts; files without commas are byte-identical on rewrite). New `psx_keybinds_get/set_button_alt()` for the launcher.
3. **Keyboard/mouse binds stay live alongside a routed gamepad** (main.cpp pad assembly): previously, routing a player to a controller silently discarded every keybinds.ini/mouse bind — which defeats the pad-in-hand + mouse-for-aiming combination these changes exist for. Active-low AND merge; unpressed sources are no-ops, so pad-only players are unaffected. (kind==keyboard already consumed the binds — not merged twice.)

## Testing

- Parser: standalone harness against a launcher-written dual-bind file — every primary/alt/mouse value resolves to the expected scancode.
- In-game: 007 TWINE (SLUS-01272) played with W/S/Z/X movement + Mouse1 fire + Mouse3 on R1, gamepad connected simultaneously; all sources live.
- Headless boot gates pass on every commit of the branch (no boot-path regression).
- Developed on our integration branch (master + our open PRs); the three commits are independent of those and cherry-pick cleanly onto current master (this branch is exactly that).

---
Developed with AI assistance; validated as described (test evidence in PR body). AI writes the code and the PR, but I always test before I send something up. Happy to iterate on this process with your feedback.