### PR TITLE
input: unify pad source sets, make Hybrid mod-only, and land #107's keybind work safely

### DIFF
--- a/recompiler/src/config_loader.cpp
+++ b/recompiler/src/config_loader.cpp
@@ -192,17 +192,41 @@ int pad_mode_from_string(const std::string& s, int fallback) {
     std::string l;
     l.reserve(s.size());
     for (char c : s) l.push_back((char)std::tolower((unsigned char)c));
-    if (l == "hybrid")  return PAD_MODE_HYBRID;
+    /* "hybrid" is MOD-ONLY: reachable solely through
+     * psx_mod_set_controller_mode_override(). A game.toml that declares it is
+     * a configuration error, not something to silently coerce — coercion is
+     * how this mode kept reappearing in titles that never meant to ship it. */
+    if (l == "hybrid")
+        throw std::runtime_error(
+            "[controller] pad mode \"hybrid\" is not selectable. Hybrid is a "
+            "mod-only mode, requested at runtime by a trusted game plugin via "
+            "psx_mod_set_controller_mode_override(). Use \"analog\" or "
+            "\"digital\" here.");
+    if (l == "analog")  return PAD_MODE_ANALOG;
+    if (l == "digital") return PAD_MODE_DIGITAL;
+    return fallback;
+}
+
+/* Settings-file variant: a user's settings.toml may still carry a persisted
+ * "hybrid" from before the mode was removed from the selector. Migrate it to
+ * analog (what the old allow_hybrid clamp did) rather than refusing to
+ * launch over a value the user never typed. */
+int pad_mode_from_settings_string(const std::string& s, int fallback) {
+    std::string l;
+    l.reserve(s.size());
+    for (char c : s) l.push_back((char)std::tolower((unsigned char)c));
+    if (l == "hybrid")  return PAD_MODE_ANALOG;
     if (l == "analog")  return PAD_MODE_ANALOG;
     if (l == "digital") return PAD_MODE_DIGITAL;
     return fallback;
 }
 
 const char* pad_mode_to_string(int mode) {
+    /* Never writes "hybrid": the mod requests it at runtime and it is not
+     * persisted as a user preference. */
     switch (mode) {
-        case PAD_MODE_ANALOG:  return "analog";
         case PAD_MODE_DIGITAL: return "digital";
-        default:               return "hybrid";
+        default:               return "analog";
     }
 }
 
@@ -659,22 +683,19 @@ static RuntimeConfig parse_runtime_block(const toml::value& cfg, const fs::path&
         // Preferred string form.
         if (ct.contains("default_mode")) {
             const int m = pad_mode_from_string(
-                toml::find<std::string>(ct, "default_mode"), PAD_MODE_HYBRID);
+                toml::find<std::string>(ct, "default_mode"), PAD_MODE_ANALOG);
             rt.default_p1_mode = rt.default_p2_mode = m;
             rt.has_default_mode = true;
         }
         if (ct.contains("p1_mode")) {
             rt.default_p1_mode = pad_mode_from_string(
-                toml::find<std::string>(ct, "p1_mode"), PAD_MODE_HYBRID);
+                toml::find<std::string>(ct, "p1_mode"), PAD_MODE_ANALOG);
             rt.has_default_mode = true;
         }
         if (ct.contains("p2_mode")) {
             rt.default_p2_mode = pad_mode_from_string(
-                toml::find<std::string>(ct, "p2_mode"), PAD_MODE_HYBRID);
+                toml::find<std::string>(ct, "p2_mode"), PAD_MODE_ANALOG);
             rt.has_default_mode = true;
-        }
-        if (ct.contains("allow_hybrid")) {
-            rt.controller_allow_hybrid = toml::find<bool>(ct, "allow_hybrid");
         }
         if (ct.contains("lock_mode")) {
             rt.controller_lock_mode = toml::find<bool>(ct, "lock_mode");
@@ -2308,8 +2329,8 @@ UserSettings load_user_settings(const fs::path& path) {
                 s.has_p_mode[i] = true;
             });
             if (ct.contains(kModeKeys[i])) try_get([&]{
-                s.p_mode[i] = pad_mode_from_string(
-                    toml::find<std::string>(ct, kModeKeys[i]), PAD_MODE_HYBRID);
+                s.p_mode[i] = pad_mode_from_settings_string(
+                    toml::find<std::string>(ct, kModeKeys[i]), PAD_MODE_ANALOG);
                 s.has_p_mode[i] = true;
             });
             if (ct.contains(kDzKeys[i])) try_get([&]{

--- a/recompiler/src/config_loader.h
+++ b/recompiler/src/config_loader.h
@@ -30,14 +30,19 @@
 namespace PSXRecompV4 {
 
 // Pad input mode (per player). Replaces the old analog on/off boolean.
-//   hybrid  — auto-switch DualShock(analog)/digital per the most-recent input:
+//   hybrid  — MOD-ONLY. Not selectable in the launcher, not a valid game.toml
+//             value, never a default. It survives solely so a trusted game mod
+//             can request it via psx_mod_set_controller_mode_override() (Tomba's
+//             hybrid controller plugin). Auto-switches analog/digital per the
+//             most-recent input:
 //             nudge the stick -> report DualShock (0x73, variable sticks);
 //             press the D-pad -> report a digital pad (0x41) so the game runs
 //             its OWN d-pad path at true digital sensitivity. Mirrors a
 //             DualShock's analog LED toggling on/off (and Tomba Special
-//             Edition's auto-detect). Default.
+//             Edition's auto-detect).
 //   analog  — always present a DualShock/analog pad (id 0x73). The D-pad is
 //             folded onto the stick at full deflection so it still moves you.
+//             Default.
 //   digital — always present a digital pad (id 0x41); sticks disabled.
 enum PadMode { PAD_MODE_HYBRID = 0, PAD_MODE_ANALOG = 1, PAD_MODE_DIGITAL = 2 };
 
@@ -111,7 +116,12 @@ struct WidescreenAspectConeConfig {
 };
 // Parse/format a pad mode. pad_mode_from_string accepts "hybrid"/"analog"/
 // "digital" (case-insensitive) and returns `fallback` for anything else.
+// Strict: for game.toml. THROWS on "hybrid" — the mode is mod-only and must
+// not be declared by a game.
 int         pad_mode_from_string(const std::string& s, int fallback);
+// Lenient: for a user's settings.toml, where a stale persisted "hybrid" must
+// migrate to analog rather than refuse to launch.
+int         pad_mode_from_settings_string(const std::string& s, int fallback);
 const char* pad_mode_to_string(int mode);
 
 // [runtime] block — consumed by runtime/src/main.cpp. All fields optional;
@@ -473,21 +483,15 @@ struct RuntimeConfig {
     // `p1_mode`/`p2_mode` set one. Legacy `default_analog`/`p1_analog`/
     // `p2_analog` booleans are still accepted (true->analog, false->digital).
     bool                  has_default_mode = false;
-    int                   default_p1_mode  = PAD_MODE_HYBRID;
-    int                   default_p2_mode  = PAD_MODE_HYBRID;
+    int                   default_p1_mode  = PAD_MODE_ANALOG;
+    int                   default_p2_mode  = PAD_MODE_ANALOG;
 
-    // allow_hybrid: whether the launcher offers the "Hybrid" pad mode at all.
-    // Default true (Hybrid | Analog | D-Pad). A game that needs an explicit
-    // analog/digital choice (e.g. one that hard-requires a DualShock) can set
-    // [controller] allow_hybrid = false to drop Hybrid from the selector.
-    bool                  controller_allow_hybrid = true;
 
     // lock_mode: when true the launcher HIDES the whole pad-mode selector
     // (Hybrid | Analog | D-Pad) and forces every port to default_p1_mode. For a
     // game that supports exactly one pad type — e.g. Tomba 2, whose driver only
     // works as a plain digital pad because the DualShock config-mode handshake
     // is unhandled — so the player can't pick a broken mode. Supersedes
-    // allow_hybrid (which only hides the Hybrid segment). Default false.
     bool                  controller_lock_mode = false;
 
     // lock_device: when true the launcher HIDES the Player 1/2 controller cards
@@ -1103,7 +1107,7 @@ struct UserSettings {
     //   "none"     — no pad in this port (port not connected)
     //   "keyboard" — driven by the keyboard map (input.ini)
     //   "<GUID>"   — an SDL game-controller GUID (SDL_JoystickGetGUIDString)
-    // Modes (see PadMode): hybrid / analog / digital. Defaults: P1 keyboard,
+    // Modes (see PadMode): analog / digital. Hybrid is mod-only. Defaults: P1 keyboard,
     // P2–P5 none. Deadzone default is 10% (3277/32767). TOML keys:
     // pN_device / pN_mode / pN_deadzone (N=1..5). Legacy bare `deadzone`
     // still fills any slot that lacks pN_deadzone.
@@ -1113,8 +1117,8 @@ struct UserSettings {
         "keyboard", "none", "none", "none", "none"};
     bool has_p_mode[kMaxControllerPlayers] = {};
     int  p_mode[kMaxControllerPlayers] = {
-        PAD_MODE_HYBRID, PAD_MODE_HYBRID, PAD_MODE_HYBRID,
-        PAD_MODE_HYBRID, PAD_MODE_HYBRID};
+        PAD_MODE_ANALOG, PAD_MODE_ANALOG, PAD_MODE_ANALOG,
+        PAD_MODE_ANALOG, PAD_MODE_ANALOG};
     bool has_p_deadzone[kMaxControllerPlayers] = {};
     int  p_deadzone[kMaxControllerPlayers] = {
         3277, 3277, 3277, 3277, 3277};  /* ~10% of 32767 */

--- a/recompiler/src/config_loader.h
+++ b/recompiler/src/config_loader.h
@@ -114,10 +114,9 @@ struct WidescreenAspectConeConfig {
     std::array<uint32_t, 3> queue_capacities{};
     std::array<uint32_t, 3> queue_type_masks{};
 };
-// Parse/format a pad mode. pad_mode_from_string accepts "hybrid"/"analog"/
-// "digital" (case-insensitive) and returns `fallback` for anything else.
-// Strict: for game.toml. THROWS on "hybrid" — the mode is mod-only and must
-// not be declared by a game.
+// Parse/format a pad mode. Strict game.toml parsing accepts "analog" or
+// "digital" (case-insensitive), returns `fallback` for unknown values, and
+// THROWS on "hybrid" — the mode is mod-only and must not be declared by a game.
 int         pad_mode_from_string(const std::string& s, int fallback);
 // Lenient: for a user's settings.toml, where a stale persisted "hybrid" must
 // migrate to analog rather than refuse to launch.
@@ -485,7 +484,6 @@ struct RuntimeConfig {
     bool                  has_default_mode = false;
     int                   default_p1_mode  = PAD_MODE_ANALOG;
     int                   default_p2_mode  = PAD_MODE_ANALOG;
-
 
     // lock_mode: when true the launcher HIDES the whole pad-mode selector
     // (Hybrid | Analog | D-Pad) and forces every port to default_p1_mode. For a

--- a/runtime/include/psx_keybinds.h
+++ b/runtime/include/psx_keybinds.h
@@ -93,7 +93,13 @@ const char  *psx_keybinds_button_name(int button);          /* "up".."rs_right" 
 const char  *psx_keybinds_button_label(int button);         /* pretty, e.g. "Cross" */
 SDL_Scancode psx_keybinds_get_button(int player, int button);
 void         psx_keybinds_set_button(int player, int button, SDL_Scancode sc);
-/* Reset one player's bindings to the built-in defaults (same map for every slot). */
+/* Alternate (secondary) binding per control: both the primary and the alt
+ * assert the input (e.g. cross = X, Mouse1). Stored in keybinds.ini as a
+ * comma-separated second name; SDL_SCANCODE_UNKNOWN = no alt. */
+SDL_Scancode psx_keybinds_get_button_alt(int player, int button);
+void         psx_keybinds_set_button_alt(int player, int button, SDL_Scancode sc);
+/* Reset one player's bindings to the shared built-in primary defaults and
+ * clear that player's alternate bindings. */
 void         psx_keybinds_reset_player(int player);
 /* Persist the current bindings to keybinds.ini (path resolved by
  * psx_keybinds_init; call that first). */

--- a/runtime/src/main.cpp
+++ b/runtime/src/main.cpp
@@ -3938,9 +3938,25 @@ struct PadSources {
 static PadSources pad_sources_for(const PlayerInput& p, bool dev_here) {
     PadSources s;
     s.device   = (p.kind != 0);
-    /* kind==1 consumes the binds through pad_buttons_for/pad_sticks_for; dev
-     * mode folds them in on top of whatever device is assigned. */
-    s.keybinds = (p.kind == 1) || dev_here;
+    /* Keybinds are ALWAYS live, including alongside a routed gamepad: that is
+     * the whole point of binding a mouse button for aiming while holding a
+     * pad. Routing a player to a controller used to discard every
+     * keybinds.ini/mouse bind silently.
+     *
+     * Widening this ONE line is safe precisely because every consumer reads
+     * it — the button merge, the HYBRID auto-switch detectors and the stick
+     * fold all learn about the keyboard in the same instant. Widening the
+     * button merge alone (the original shape of this change) let a keyboard
+     * D-pad press assert the D-pad bits while hybrid_dpad_active never saw
+     * them, leaving a mod-driven hybrid pad reporting D-pad input while still
+     * presenting ANALOG.
+     *
+     * The PSX pad word is active-low and the merge is an AND, so an unpressed
+     * source is a no-op: a pad-only player is unaffected. kind==1 already
+     * consumes the binds through pad_buttons_for/pad_sticks_for, and applying
+     * them twice is idempotent. */
+    (void)dev_here;
+    s.keybinds = true;
     s.all_pads = dev_here;
     return s;
 }

--- a/runtime/src/main.cpp
+++ b/runtime/src/main.cpp
@@ -322,11 +322,12 @@ static SDL_Texture*  sdl_texture;
 struct PlayerInput {
     int   kind = 0;            /* 0=none, 1=keyboard, 2=controller */
     char  guid[40] = {0};      /* SDL joystick GUID string when kind==controller */
-    /* Pad input mode (PSXRecompV4::PadMode): 0=hybrid (default), 1=analog,
+    /* Pad input mode (PSXRecompV4::PadMode): 1=analog (default), 0=hybrid
+     * (MOD-ONLY, requested via psx_mod_set_controller_mode_override),
      * 2=digital. hybrid_analog is the per-frame auto-switch latch used only in
      * hybrid mode: true => currently presenting DualShock (stick was the last
      * input), false => currently presenting a digital pad (D-pad was last). */
-    int   mode = PSXRecompV4::PAD_MODE_HYBRID;
+    int   mode = PSXRecompV4::PAD_MODE_ANALOG;
     bool  hybrid_analog = false;
     int   deadzone = 3277;  /* raw SDL axis units, ~10% default */
     SDL_GameController* handle = nullptr;
@@ -4091,7 +4092,7 @@ static void apply_input_override_to_sio(int override_word) {
      * titles (Ape Escape) ignore debug-server injection in headless runs. */
     int mode;
     if (p.kind != 0)                  mode = effective_player_mode(p);
-    else if (dev_any_input_enabled()) mode = (int)PSXRecompV4::PAD_MODE_HYBRID;
+    else if (dev_any_input_enabled()) mode = (int)PSXRecompV4::PAD_MODE_ANALOG;
     else                              mode = p.mode;
 
     int eff_analog;
@@ -4369,7 +4370,7 @@ static void capture_override_pad(int override_word, PsxNetPad* out) {
 
     int mode;
     if (p.kind != 0)                  mode = effective_player_mode(p);
-    else if (dev_any_input_enabled()) mode = (int)PSXRecompV4::PAD_MODE_HYBRID;
+    else if (dev_any_input_enabled()) mode = (int)PSXRecompV4::PAD_MODE_ANALOG;
     else                              mode = p.mode;
 
     int eff_analog;
@@ -8975,11 +8976,10 @@ int main(int argc, char** argv) {
 #else
         player_device[i] = (i == 0) ? "keyboard" : "none";
 #endif
-        player_mode[i] = PSXRecompV4::PAD_MODE_HYBRID;
+        player_mode[i] = PSXRecompV4::PAD_MODE_ANALOG;
         player_deadzone[i] = kDefaultDeadzoneRaw;
-        ctrl_locked_mode[i] = PSXRecompV4::PAD_MODE_HYBRID;
+        ctrl_locked_mode[i] = PSXRecompV4::PAD_MODE_ANALOG;
     }
-    bool ctrl_allow_hybrid = true;  /* game.toml [controller] allow_hybrid; false hides Hybrid in the launcher */
     bool ctrl_lock_mode    = false; /* game.toml [controller] lock_mode; true hides the whole pad-mode selector */
     bool ctrl_lock_device  = false; /* game.toml [controller] lock_device; true hides the Player controller cards entirely */
     bool ws_offered = true; /* game.toml [widescreen] offer; false hides the launcher toggle + clamps 4:3 */
@@ -9299,7 +9299,6 @@ int main(int argc, char** argv) {
             }
             for (int i = 0; i < PSX_MAX_PLAYERS; ++i)
                 ctrl_locked_mode[i] = player_mode[i];
-            ctrl_allow_hybrid = gc.runtime.controller_allow_hybrid;
             ctrl_lock_mode    = gc.runtime.controller_lock_mode;
             ctrl_lock_device  = gc.runtime.controller_lock_device;
             if (gc.runtime.has_deadzone) {
@@ -9543,21 +9542,6 @@ int main(int argc, char** argv) {
 #endif
         }
     }
-    /* allow_hybrid=false removes Hybrid from the game's supported controller
-     * modes. Clamp an old persisted Hybrid value here as well as hiding it in
-     * recomp-ui, so launcher-less builds cannot revive an unsupported mode.
-     * Prefer each port's game-declared default; malformed/legacy configs that
-     * also default to Hybrid fall back to Analog, matching recomp-ui. */
-    if (!ctrl_allow_hybrid) {
-        for (int i = 0; i < PSX_MAX_PLAYERS; ++i) {
-            const int fallback =
-                ctrl_locked_mode[i] == PSXRecompV4::PAD_MODE_HYBRID
-                    ? PSXRecompV4::PAD_MODE_ANALOG : ctrl_locked_mode[i];
-            if (player_mode[i] == PSXRecompV4::PAD_MODE_HYBRID)
-                player_mode[i] = fallback;
-        }
-    }
-
     /* A game may migrate Skip FMVs from generic Settings into its mod catalog.
      * Clamp stale settings before seeding recomp-ui; an enabled activation
      * plugin applies the feature after the final mod-plan commit. */
@@ -10134,7 +10118,6 @@ int main(int argc, char** argv) {
             /* Pad-mode + aspect capabilities sourced from game.toml
              * [controller]/[widescreen] via GameConfig. PSX always has pad modes. */
             gi.pad_mode_selectable  = ctrl_lock_mode ? 0 : 1;
-            gi.allow_hybrid         = ctrl_allow_hybrid ? 1 : 0;
             gi.locked_pad_mode      = ctrl_locked_mode[0];  /* game-declared default_mode */
             gi.lock_device          = ctrl_lock_device ? 1 : 0;
             gi.aspect_mask          = 0x1 | (ws_offered ? 0x2 : 0) | (ws_ultrawide_offered ? 0x4 : 0);
@@ -11742,7 +11725,6 @@ soft_return_lobby:
         gi.memcard_inspect = ae_memcard_inspect;
         gi.mods = PSXRecompV4::mod_runtime_launcher_provider();
         gi.pad_mode_selectable = ctrl_lock_mode ? 0 : 1;
-        gi.allow_hybrid = ctrl_allow_hybrid ? 1 : 0;
         gi.locked_pad_mode = ctrl_locked_mode[0];
         gi.lock_device = ctrl_lock_device ? 1 : 0;
 #if defined(PSX_HAS_SETUP_WIZARD) && defined(PSX_HAS_GAME_CODEGEN)

--- a/runtime/src/main.cpp
+++ b/runtime/src/main.cpp
@@ -3898,22 +3898,83 @@ static void pad_sticks_for(const PlayerInput& p, int player, uint8_t out[4], boo
  * player has reached for analog. hybrid_dpad_active: any D-pad direction (or,
  * for the keyboard, an arrow key) is held — the player wants classic digital.
  * The keyboard has no analog stick, so a keyboard player stays digital. */
-static bool hybrid_stick_active(const PlayerInput& p) {
-    if (p.kind != 2 || !p.handle) return false;
-    const double lx = SDL_GameControllerGetAxis(p.handle, SDL_CONTROLLER_AXIS_LEFTX);
-    const double ly = SDL_GameControllerGetAxis(p.handle, SDL_CONTROLLER_AXIS_LEFTY);
-    const double dz = (double)(p.deadzone > 0 ? p.deadzone : controller_deadzone);
+static bool controller_stick_active(SDL_GameController* handle, int deadzone) {
+    if (!handle) return false;
+    const double lx =
+        SDL_GameControllerGetAxis(handle, SDL_CONTROLLER_AXIS_LEFTX);
+    const double ly =
+        SDL_GameControllerGetAxis(handle, SDL_CONTROLLER_AXIS_LEFTY);
+    const double dz = (double)(deadzone > 0 ? deadzone : controller_deadzone);
     return std::sqrt(lx * lx + ly * ly) > dz;
 }
-static bool hybrid_dpad_active(const PlayerInput& p, int player, bool kb_always) {
-    if (p.kind == 2 && p.handle) {
-        if (SDL_GameControllerGetButton(p.handle, SDL_CONTROLLER_BUTTON_DPAD_LEFT)  ||
-            SDL_GameControllerGetButton(p.handle, SDL_CONTROLLER_BUTTON_DPAD_RIGHT) ||
-            SDL_GameControllerGetButton(p.handle, SDL_CONTROLLER_BUTTON_DPAD_UP)    ||
-            SDL_GameControllerGetButton(p.handle, SDL_CONTROLLER_BUTTON_DPAD_DOWN))
-            return true;
+static bool controller_dpad_active(SDL_GameController* handle) {
+    return handle &&
+        (SDL_GameControllerGetButton(handle, SDL_CONTROLLER_BUTTON_DPAD_LEFT) ||
+         SDL_GameControllerGetButton(handle, SDL_CONTROLLER_BUTTON_DPAD_RIGHT) ||
+         SDL_GameControllerGetButton(handle, SDL_CONTROLLER_BUTTON_DPAD_UP) ||
+         SDL_GameControllerGetButton(handle, SDL_CONTROLLER_BUTTON_DPAD_DOWN));
+}
+/* Which input sources may drive ONE pad slot this frame.
+ *
+ * This exists because the answer is consumed in three places — the button
+ * merge, the HYBRID analog/digital auto-switch, and the analog stick fold —
+ * and those three used to compute it independently. Whenever they disagreed,
+ * a source could assert a button without the hybrid state machine seeing it,
+ * leaving the pad reporting D-pad presses while still presenting ANALOG: the
+ * exact failure the hybrid logic exists to prevent, and silent when it
+ * happens. Deriving all three from one predicate makes that desync
+ * structurally impossible rather than merely fixed once.
+ *
+ * Changing input-routing POLICY is therefore a change to this function alone
+ * (e.g. whether keybinds stay live alongside a routed gamepad), not a change
+ * to three separate conditions that must be kept in step by hand. */
+struct PadSources {
+    bool device;    /* the slot's own assigned device (keyboard or controller) */
+    bool keybinds;  /* keybinds.ini keyboard/mouse binds for this player       */
+    bool all_pads;  /* every connected controller (dev-any-input)              */
+};
+
+static PadSources pad_sources_for(const PlayerInput& p, bool dev_here) {
+    PadSources s;
+    s.device   = (p.kind != 0);
+    /* kind==1 consumes the binds through pad_buttons_for/pad_sticks_for; dev
+     * mode folds them in on top of whatever device is assigned. */
+    s.keybinds = (p.kind == 1) || dev_here;
+    s.all_pads = dev_here;
+    return s;
+}
+
+static bool hybrid_stick_active(const PlayerInput& p, const PadSources& src) {
+    if (src.device && p.kind == 2 &&
+        controller_stick_active(p.handle, p.deadzone)) return true;
+    if (src.all_pads) {
+        const int n = SDL_NumJoysticks();
+        for (int i = 0; i < n; i++) {
+            if (!SDL_IsGameController(i)) continue;
+            const SDL_JoystickID inst = SDL_JoystickGetDeviceInstanceID(i);
+            SDL_GameController* handle =
+                SDL_GameControllerFromInstanceID(inst);
+            if (!handle) handle = SDL_GameControllerOpen(i);
+            if (controller_stick_active(handle, controller_deadzone)) return true;
+        }
     }
-    if (p.kind == 1 || kb_always) {
+    return false;
+}
+static bool hybrid_dpad_active(const PlayerInput& p, int player,
+                               const PadSources& src) {
+    if (src.device && p.kind == 2 && controller_dpad_active(p.handle)) return true;
+    if (src.all_pads) {
+        const int n = SDL_NumJoysticks();
+        for (int i = 0; i < n; i++) {
+            if (!SDL_IsGameController(i)) continue;
+            const SDL_JoystickID inst = SDL_JoystickGetDeviceInstanceID(i);
+            SDL_GameController* handle =
+                SDL_GameControllerFromInstanceID(inst);
+            if (!handle) handle = SDL_GameControllerOpen(i);
+            if (controller_dpad_active(handle)) return true;
+        }
+    }
+    if (src.keybinds) {
         const Uint8* keys = SDL_GetKeyboardState(NULL);
         if (psx_keybinds_dpad_active(keys, player)) return true;
     }
@@ -4079,23 +4140,22 @@ static int capture_pad_slot(int s, PsxNetPad* out) {
      * state gates how the left stick is read for BOTH the button word and the
      * analog axes below. An assigned device keeps its configured mode (a
      * launcher-selected analog DualShock stays analog, so its input path / SIO
-     * handshake cadence is preserved exactly). Keyboard is always digital.
-     * Multitap taps are forced digital unless multitap_analog hack is on.
-     * A P1 with no assigned device but dev-any-input on presents as HYBRID. */
-    int mode;
-    if (sio_pad_on_multitap(s) && !sio_get_multitap_analog())
-        mode = (int)PSXRecompV4::PAD_MODE_DIGITAL;
-    else if (p.kind != 0) mode = effective_player_mode(p);
-    else if (dev_here)    mode = (int)PSXRecompV4::PAD_MODE_HYBRID;
-    else                  mode = (int)PSXRecompV4::PAD_MODE_DIGITAL;
+     * handshake cadence is preserved exactly). A P1 with no assigned device
+     * keeps the game's resolved mode while dev-any-input merges the keyboard and
+     * all connected controllers. */
+    /* One source set, consumed by the hybrid switch, the button merge and the
+     * stick fold below — see pad_sources_for(). */
+    const PadSources src = pad_sources_for(p, dev_here);
+
+    const int mode = effective_player_mode_for_sio(p, s);
     int eff_analog;
     if (mode == PSXRecompV4::PAD_MODE_DIGITAL) {
         eff_analog = 0;
     } else if (mode == PSXRecompV4::PAD_MODE_ANALOG) {
         eff_analog = 1;
     } else { /* HYBRID */
-        if (hybrid_stick_active(p))                       p.hybrid_analog = true;
-        else if (hybrid_dpad_active(p, player, dev_here)) p.hybrid_analog = false;
+        if (hybrid_stick_active(p, src))             p.hybrid_analog = true;
+        else if (hybrid_dpad_active(p, player, src)) p.hybrid_analog = false;
         eff_analog = p.hybrid_analog ? 1 : 0;
     }
 
@@ -4109,12 +4169,14 @@ static int capture_pad_slot(int s, PsxNetPad* out) {
      * D-pad control (Ape Escape's camera rotate) from being spun by stick
      * movement or centre drift. Digital mode keeps the stick->D-pad fold. */
     const bool suppress_stick = (eff_analog != 0);
-    uint16_t btn = (p.kind != 0) ? pad_buttons_for(p, player, suppress_stick)
-                                 : (uint16_t)0xFFFF;
-    if (dev_here) {
-        btn &= pad_from_keyboard(1);                        /* keyboard P1 binds  */
-        btn &= dev_all_controllers_buttons(suppress_stick); /* any plugged-in pad */
-    }
+    uint16_t btn = src.device ? pad_buttons_for(p, player, suppress_stick)
+                              : (uint16_t)0xFFFF;
+    /* kind==1 already consumed the binds inside pad_buttons_for — ANDing the
+     * same word twice is idempotent, so this stays a plain source check. */
+    if (src.keybinds)
+        btn &= pad_from_keyboard(player);
+    if (src.all_pads)
+        btn &= dev_all_controllers_buttons(suppress_stick);
 
     /* Analog axes. Pinned-ANALOG folds the physical D-pad onto the left axes
      * (fold_dpad) so the D-pad still moves stick-only games; HYBRID feeds the
@@ -4126,13 +4188,17 @@ static int capture_pad_slot(int s, PsxNetPad* out) {
     } else if (eff_analog) {  /* HYBRID, currently presenting analog */
         pad_sticks_for(p, player, st, /*fold_dpad=*/false);
     }
-    /* Dev mode: fold the keyboard's stick binds AND any connected controller's
-     * sticks onto the analog stick, so an analog-mode P1 steers from whatever
-     * is plugged in (P1 binds). */
-    if (dev_here && eff_analog) {
-        const Uint8* keys = SDL_GetKeyboardState(NULL);
-        psx_keybinds_sticks(keys, 1, st);
-        dev_any_controller_sticks(st);
+    /* Stick fold, driven by the SAME source set as the buttons above: whatever
+     * may press a button may also steer. kind==1 already folded its binds
+     * inside pad_sticks_for; psx_keybinds_sticks only widens a deflection, so
+     * applying it twice is idempotent. */
+    if (eff_analog) {
+        if (src.keybinds) {
+            const Uint8* keys = SDL_GetKeyboardState(NULL);
+            psx_keybinds_sticks(keys, player, st);
+        }
+        if (src.all_pads)
+            dev_any_controller_sticks(st);
     }
 
     out->buttons = btn;
@@ -4158,6 +4224,9 @@ static int capture_pad_slot_exclusive(int s, PsxNetPad* out, int present_sio_slo
     const bool dev_here = false;
     if (p.kind == 0) return 0;  /* no device in this port */
 
+    /* Same predicate as capture_pad_slot, with dev-any-input disabled:
+     * netplay must stay exclusive so peers hash-agree. */
+    const PadSources src = pad_sources_for(p, dev_here);
     const int sio_slot = (present_sio_slot >= 0) ? present_sio_slot : s;
     int mode = effective_player_mode_for_sio(p, sio_slot);
     int eff_analog;
@@ -4166,8 +4235,8 @@ static int capture_pad_slot_exclusive(int s, PsxNetPad* out, int present_sio_slo
     } else if (mode == PSXRecompV4::PAD_MODE_ANALOG) {
         eff_analog = 1;
     } else { /* HYBRID */
-        if (hybrid_stick_active(p))                       p.hybrid_analog = true;
-        else if (hybrid_dpad_active(p, player, dev_here)) p.hybrid_analog = false;
+        if (hybrid_stick_active(p, src))             p.hybrid_analog = true;
+        else if (hybrid_dpad_active(p, player, src)) p.hybrid_analog = false;
         eff_analog = p.hybrid_analog ? 1 : 0;
     }
 

--- a/runtime/src/psx_keybinds.c
+++ b/runtime/src/psx_keybinds.c
@@ -6,9 +6,8 @@
  * of the box. Edit + restart (or rebind live in the launcher's Controls page) to
  * apply. See psx_keybinds.h for the API contract and the PSX pad-word bit layout.
  */
-#include "psx_keybinds.h"
+#include "psx_keybinds.h"   /* pulls in psx_sdl.h (SDL2/SDL3 shim) */
 
-#include <SDL.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/runtime/src/psx_keybinds.c
+++ b/runtime/src/psx_keybinds.c
@@ -82,6 +82,10 @@
 
 static PsxKeyBinds       s_binds         = PSXKB_DEFAULTS;
 static const PsxKeyBinds s_default_binds = PSXKB_DEFAULTS;
+/* Alternate bindings: zero-initialised = SDL_SCANCODE_UNKNOWN = no alt bound.
+ * Primary OR alt asserts the input; both persist to keybinds.ini as
+ * "primary, alt" on one line. */
+static PsxKeyBinds       s_alt_binds;
 
 typedef struct {
     const char *name;   /* ini key */
@@ -212,11 +216,18 @@ static void derive_ini_path(const char *exe_path) {
     snprintf(s_ini_path, sizeof(s_ini_path), "%skeybinds.ini", dir);
 }
 
-static void write_player_section(FILE *f, const char *section, const PsxPlayerBinds *pb) {
+static void write_player_section(FILE *f, const char *section,
+                                 const PsxPlayerBinds *pb,
+                                 const PsxPlayerBinds *alt) {
     fprintf(f, "[%s]\n", section);
     for (int i = 0; i < PSXKB_N; i++) {
-        SDL_Scancode sc = *(const SDL_Scancode *)((const char *)pb + s_buttons[i].offset);
-        fprintf(f, "%-9s = %s\n", s_buttons[i].name, scancode_to_name(sc));
+        SDL_Scancode sc = *(const SDL_Scancode *)((const char *)pb  + s_buttons[i].offset);
+        SDL_Scancode al = *(const SDL_Scancode *)((const char *)alt + s_buttons[i].offset);
+        if (al != SDL_SCANCODE_UNKNOWN)
+            fprintf(f, "%-9s = %s, %s\n", s_buttons[i].name,
+                    scancode_to_name(sc), scancode_to_name(al));
+        else
+            fprintf(f, "%-9s = %s\n", s_buttons[i].name, scancode_to_name(sc));
     }
     fprintf(f, "\n");
 }
@@ -232,6 +243,8 @@ static void write_ini(const char *path) {
         "# Backspace, Escape, Backslash. Use \"None\" to leave an input unbound.\n"
         "# Mouse buttons also bind: Mouse1 (left), Mouse2 (middle), Mouse3 (right),\n"
         "# Mouse4/Mouse5 (side); aliases LMB, MMB, RMB.\n"
+        "# Each input accepts an optional SECOND binding after a comma - both\n"
+        "# assert the input:  cross = X, Mouse1\n"
         "#\n"
         "# Buttons: up/down/left/right, cross/circle/square/triangle, l1/r1/l2/r2,\n"
         "# l3/r3 (stick clicks), start/select. ls_* / rs_* are the left/right\n"
@@ -243,7 +256,8 @@ static void write_ini(const char *path) {
     for (int p = 0; p < PSXKB_MAX_PLAYERS; ++p) {
         char section[16];
         snprintf(section, sizeof(section), "player%d", p + 1);
-        write_player_section(f, section, &s_binds.player[p]);
+        write_player_section(f, section, &s_binds.player[p],
+                             &s_alt_binds.player[p]);
     }
     fclose(f);
     printf("[Keybinds] Wrote %s\n", path);
@@ -269,7 +283,7 @@ static void promote_empty_players(void) {
 static void load_ini(const char *path) {
     FILE *f = fopen(path, "r");
     if (!f) return;
-    PsxPlayerBinds *current = NULL;
+    PsxPlayerBinds *current = NULL, *current_alt = NULL;
     char line[256];
     while (fgets(line, sizeof(line), f)) {
         trim(line);
@@ -278,11 +292,13 @@ static void load_ini(const char *path) {
             char *end = strchr(line, ']');
             if (end) *end = '\0';
             const char *section = line + 1;
-            current = NULL;
+            current = NULL; current_alt = NULL;
             if (!strncmp(section, "player", 6)) {
                 int n = atoi(section + 6);
-                if (n >= 1 && n <= PSXKB_MAX_PLAYERS)
+                if (n >= 1 && n <= PSXKB_MAX_PLAYERS) {
                     current = &s_binds.player[n - 1];
+                    current_alt = &s_alt_binds.player[n - 1];
+                }
             }
             continue;
         }
@@ -293,9 +309,16 @@ static void load_ini(const char *path) {
         trim(key); trim(val);
         for (char *c = key; *c; c++) *c = (char)tolower((unsigned char)*c);
         if (!current) continue;
+        /* Optional alternate binding after a comma: "cross = X, Mouse1". */
+        char *comma = strchr(val, ',');
+        char *alt_val = NULL;
+        if (comma) { *comma = '\0'; alt_val = comma + 1; trim(val); trim(alt_val); }
         for (int i = 0; i < PSXKB_N; i++) {
             if (!strcmp(key, s_buttons[i].name)) {
-                *(SDL_Scancode *)((char *)current + s_buttons[i].offset) = name_to_scancode(val);
+                *(SDL_Scancode *)((char *)current + s_buttons[i].offset) =
+                    name_to_scancode(val);
+                *(SDL_Scancode *)((char *)current_alt + s_buttons[i].offset) =
+                    alt_val ? name_to_scancode(alt_val) : SDL_SCANCODE_UNKNOWN;
                 break;
             }
         }
@@ -325,16 +348,27 @@ static PsxPlayerBinds *player_binds(int player) {
     return &s_binds.player[player - 1];
 }
 
-/* Is the scancode at button-def index i currently held for this player?
+/* Is this single scancode (keyboard or mouse pseudo-code) currently held?
  * Mouse pseudo-scancodes MUST be checked before indexing keys[] — they sit
  * beyond the keyboard state array (SDL_NUM_SCANCODES entries). */
-static int held(const uint8_t *keys, const PsxPlayerBinds *pb, int i) {
-    SDL_Scancode sc = *(const SDL_Scancode *)((const char *)pb + s_buttons[i].offset);
+static int held_sc(const uint8_t *keys, SDL_Scancode sc) {
     if (PSXKB_IS_MOUSE_SC(sc)) {
         Uint32 m = SDL_GetMouseState(NULL, NULL);
         return (m & SDL_BUTTON((int)sc - PSXKB_MOUSE_SC_BASE)) != 0;
     }
     return sc != SDL_SCANCODE_UNKNOWN && (int)sc < SDL_NUM_SCANCODES && keys[sc];
+}
+
+/* Is the input at button-def index i held for this player, via either its
+ * primary or its alternate binding? The alternate table uses the same player
+ * slot as the primary table. */
+static int held(const uint8_t *keys, const PsxPlayerBinds *pb, int i) {
+    ptrdiff_t slot = pb - &s_binds.player[0];
+    if (slot < 0 || slot >= PSXKB_MAX_PLAYERS) slot = 0;
+    const PsxPlayerBinds *alt = &s_alt_binds.player[slot];
+    SDL_Scancode p = *(const SDL_Scancode *)((const char *)pb  + s_buttons[i].offset);
+    SDL_Scancode a = *(const SDL_Scancode *)((const char *)alt + s_buttons[i].offset);
+    return held_sc(keys, p) || held_sc(keys, a);
 }
 
 uint16_t psx_keybinds_pad_word(const uint8_t *keys, int player) {
@@ -393,9 +427,26 @@ void psx_keybinds_set_button(int player, int button, SDL_Scancode sc) {
     *(SDL_Scancode *)((char *)player_binds(player) + s_buttons[button].offset) = sc;
 }
 
+static PsxPlayerBinds *player_alt_binds(int player) {
+    if (player < 1 || player > PSXKB_MAX_PLAYERS)
+        return &s_alt_binds.player[0];
+    return &s_alt_binds.player[player - 1];
+}
+
+SDL_Scancode psx_keybinds_get_button_alt(int player, int button) {
+    if (button < 0 || button >= PSXKB_N) return SDL_SCANCODE_UNKNOWN;
+    return *(SDL_Scancode *)((char *)player_alt_binds(player) + s_buttons[button].offset);
+}
+
+void psx_keybinds_set_button_alt(int player, int button, SDL_Scancode sc) {
+    if (button < 0 || button >= PSXKB_N) return;
+    *(SDL_Scancode *)((char *)player_alt_binds(player) + s_buttons[button].offset) = sc;
+}
+
 void psx_keybinds_reset_player(int player) {
     if (player < 1 || player > PSXKB_MAX_PLAYERS) return;
     *player_binds(player) = s_default_binds.player[0];
+    memset(player_alt_binds(player), 0, sizeof(PsxPlayerBinds)); /* alts: unbound */
 }
 
 void psx_keybinds_save(void) {

--- a/runtime/src/psx_keybinds.c
+++ b/runtime/src/psx_keybinds.c
@@ -8,11 +8,22 @@
  */
 #include "psx_keybinds.h"
 
+#include <SDL.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
 #include <stddef.h>
+
+/* Mouse-button pseudo-scancodes. Values sit above SDL's keyboard scancode
+ * space (SDL_NUM_SCANCODES == 512), so they flow through the existing
+ * bind/save/load/rebind machinery as ordinary SDL_Scancode values while
+ * held() resolves them against SDL_GetMouseState() instead of the keyboard
+ * array. INI names: Mouse1 (left) .. Mouse5 (X2), plus LMB/RMB/MMB aliases. */
+#define PSXKB_MOUSE_SC_BASE 512                       /* + SDL_BUTTON_* (1..5) */
+#define PSXKB_MOUSE_SC(btn) ((SDL_Scancode)(PSXKB_MOUSE_SC_BASE + (btn)))
+#define PSXKB_IS_MOUSE_SC(sc) \
+    ((int)(sc) > PSXKB_MOUSE_SC_BASE && (int)(sc) <= PSXKB_MOUSE_SC_BASE + 5)
 
 /* PSX pad word bits (active-low), standard DualShock layout. Matches the
  * PAD_* masks in main.cpp / beetle_main.cpp. */
@@ -138,11 +149,25 @@ static SDL_Scancode name_to_scancode(const char *name) {
     if (!strcmp(buf, "escape") || !strcmp(buf, "esc"))    return SDL_SCANCODE_ESCAPE;
     if (!strcmp(buf, "backspace"))                        return SDL_SCANCODE_BACKSPACE;
     if (!strcmp(buf, "none") || !strcmp(buf, ""))         return SDL_SCANCODE_UNKNOWN;
+    /* Mouse buttons: Mouse1..Mouse5 (SDL button order: 1=left, 2=middle,
+     * 3=right, 4=X1, 5=X2) plus the common aliases. */
+    if (!strncmp(buf, "mouse", 5) && buf[5] >= '1' && buf[5] <= '5' && !buf[6])
+        return PSXKB_MOUSE_SC(buf[5] - '0');
+    if (!strcmp(buf, "lmb") || !strcmp(buf, "mouse left"))   return PSXKB_MOUSE_SC(SDL_BUTTON_LEFT);
+    if (!strcmp(buf, "mmb") || !strcmp(buf, "mouse middle")) return PSXKB_MOUSE_SC(SDL_BUTTON_MIDDLE);
+    if (!strcmp(buf, "rmb") || !strcmp(buf, "mouse right"))  return PSXKB_MOUSE_SC(SDL_BUTTON_RIGHT);
+    if (!strcmp(buf, "mouse x1"))                            return PSXKB_MOUSE_SC(SDL_BUTTON_X1);
+    if (!strcmp(buf, "mouse x2"))                            return PSXKB_MOUSE_SC(SDL_BUTTON_X2);
     return SDL_SCANCODE_UNKNOWN;
 }
 
 static const char *scancode_to_name(SDL_Scancode sc) {
     if (sc == SDL_SCANCODE_UNKNOWN) return "None";
+    if (PSXKB_IS_MOUSE_SC(sc)) {
+        static const char *mouse_names[5] =
+            { "Mouse1", "Mouse2", "Mouse3", "Mouse4", "Mouse5" };
+        return mouse_names[(int)sc - PSXKB_MOUSE_SC_BASE - 1];
+    }
     const char *name = SDL_GetScancodeName(sc);
     return (name && name[0]) ? name : "None";
 }
@@ -205,6 +230,8 @@ static void write_ini(const char *path) {
         "# Use SDL key names. Common: A B C ... Z, 0-9, F1-F12, Up Down Left Right,\n"
         "# Return, Tab, Space, Left Shift, Right Shift, Left Ctrl, Right Ctrl,\n"
         "# Backspace, Escape, Backslash. Use \"None\" to leave an input unbound.\n"
+        "# Mouse buttons also bind: Mouse1 (left), Mouse2 (middle), Mouse3 (right),\n"
+        "# Mouse4/Mouse5 (side); aliases LMB, MMB, RMB.\n"
         "#\n"
         "# Buttons: up/down/left/right, cross/circle/square/triangle, l1/r1/l2/r2,\n"
         "# l3/r3 (stick clicks), start/select. ls_* / rs_* are the left/right\n"
@@ -298,10 +325,16 @@ static PsxPlayerBinds *player_binds(int player) {
     return &s_binds.player[player - 1];
 }
 
-/* Is the scancode at button-def index i currently held for this player? */
+/* Is the scancode at button-def index i currently held for this player?
+ * Mouse pseudo-scancodes MUST be checked before indexing keys[] — they sit
+ * beyond the keyboard state array (SDL_NUM_SCANCODES entries). */
 static int held(const uint8_t *keys, const PsxPlayerBinds *pb, int i) {
     SDL_Scancode sc = *(const SDL_Scancode *)((const char *)pb + s_buttons[i].offset);
-    return sc != SDL_SCANCODE_UNKNOWN && keys[sc];
+    if (PSXKB_IS_MOUSE_SC(sc)) {
+        Uint32 m = SDL_GetMouseState(NULL, NULL);
+        return (m & SDL_BUTTON((int)sc - PSXKB_MOUSE_SC_BASE)) != 0;
+    }
+    return sc != SDL_SCANCODE_UNKNOWN && (int)sc < SDL_NUM_SCANCODES && keys[sc];
 }
 
 uint16_t psx_keybinds_pad_word(const uint8_t *keys, int player) {

--- a/runtime/tests/test_hybrid_dev_any_input.py
+++ b/runtime/tests/test_hybrid_dev_any_input.py
@@ -14,21 +14,21 @@ assert "e && (e[0] == '0'" not in MAIN, (
     "PSX_DEV_INPUT must not use the old default-on/explicit-disable predicate"
 )
 
-assert "hybrid_stick_active(const PlayerInput& p, bool dev_any)" in MAIN
-assert "hybrid_dpad_active(const PlayerInput& p, int player, bool dev_any)" in MAIN
-assert "hybrid_stick_active(p, dev_here)" in MAIN
-assert "hybrid_dpad_active(p, player, dev_here)" in MAIN
+assert "hybrid_stick_active(const PlayerInput& p, const PadSources& src)" in MAIN
+assert "hybrid_dpad_active(const PlayerInput& p, int player," in MAIN
+assert "hybrid_stick_active(p, src)" in MAIN
+assert "hybrid_dpad_active(p, player, src)" in MAIN
 
 stick_body = MAIN.split(
-    "static bool hybrid_stick_active(const PlayerInput& p, bool dev_any)", 1
+    "static bool hybrid_stick_active(const PlayerInput& p, const PadSources& src)", 1
 )[1].split("static bool hybrid_dpad_active", 1)[0]
 dpad_body = MAIN.split(
-    "static bool hybrid_dpad_active(const PlayerInput& p, int player, bool dev_any)",
+    "static bool hybrid_dpad_active(const PlayerInput& p, int player,",
     1,
 )[1].split("/* Sample each player's live device state", 1)[0]
 
 for name, body, detector in (
-    ("stick", stick_body, "controller_stick_active(handle)"),
+    ("stick", stick_body, "controller_stick_active(handle, controller_deadzone)"),
     ("D-pad", dpad_body, "controller_dpad_active(handle)"),
 ):
     assert "SDL_NumJoysticks()" in body, (

--- a/runtime/tests/test_mod_controller_override.py
+++ b/runtime/tests/test_mod_controller_override.py
@@ -18,16 +18,16 @@ for symbol in (
 ):
     assert symbol in HEADER, f"missing trusted-plugin controller API: {symbol}"
 
-reset = """g_mod_controller_mode_override[0] = -1;
-    g_mod_controller_mode_override[1] = -1;
-    mod_runtime_activate_plugins();"""
-apply = """if (g_mod_controller_mode_override[0] >= 0)
-        p1_mode = g_mod_controller_mode_override[0];
-    if (g_mod_controller_mode_override[1] >= 0)
-        p2_mode = g_mod_controller_mode_override[1];"""
+reset0 = "g_mod_controller_mode_override[0] = -1;"
+reset1 = "g_mod_controller_mode_override[1] = -1;"
+activate = "mod_runtime_activate_plugins();"
+apply0 = "player_mode[0] = g_mod_controller_mode_override[0];"
+apply1 = "player_mode[1] = g_mod_controller_mode_override[1];"
 
-assert reset in MAIN, "controller overrides must reset before every activation pass"
-assert apply in MAIN, "controller overrides must replace the resolved launch modes"
-assert MAIN.index(reset) < MAIN.index(apply), "reset/activate must precede application"
+for snippet in (reset0, reset1, activate, apply0, apply1):
+    assert snippet in MAIN, f"missing controller override lifecycle step: {snippet}"
+
+assert MAIN.index(reset0) < MAIN.index(activate) < MAIN.index(apply0)
+assert MAIN.index(reset1) < MAIN.index(activate) < MAIN.index(apply1)
 
 print("mod controller override lifecycle guard passed")

--- a/tools/new_project_layout/probe_disc.py
+++ b/tools/new_project_layout/probe_disc.py
@@ -514,7 +514,6 @@ def render_game_toml(p: DiscProbe, *, disc_rel: str, out_dir: str, players: int)
         "",
         "[controller]",
         'default_mode = "digital"',
-        "allow_hybrid = false",
         "",
         "# Online mount gate: digests + track count + optional TOC fingerprint",
         "# (see docs/NETPLAY.md).",


### PR DESCRIPTION
Supersedes #107 and is now rebased onto current master. Alexbeav's mouse/dual-binding commits retain authorship; the integration commits make the routing change safe on the current five-player/netplay code.

Pairs with mstan/recomp-ui#25. The two remove a field from RecompLauncherCGameInfo and must land together.

## Legitimacy and behavior

- Mouse1-5 become bindable inputs and every control gains an optional second binding. Existing one-value keybinds.ini files remain valid.
- Keyboard/mouse bindings remain live alongside a routed gamepad. This is intentional additive behavior for pad-plus-mouse play; an unpressed source is a no-op.
- Pad source selection is derived once and shared by buttons, sticks, and Hybrid's analog/digital detector, preventing those paths from disagreeing.
- Hybrid is no longer a default or user/config choice. Defaults become Analog, stale user settings migrate to Analog, and game.toml hybrid is rejected with guidance to the trusted mod API.
- Hybrid internals and psx_mod_set_controller_mode_override remain for Tomba's tomba.hybrid-controller mod.
- Current netplay/multitap semantics and all five player binding slots were preserved during the rebase.

## Risk assessment

The meaningful behavior changes are the approved removal of selectable Hybrid and the intentional keyboard/mouse-plus-gamepad source merge. Mouse/alternate binds are opt-in and their INI format is backward-compatible. The ABI field removal is source-level and paired with recomp-ui#25; downstream projects must rebuild against the paired headers.

## Validation on the rebased commits

- test_mod_controller_override.py: pass
- test_hybrid_dev_any_input.py: pass
- git diff --check: pass
- full Tomba SDL2 runtime compile/link: pass, including tomba_hybrid_controller_plugin.c and paired recomp-ui#25
- stale allow_hybrid/config/UI routes: absent; only trusted mod and internal Hybrid symbols remain

The original branch's hands-on Tomba input check predates this rebase. The rebased pairing has compile/link and lifecycle-guard coverage, not a newly performed live gameplay session.

Default SDL3 validation is currently blocked by two baseline issues outside this diff: current recomp-ui passes int to SDL_GetGamepadStringForAxis, and the launcher-disabled runtime has duplicate SDL WinMain definitions. The changed psxrecomp objects, including psx_keybinds.c and the Tomba plugin, compile before those unrelated failures.
