### PR TITLE
Fix Windows setup installs: require_generated cmdline + BIOS picker.

### DIFF
--- a/host/psxrecomp_codegen_host.c
+++ b/host/psxrecomp_codegen_host.c
@@ -3783,6 +3783,10 @@ void psxrecomp_codegen_host_apply(RecompLauncherCGameInfo* gi,
 
     /* Master switch for recomp-ui: first-run wizard + Generate & rebuild. */
     gi->setup_wizard_supported = 1;
+    /* Setup SDKs often link OpenBIOS only (retail C comes from Generate).
+     * psx_bios_has_selectable() is then 0 and would hide the BIOS row — keep
+     * the optional SCPH1001 picker so prepare can ingest a dump first. */
+    gi->has_bios = 1;
 
     if (!discover_project_root(g_project_root, sizeof(g_project_root))) {
         /* Still force the wizard when generated/ is missing — discover may

--- a/psxrecomp_cli.py
+++ b/psxrecomp_cli.py
@@ -897,18 +897,39 @@ def cmd_generate(args: argparse.Namespace, progress: ProgressReporter) -> int:
         message=f"Running psxrecomp-game -> {out_dir}",
     )
     cmd = [str(game_tool), "--config", str(config)]
+    # Product Generate: collapse reserved-opcode WARNING spam in the wizard log.
+    # The emitter also dedupes to once-per-PC unless PSXRECOMP_VERBOSE_RI_WARNINGS=1.
+    verbose_ri = os.environ.get("PSXRECOMP_VERBOSE_RI_WARNINGS", "").strip() not in (
+        "",
+        "0",
+    )
     proc = subprocess.run(
         cmd,
         cwd=str(project_root),
         capture_output=True,
         text=True,
     )
+    ri_warn = 0
     for stream in (proc.stdout, proc.stderr):
         if not stream:
             continue
         for line in stream.splitlines():
-            if line.strip():
-                progress.log(line)
+            if not line.strip():
+                continue
+            if (
+                not verbose_ri
+                and "WARNING: reserved opcode" in line
+                and "emitting guest RI" in line
+            ):
+                ri_warn += 1
+                continue
+            progress.log(line)
+    if ri_warn:
+        progress.log(
+            f"Note: suppressed {ri_warn} reserved-opcode WARNING line(s) "
+            "(data-as-code sites; RI raises still emitted). "
+            "Set PSXRECOMP_VERBOSE_RI_WARNINGS=1 for full detail."
+        )
     if proc.returncode != 0:
         progress.error(
             f"psxrecomp-game failed (exit {proc.returncode})", code=EXIT_ERROR

--- a/recompiler/src/code_generator.cpp
+++ b/recompiler/src/code_generator.cpp
@@ -14,9 +14,23 @@
 #include <cstdlib>
 #include <set>
 #include <stdexcept>
+#include <unordered_set>
 #include <vector>
 
 namespace PSXRecomp {
+
+/* Reserved MIPS-II branch-likely words often appear when discovery sweeps
+ * ASCII/data as code. Emit the RI raise every time (faithfulness), but do not
+ * spam one WARNING per revisit of the same PC — product Generate was flooding
+ * the setup wizard with hundreds of identical lines. Set
+ * PSXRECOMP_VERBOSE_RI_WARNINGS=1 to print every hit (dev / tests). */
+static bool should_print_reserved_opcode_warning(uint32_t addr) {
+    const char* e = std::getenv("PSXRECOMP_VERBOSE_RI_WARNINGS");
+    if (e != nullptr && e[0] != '\0' && e[0] != '0')
+        return true;
+    static std::unordered_set<uint32_t> seen;
+    return seen.insert(addr).second;
+}
 
 static bool codegen_cycle_per_insn() {
     // DEFAULT ON for the faithful-timing (cycle-audit) branch: each instruction
@@ -1913,9 +1927,11 @@ std::string CodeGenerator::translate_basic_block(
                      * the word is data (never executed) nothing happens; if the
                      * guest really reaches it, the kernel handler sees the same
                      * exception hardware would deliver. */
-                    fmt::print("  WARNING: reserved opcode 0x{:08X} at 0x{:08X} "
-                               "— emitting guest RI exception raise\n",
-                               block.exit_instr.instruction, addr);
+                    if (should_print_reserved_opcode_warning(addr)) {
+                        fmt::print("  WARNING: reserved opcode 0x{:08X} at 0x{:08X} "
+                                   "— emitting guest RI exception raise\n",
+                                   block.exit_instr.instruction, addr);
+                    }
                     ss << config_.indent
                        << fmt::format("{{ /* reserved opcode 0x{:08X}: architectural RI exception */\n",
                                       block.exit_instr.instruction);

--- a/runtime/check_generated_sources.cmake
+++ b/runtime/check_generated_sources.cmake
@@ -11,15 +11,29 @@
 # build-time dependency of the runtime target (see psxrecomp_add_runtime_target)
 # so the failure surfaces first, names the missing files, and states the fix.
 #
-# Invoked via: cmake -DSOURCES=<;-list> -DTARGET=.. -DGAME_CONFIG=.. \
-#                    -DRECOMPILER=.. -DDOC=.. -P check_generated_sources.cmake
+# Invoked via:
+#   cmake -DSOURCES_FILE=<path> -DTARGET=.. -DGAME_CONFIG=.. \
+#         -DRECOMPILER=.. -DDOC=.. -P check_generated_sources.cmake
+# or (small lists only; Windows CreateProcess is ~8191 chars):
+#   cmake -DSOURCES=<;-list> ...
 
-if(NOT DEFINED SOURCES)
-    message(FATAL_ERROR "check_generated_sources.cmake requires SOURCES")
+set(_sources "")
+if(DEFINED SOURCES_FILE AND SOURCES_FILE)
+    if(NOT EXISTS "${SOURCES_FILE}")
+        message(FATAL_ERROR
+            "check_generated_sources.cmake: SOURCES_FILE does not exist:\n"
+            "  ${SOURCES_FILE}")
+    endif()
+    file(STRINGS "${SOURCES_FILE}" _sources)
+elseif(DEFINED SOURCES)
+    set(_sources ${SOURCES})
+else()
+    message(FATAL_ERROR
+        "check_generated_sources.cmake requires SOURCES_FILE or SOURCES")
 endif()
 
 set(_missing "")
-foreach(_src IN LISTS SOURCES)
+foreach(_src IN LISTS _sources)
     if(_src AND NOT EXISTS "${_src}")
         list(APPEND _missing "${_src}")
     endif()

--- a/runtime/runtime.cmake
+++ b/runtime/runtime.cmake
@@ -842,9 +842,18 @@ function(psxrecomp_add_runtime_target target)
                 "  (build that tool first if needed; see psxrecomp/docs/BUILDING.md). "
                 "This is expected on a fresh checkout before the first generation.")
         endif()
+        # Pass paths via a list file — large shard counts (hundreds of
+        # generated/*_full_*.c) make -DSOURCES=... exceed Windows' ~8191-char
+        # CreateProcess limit ("The system cannot execute the specified program").
+        set(_psxrt_gen_list
+            "${CMAKE_CURRENT_BINARY_DIR}/${target}_generated_sources.txt")
+        file(WRITE "${_psxrt_gen_list}" "")
+        foreach(_g IN LISTS _game_generated_check)
+            file(APPEND "${_psxrt_gen_list}" "${_g}\n")
+        endforeach()
         add_custom_target(${target}_require_generated
             COMMAND ${CMAKE_COMMAND}
-                    "-DSOURCES=${_game_generated_check}"
+                    "-DSOURCES_FILE=${_psxrt_gen_list}"
                     "-DTARGET=${target}"
                     "-DGAME_CONFIG=${PSXRT_DEFAULT_GAME_CONFIG_PATH}"
                     "-DRECOMPILER=${_psxrt_recompiler_hint}"

--- a/runtime/src/main.cpp
+++ b/runtime/src/main.cpp
@@ -10221,6 +10221,9 @@ int main(int argc, char** argv) {
             /* Local codegen: missing generated/ or MOTK_FORCE_SETUP opens the
              * generate & rebuild wizard (may also set prepare_required). */
             psx_game_codegen_setup_apply(&gi);
+            /* host_apply forces has_bios for OpenBIOS-only setup packages. */
+            if (gi.setup_wizard_supported)
+                gi.has_bios = 1;
 #endif
 #endif /* PSX_HAS_SETUP_WIZARD */
             launcher_boot_timing_mark("host:setup_checks_done");


### PR DESCRIPTION
Pass generated shard paths via a SOURCES_FILE so cmake -P is not killed by CreateProcess's ~8191-char limit, and keep has_bios on for OpenBIOS-only setup SDKs so the first-run wizard still offers SCPH1001.