### PR TITLE
cmake: BIOS pin replaces only its own stem, keeps registry and other backends

### DIFF
--- a/runtime/runtime.cmake
+++ b/runtime/runtime.cmake
@@ -530,10 +530,30 @@ function(psxrecomp_add_runtime_target target)
     endif()
 
     if(PSXRT_BIOS_GENERATED_FULL_C AND PSXRT_BIOS_GENERATED_DISPATCH_C)
-        set(generated_sources
+        # Per-game BIOS pin: the pinned files REPLACE the matching stem's
+        # fork-global generated files only. Every other backend and the
+        # generated psx_bios_registry.c stay linked — replacing the whole set
+        # (the previous behaviour) dropped the registry and the other
+        # backends, producing undefined references to psx_bios_registry at
+        # link time. The registry's extern for the pinned stem is satisfied
+        # by the pinned dispatch.c, which carries the same backend descriptor.
+        get_filename_component(_psxrt_pin_name "${PSXRT_BIOS_GENERATED_DISPATCH_C}" NAME)
+        string(REPLACE "_dispatch.c" "" _psxrt_pin_stem "${_psxrt_pin_name}")
+        set(generated_sources "")
+        foreach(_psxrt_src IN LISTS PSXRECOMP_BIOS_GENERATED)
+            get_filename_component(_psxrt_src_name "${_psxrt_src}" NAME)
+            if(_psxrt_src_name STREQUAL "${_psxrt_pin_stem}_full.c" OR
+               _psxrt_src_name STREQUAL "${_psxrt_pin_stem}_dispatch.c")
+                # replaced by the game's pinned copy
+            else()
+                list(APPEND generated_sources "${_psxrt_src}")
+            endif()
+        endforeach()
+        list(APPEND generated_sources
             "${PSXRT_BIOS_GENERATED_FULL_C}"
             "${PSXRT_BIOS_GENERATED_DISPATCH_C}")
         set_source_files_properties(${generated_sources} PROPERTIES GENERATED TRUE)
+        message(STATUS "psxrecomp: BIOS stem ${_psxrt_pin_stem} pinned to game-local copies")
     else()
         set(generated_sources ${PSXRECOMP_BIOS_GENERATED})
     endif()


### PR DESCRIPTION
Fixes the per-game BIOS pin path (BIOS_GENERATED_FULL_C / BIOS_GENERATED_DISPATCH_C in psxrecomp_add_runtime_target), as flagged in #106: as shipped, pinning replaced the ENTIRE generated-sources set, dropping the generated psx_bios_registry.c and every other backend — any pinned build failed to link with undefined references to `psx_bios_registry`. The pin now replaces only its own stem's files; the registry and remaining backends stay linked, and the registry's extern for the pinned stem is satisfied by the pinned dispatch.c's backend descriptor.

Why pinning matters (context in #106): the shared generated/ BIOS is compiled into every title, so widening seeds for one title can regress another while the emitter's unmodeled load-delay shapes exist. Per-game pinning decouples titles until that's fixed.

Tested: 007 TWINE pinned to a game-local SCPH1001 snapshot — configure logs "BIOS stem SCPH1001 pinned to game-local copies", links clean, headless boot gate passes (previously: link failure).

---
Developed with AI assistance; validated as described (test evidence in PR body). AI writes the code and the PR, but I always test before I send something up. Happy to iterate on this process with your feedback.