### PR TITLE
Fix MSVC portability gaps in runtime and BIOS output

### DIFF
--- a/recompiler/CMakeLists.txt
+++ b/recompiler/CMakeLists.txt
@@ -380,6 +380,12 @@ if(BUILD_TESTING)
             NAME dirty_text_continuation_guards
             COMMAND ${Python3_EXECUTABLE}
                     ${CMAKE_CURRENT_SOURCE_DIR}/../runtime/tests/test_dirty_text_continuation_guards.py)
+        add_test(
+            NAME bios_backend_constant_codegen
+            COMMAND ${Python3_EXECUTABLE}
+                    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_bios_backend_constant_codegen.py
+                    --recompiler $<TARGET_FILE:psxrecomp-bios>
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/..)
 
         # ---- codegen tests that were written but never registered -----------
         # These existed in recompiler/tests/ with no add_test() entry, so they

--- a/recompiler/src/full_function_emitter.cpp
+++ b/recompiler/src/full_function_emitter.cpp
@@ -1793,7 +1793,10 @@ void FullFunctionEmitter::emit_dispatch(
                            g_sym_prefix, kb_count);
         out += kb;
         out += "};\n";
-        out += fmt::format("static const uint32_t {}psx_bios_kernel_body_count = {}u;\n\n",
+        // An enum is an integer constant expression in C. A const-qualified
+        // object is not, so MSVC rejects it in the file-scope backend
+        // initializer even though GCC and Clang accept it as an extension.
+        out += fmt::format("enum {{ {}psx_bios_kernel_body_count = {}u }};\n\n",
                            g_sym_prefix, kb_count);
     }
 

--- a/recompiler/tests/test_bios_backend_constant_codegen.py
+++ b/recompiler/tests/test_bios_backend_constant_codegen.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Verify BIOS backend counts are emitted as C integer constant expressions."""
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+import tempfile
+
+
+def main():
+    here = os.path.dirname(os.path.abspath(__file__))
+    root = os.path.normpath(os.path.join(here, "..", ".."))
+    default = os.path.join(root, "recompiler", "build", "psxrecomp-bios.exe")
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--recompiler", default=default)
+    args = parser.parse_args()
+
+    if not os.path.isfile(args.recompiler):
+        print(f"FAIL: recompiler not found: {args.recompiler}", file=sys.stderr)
+        return 2
+
+    with tempfile.TemporaryDirectory() as out_dir:
+        result = subprocess.run(
+            [
+                args.recompiler,
+                "--config",
+                os.path.join(root, "bios", "OpenBIOS.toml"),
+                "--out-dir",
+                out_dir,
+            ],
+            cwd=root,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode:
+            print(result.stderr or result.stdout, file=sys.stderr)
+            return 1
+
+        dispatch_path = os.path.join(out_dir, "OpenBIOS_dispatch.c")
+        with open(dispatch_path, encoding="utf-8") as stream:
+            generated = stream.read()
+
+    constant = re.compile(
+        r"enum \{ OpenBIOS_psx_bios_kernel_body_count = \d+u \};"
+    )
+    if not constant.search(generated):
+        print("FAIL: generated dispatch has no enum backend count", file=sys.stderr)
+        return 1
+    if "static const uint32_t OpenBIOS_psx_bios_kernel_body_count" in generated:
+        print("FAIL: backend count is still emitted as a const object", file=sys.stderr)
+        return 1
+
+    print("PASS: BIOS backend count is a C integer constant expression.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/runtime/runtime.cmake
+++ b/runtime/runtime.cmake
@@ -763,6 +763,10 @@ function(psxrecomp_add_runtime_target target)
         ${PSXRT_EXTRAS_SOURCES}
     )
     target_link_libraries(${target} PRIVATE chdr-static)
+    # audio_trace.c uses C11 atomics. Make the runtime's actual language
+    # requirement explicit instead of relying on a parent project's global
+    # CMAKE_C_STANDARD setting.
+    target_compile_features(${target} PRIVATE c_std_11)
 
     # Game-specific executable name. Every title instantiates this function with
     # the same CMake target name ("psx-runtime"), so without this they ALL produce
@@ -950,6 +954,7 @@ function(psxrecomp_add_runtime_target target)
         PSX_GAME_VERSION="${PSXRT_GAME_VERSION}"
         PSX_MAX_PLAYERS=${PSXRT_MAX_PLAYERS}
         FMT_HEADER_ONLY=1
+        $<$<PLATFORM_ID:Windows>:NOMINMAX>
         $<$<BOOL:${PSX_SDL3}>:PSX_SDL3=1>
         $<$<CXX_COMPILER_ID:MSVC>:SDL_MAIN_HANDLED>
     )
@@ -1281,6 +1286,11 @@ function(psxrecomp_add_runtime_target target)
         endif()
     elseif(MSVC)
         target_compile_options(${target} PRIVATE /GS- /guard:cf-)
+        # Visual Studio project files cannot represent language-specific target
+        # options on a mixed C/C++ target. Scope the experimental MSVC atomics
+        # switch to the one C source that needs it instead.
+        set_property(SOURCE ${PSXRECOMP_ROOT}/runtime/src/audio_trace.c
+            APPEND PROPERTY COMPILE_OPTIONS /experimental:c11atomics)
         target_link_options(${target} PRIVATE /STACK:67108864,67108864 /GUARD:NO)
         # No console window in Release MSVC builds. /ENTRY keeps main() as
         # the entry point (not WinMain) while switching to the Windows subsystem.

--- a/runtime/src/crash_trace.c
+++ b/runtime/src/crash_trace.c
@@ -23,7 +23,9 @@
 
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif
 #include <windows.h>
 #include <intrin.h>     /* __readgsqword — fiber TEB stack bounds for native_stack walk */
 #endif


### PR DESCRIPTION
## Summary
- define `NOMINMAX` for Windows runtime targets and make the existing local definition warning-free
- declare the runtime's C11 requirement and enable MSVC C11 atomics only for `audio_trace.c`
- emit BIOS backend counts as C integer constant expressions
- add a regression test for the generated backend descriptor

## Validation
- built `psxrecomp-bios` and `psxrecomp-game` with MSVC 19.41
- generated OpenBIOS and compiled its dispatcher with MSVC C11
- compiled `audio_trace.c` with MSVC C11 atomics
- confirmed `main.cpp` passes the former `min`/`max` failure during a native runtime build
- passed `bios_backend_constant_codegen` and `msvc_cps_codegen`

A complete runtime build now gets past the three failures reported in #122, then reaches separate portability failures added after the reporter's pinned commit; those are tracked separately.

Fixes #122