### PR TITLE
recompiler: fail closed on unmodeled BIOS load delays

### DIFF
--- a/recompiler/CMakeLists.txt
+++ b/recompiler/CMakeLists.txt
@@ -311,6 +311,28 @@ if(BUILD_TESTING)
     target_link_libraries(recompiler_patch_test PRIVATE fmt rabbitizer)
     add_test(NAME recompiler_patch_test COMMAND recompiler_patch_test)
 
+    add_executable(full_function_emitter_test
+        tests/full_function_emitter_test.cpp
+        src/ps1_exe_parser.cpp
+        src/mips_decoder.cpp
+        src/strict_translator.cpp
+        src/bios_address_model.cpp
+        src/function_discovery.cpp
+        src/full_function_emitter.cpp
+        src/config_loader.cpp
+        src/recompiler_patch.cpp
+    )
+    target_include_directories(full_function_emitter_test PRIVATE
+        include
+        src
+        lib/rabbitizer/include
+        lib/rabbitizer/cplusplus/include
+        lib/fmt/include
+        lib/toml11
+    )
+    target_link_libraries(full_function_emitter_test PRIVATE fmt rabbitizer)
+    add_test(NAME full_function_emitter_test COMMAND full_function_emitter_test)
+
     add_executable(recompiler_patch_cxx17_header_test
         tests/recompiler_patch_cxx17_header_test.cpp
     )

--- a/recompiler/src/full_function_emitter.cpp
+++ b/recompiler/src/full_function_emitter.cpp
@@ -150,9 +150,11 @@ bool FullFunctionEmitter::emit_function(
     uint32_t                    /* rom_end */,
     std::vector<ContinuationLabel>& out_continuations,
     const std::set<uint32_t>&   injected_cross_targets,
-    std::vector<ContinuationLabel>& out_cross_targets)
+    std::vector<ContinuationLabel>& out_cross_targets,
+    std::string*                out_interpreter_reason)
 {
     const uint32_t norm = func.normalized_addr;
+    if (out_interpreter_reason) out_interpreter_reason->clear();
 
     // RECURSION_BUG.md §25 — continuation-passing call/return (the universal fix
     // for the idle-freeze host-stack leak). When PSX_CPS is set at gen time,
@@ -292,10 +294,6 @@ bool FullFunctionEmitter::emit_function(
     // continuation entry-switch after we know which labels exist.
     std::string branch_decls;
     std::string body;
-    // Shadow 'out' with a reference to 'body' so all existing out+= lines
-    // write to the temporary buffer.  The real 'out' is assembled at the end.
-    std::string& func_out = body;
-    #define out func_out
 
     // --- Emit instructions in address order ---
     // Delay slots are emitted at their natural address (NOT inline with
@@ -499,6 +497,7 @@ bool FullFunctionEmitter::emit_function(
     };
     /* load addr -> {dest reg, flush writeback (vs discard)} */
     std::map<uint32_t, std::pair<int, bool>> ldd_sites;
+    std::string unmodeled_load_delay;
     for (const auto& [la, lw_raw] : addr_to_raw) {
         int dest = simple_load_dest(lw_raw);
         uint32_t lop = lw_raw >> 26;
@@ -516,10 +515,15 @@ bool FullFunctionEmitter::emit_function(
             if (f != addr_to_raw.end() && insn_reads_gpr(f->second, dep_reg)) dep = true;
             auto t = addr_to_raw.find(pb.target);
             if (pb.target && t != addr_to_raw.end() && insn_reads_gpr(t->second, dep_reg)) dep = true;
-            if (dep)
-                std::fprintf(stderr,
-                    "[load-delay] UNMODELED: load 0x%08X in delay slot with dependent successor (func 0x%08X)\n",
-                    la, func.entry_addr);
+            if (dep) {
+                unmodeled_load_delay = fmt::format(
+                    "load 0x{:08X} in a branch delay slot has a dependent successor", la);
+                if (out_interpreter_reason) {
+                    std::fprintf(stderr,
+                        "[load-delay] UNMODELED: load 0x%08X in delay slot with dependent successor (func 0x%08X)\n",
+                        la, func.entry_addr);
+                }
+            }
             continue;
         }
         auto nx = addr_to_raw.find(la + 4);
@@ -531,10 +535,15 @@ bool FullFunctionEmitter::emit_function(
             uint32_t nx_phys = (la + 4) & 0x1FFFFFFFu;
             if (nx_phys >= base_phys && nx_phys + 4 <= base_phys + rom.size()) {
                 uint32_t nx_raw = read_u32_le(rom, nx_phys - base_phys);
-                if (insn_reads_gpr(nx_raw, dep_reg))
-                    std::fprintf(stderr,
-                        "[load-delay] UNMODELED: dependent pair crosses fragment boundary after load 0x%08X rt=%d (func 0x%08X)\n",
-                        la, dep_reg, func.entry_addr);
+                if (insn_reads_gpr(nx_raw, dep_reg)) {
+                    unmodeled_load_delay = fmt::format(
+                        "dependent load pair crosses a fragment boundary after 0x{:08X}", la);
+                    if (out_interpreter_reason) {
+                        std::fprintf(stderr,
+                            "[load-delay] UNMODELED: dependent pair crosses fragment boundary after load 0x%08X rt=%d (func 0x%08X)\n",
+                            la, dep_reg, func.entry_addr);
+                    }
+                }
             }
             continue;
         }
@@ -547,20 +556,61 @@ bool FullFunctionEmitter::emit_function(
             uint32_t nop_ = nx->second >> 26, nrt = (nx->second >> 16) & 31;
             bool complementary = (nrt == (uint32_t)dep_reg) &&
                                  ((lop == 0x22 && nop_ == 0x26) || (lop == 0x26 && nop_ == 0x22));
-            if (!complementary)
-                std::fprintf(stderr,
-                    "[load-delay] UNMODELED: LWL/LWR 0x%08X with dependent successor (func 0x%08X)\n",
-                    la, func.entry_addr);
+            if (!complementary) {
+                unmodeled_load_delay = fmt::format(
+                    "LWL/LWR 0x{:08X} has a dependent non-complementary successor", la);
+                if (out_interpreter_reason) {
+                    std::fprintf(stderr,
+                        "[load-delay] UNMODELED: LWL/LWR 0x%08X with dependent successor (func 0x%08X)\n",
+                        la, func.entry_addr);
+                }
+            }
             continue;
         }
         if (block_leaders.count(la + 4)) {
-            std::fprintf(stderr,
-                "[load-delay] UNMODELED: dependent pair split by label at 0x%08X (func 0x%08X)\n",
-                la + 4, func.entry_addr);
+            unmodeled_load_delay = fmt::format(
+                "dependent load pair is split by a label at 0x{:08X}", la + 4);
+            if (out_interpreter_reason) {
+                std::fprintf(stderr,
+                    "[load-delay] UNMODELED: dependent pair split by label at 0x%08X (func 0x%08X)\n",
+                    la + 4, func.entry_addr);
+            }
             continue;
         }
         ldd_sites[la] = {dest, true};
     }
+    if (!unmodeled_load_delay.empty()) {
+        // dirty_ram_dispatch interprets live main-RAM bytes only. Relocated
+        // kernel/shell functions satisfy that contract; a pure ROM function
+        // does not. Never turn a correctness fallback into a later
+        // unknown-dispatch abort: stop generation if there is no interpreter
+        // backend capable of executing every instruction in this function.
+        const bool ram_backed = std::all_of(
+            addr_to_raw.begin(), addr_to_raw.end(),
+            [](const auto& insn) {
+                return (bios_runtime_pc(insn.first) & 0x1FFFFFFFu) <
+                       (2u * 1024u * 1024u);
+            });
+        if (!ram_backed) {
+            throw std::runtime_error(fmt::format(
+                "cannot safely emit BIOS function 0x{:08X}: {}; "
+                "the function is not RAM-backed, so interpreter fallback is unavailable",
+                func.entry_addr, unmodeled_load_delay));
+        }
+        if (out_interpreter_reason) {
+            *out_interpreter_reason = unmodeled_load_delay;
+            std::fprintf(stderr,
+                "[load-delay] FALLBACK: function 0x%08X excluded from native dispatch; using interpreter (%s)\n",
+                func.entry_addr, unmodeled_load_delay.c_str());
+        }
+        return false;
+    }
+
+    // Shadow 'out' with a reference to 'body' so all existing out+= lines
+    // write to the temporary buffer.  The real 'out' is assembled at the end.
+    std::string& func_out = body;
+    #define out func_out
+
     for (auto& [la, s] : ldd_sites) {
         uint32_t nw = addr_to_raw.at(la + 4);
         if (insn_writes_gpr(nw, static_cast<uint32_t>(s.first))) {
@@ -2305,7 +2355,7 @@ EmitStats FullFunctionEmitter::emit(
             std::string tmp;
             std::set<uint32_t> empty;
             (void)emit_function(tmp, fn, sfr, all_function_entries_norm, rom, base_addr, rom_end,
-                                dry_run_continuations, empty, dry_run_cross);
+                                dry_run_continuations, empty, dry_run_cross, nullptr);
         }
         for (const auto& cl : dry_run_cross) {
             auto ow = insn_owner.find(cl.rom_addr);
@@ -2351,9 +2401,15 @@ EmitStats FullFunctionEmitter::emit(
         }
 
         std::vector<ContinuationLabel> discard_cross;  /* PASS 2 cross is unused */
+        std::string interpreter_reason;
         bool ok = emit_function(full_c, fn, sfr, all_function_entries_norm, rom, base_addr, rom_end,
-                                all_continuations, injected, discard_cross);
+                                all_continuations, injected, discard_cross, &interpreter_reason);
         if (!ok) {
+            if (!interpreter_reason.empty()) {
+                stats.interpreted.emplace_back(fn.entry_addr, interpreter_reason);
+                stats.functions_interpreted++;
+                continue;
+            }
             stats.skipped.emplace_back(fn.entry_addr, "emit_function failed");
             stats.functions_skipped++;
             continue;
@@ -2437,6 +2493,25 @@ EmitStats FullFunctionEmitter::emit(
         }
         json += "]\n";
         std::string path = out_dir + "/" + out_stem + "_skipped_functions.json";
+        std::ofstream f(path, std::ios::binary);
+        if (!f) throw std::runtime_error(fmt::format("cannot write {}", path));
+        f.write(json.data(), static_cast<std::streamsize>(json.size()));
+    }
+
+    // Fail-closed functions are deliberately absent from native dispatch so
+    // the existing dispatch miss path executes their live bytes through the
+    // interpreter. Keep this separate from skipped_functions.json: skipped
+    // functions receive fatal diagnostic stubs, while these remain runnable.
+    if (!stats.interpreted.empty()) {
+        std::string json = "[\n";
+        for (size_t i = 0; i < stats.interpreted.size(); ++i) {
+            json += fmt::format("  {{\"address\": \"0x{:08X}\", \"reason\": \"{}\"}}",
+                                stats.interpreted[i].first, stats.interpreted[i].second);
+            if (i + 1 < stats.interpreted.size()) json += ",";
+            json += "\n";
+        }
+        json += "]\n";
+        std::string path = out_dir + "/" + out_stem + "_interpreted_functions.json";
         std::ofstream f(path, std::ios::binary);
         if (!f) throw std::runtime_error(fmt::format("cannot write {}", path));
         f.write(json.data(), static_cast<std::streamsize>(json.size()));

--- a/recompiler/src/full_function_emitter.h
+++ b/recompiler/src/full_function_emitter.h
@@ -34,10 +34,12 @@ namespace PSXRecompV4 {
 struct EmitStats {
     uint32_t functions_emitted = 0;
     uint32_t functions_skipped = 0;  // e.g. FPU functions
+    uint32_t functions_interpreted = 0;  // fail-closed correctness fallback
     uint32_t total_instructions = 0;
     uint32_t dispatch_entries = 0;
     uint32_t continuation_entries = 0;
     std::vector<std::pair<uint32_t, std::string>> skipped;  // (addr, reason)
+    std::vector<std::pair<uint32_t, std::string>> interpreted;  // (addr, reason)
 };
 
 // A continuation label: the return point inside a calling function after
@@ -102,7 +104,8 @@ private:
         uint32_t                    rom_end,
         std::vector<ContinuationLabel>& out_continuations,
         const std::set<uint32_t>&   injected_cross_targets,
-        std::vector<ContinuationLabel>& out_cross_targets);
+        std::vector<ContinuationLabel>& out_cross_targets,
+        std::string*                out_interpreter_reason);
 
     // Emit the dispatch table.
     static void emit_dispatch(

--- a/recompiler/src/main_bios.cpp
+++ b/recompiler/src/main_bios.cpp
@@ -862,10 +862,17 @@ int run_emit_full(const fs::path& bios_path, const fs::path& out_dir,
         dr, sha, out_dir.string(), out_stem, bios_vectors, bios_aliases);
 
     std::fprintf(stdout,
-        "psxrecomp-bios: EMIT OK  emitted=%u  skipped=%u  instructions=%u  "
+        "psxrecomp-bios: EMIT OK  emitted=%u  interpreted=%u  skipped=%u  instructions=%u  "
         "dispatch_entries=%u\n",
-        stats.functions_emitted, stats.functions_skipped,
+        stats.functions_emitted, stats.functions_interpreted, stats.functions_skipped,
         stats.total_instructions, stats.dispatch_entries);
+
+    if (stats.functions_interpreted > 0) {
+        std::fprintf(stdout, "psxrecomp-bios: interpreter fallbacks:\n");
+        for (const auto& [addr, reason] : stats.interpreted) {
+            std::fprintf(stdout, "  0x%08X: %s\n", addr, reason.c_str());
+        }
+    }
 
     if (stats.functions_skipped > 0) {
         std::fprintf(stdout, "psxrecomp-bios: skipped functions:\n");

--- a/recompiler/tests/full_function_emitter_test.cpp
+++ b/recompiler/tests/full_function_emitter_test.cpp
@@ -1,0 +1,231 @@
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <initializer_list>
+#include <string>
+#include <vector>
+
+#include "../src/bios_address_model.h"
+#include "../src/config_loader.h"
+#include "../src/full_function_emitter.h"
+#include "../src/function_discovery.h"
+
+using PSXRecompV4::BiosAddressModel;
+using PSXRecompV4::BiosAddrCopy;
+using PSXRecompV4::BiosConfig;
+using PSXRecompV4::DiscoveredFunction;
+using PSXRecompV4::DiscoveryResult;
+using PSXRecompV4::EmitStats;
+using PSXRecompV4::FullFunctionEmitter;
+using PSXRecompV4::FunctionDiscovery;
+
+namespace {
+
+constexpr uint32_t kBase = 0xBFC00000u;
+int failures = 0;
+
+void expect(bool condition, const char* message) {
+    if (!condition) {
+        std::fprintf(stderr, "FAIL: %s\n", message);
+        ++failures;
+    }
+}
+
+void append_word(std::vector<uint8_t>& rom, uint32_t word) {
+    rom.push_back(static_cast<uint8_t>(word));
+    rom.push_back(static_cast<uint8_t>(word >> 8));
+    rom.push_back(static_cast<uint8_t>(word >> 16));
+    rom.push_back(static_cast<uint8_t>(word >> 24));
+}
+
+DiscoveredFunction function_at(uint32_t entry, uint32_t end,
+                               std::initializer_list<uint32_t> leaders) {
+    DiscoveredFunction fn{};
+    fn.entry_addr = entry;
+    fn.normalized_addr = entry & 0x1FFFFFFFu;
+    fn.end_addr = end;
+    fn.instruction_count = (end - entry) / 4u + 1u;
+    fn.termination_reason = "jr_ra";
+    fn.discovered_by = "synthetic test";
+    fn.block_leaders.assign(leaders.begin(), leaders.end());
+    return fn;
+}
+
+std::string read_file(const std::filesystem::path& path) {
+    std::ifstream in(path, std::ios::binary);
+    return std::string(std::istreambuf_iterator<char>(in),
+                       std::istreambuf_iterator<char>());
+}
+
+struct RunResult {
+    EmitStats stats;
+    std::string dispatch;
+};
+
+RunResult run_case(const char* name, const std::vector<uint32_t>& words,
+                   std::vector<DiscoveredFunction> functions) {
+    std::vector<uint8_t> rom;
+    for (uint32_t word : words) append_word(rom, word);
+
+    DiscoveryResult discovery{};
+    discovery.ok = true;
+    discovery.functions = std::move(functions);
+
+    const auto nonce = std::chrono::high_resolution_clock::now()
+                           .time_since_epoch().count();
+    const auto out_dir = std::filesystem::temp_directory_path() /
+                         ("psxrecomp-full-emitter-" + std::string(name) + "-" +
+                          std::to_string(nonce));
+    std::filesystem::create_directories(out_dir);
+
+    const std::string stem = "Test";
+    RunResult result;
+    result.stats = FullFunctionEmitter::emit(
+        rom, kBase, kBase + static_cast<uint32_t>(rom.size()) - 1u,
+        discovery, "synthetic", out_dir.string(), stem);
+    result.dispatch = read_file(out_dir / (stem + "_dispatch.c"));
+    std::filesystem::remove_all(out_dir);
+    return result;
+}
+
+void expect_entry_absent(const RunResult& result, uint32_t normalized,
+                         const char* message) {
+    char needle[96];
+    std::snprintf(needle, sizeof(needle),
+                  "{ 0x%08Xu, Test_func_%08X }", normalized, normalized);
+    expect(result.dispatch.find(needle) == std::string::npos, message);
+}
+
+void expect_dispatch_key_absent(const RunResult& result, uint32_t normalized,
+                                const char* message) {
+    char needle[32];
+    std::snprintf(needle, sizeof(needle), "{ 0x%08Xu,", normalized);
+    expect(result.dispatch.find(needle) == std::string::npos, message);
+}
+
+void delay_slot_load_falls_back() {
+    const auto result = run_case(
+        "delay-slot",
+        {
+            0x10000001u,  // beq zero,zero,+1
+            0x8D280000u,  // lw t0,0(t1) -- branch delay slot
+            0x01001021u,  // addu v0,t0,zero -- dependent successor
+            0x03E00008u,  // jr ra
+            0x00000000u,  // nop
+        },
+        {function_at(kBase, kBase + 16u, {kBase, kBase + 8u})});
+    expect(result.stats.functions_interpreted == 1,
+           "delay-slot load marks the function for interpretation");
+    expect(result.stats.functions_emitted == 0,
+           "delay-slot load function is not emitted");
+    expect_entry_absent(result, 0x00000500u,
+                        "delay-slot load function is absent from dispatch");
+    expect_dispatch_key_absent(result, 0x00000508u,
+                               "delay-slot successor continuation is absent from dispatch");
+}
+
+void label_split_load_falls_back() {
+    const auto result = run_case(
+        "label-split",
+        {
+            0x8D280000u,  // lw t0,0(t1)
+            0x01001021u,  // addu v0,t0,zero -- dependent labeled successor
+            0x03E00008u,  // jr ra
+            0x00000000u,  // nop
+        },
+        {function_at(kBase, kBase + 12u, {kBase, kBase + 4u})});
+    expect(result.stats.functions_interpreted == 1,
+           "label-split load marks the function for interpretation");
+    expect_entry_absent(result, 0x00000500u,
+                        "label-split function is absent from dispatch");
+    expect_dispatch_key_absent(result, 0x00000504u,
+                               "label-split continuation is absent from dispatch");
+}
+
+void fragment_split_load_falls_back() {
+    const auto result = run_case(
+        "fragment-split",
+        {
+            0x8D280000u,  // fragment 1: lw t0,0(t1)
+            0x01001021u,  // fragment 2: dependent successor
+            0x03E00008u,  // jr ra
+            0x00000000u,  // nop
+        },
+        {
+            function_at(kBase, kBase, {kBase}),
+            function_at(kBase + 4u, kBase + 12u, {kBase + 4u}),
+        });
+    expect(result.stats.functions_interpreted == 1,
+           "fragment-split load marks only its owning function for interpretation");
+    expect(result.stats.functions_emitted == 1,
+           "unaffected neighboring fragment remains native");
+    expect_entry_absent(result, 0x00000500u,
+                        "fragment-split load owner is absent from dispatch");
+}
+
+void noncomplementary_lwl_falls_back() {
+    const auto result = run_case(
+        "lwl-dependent",
+        {
+            0x89280000u,  // lwl t0,0(t1)
+            0x01001021u,  // addu v0,t0,zero -- dependent, not lwr
+            0x03E00008u,  // jr ra
+            0x00000000u,  // nop
+        },
+        {function_at(kBase, kBase + 12u, {kBase})});
+    expect(result.stats.functions_interpreted == 1,
+           "non-complementary LWL dependency falls back");
+    expect_entry_absent(result, 0x00000500u,
+                        "non-complementary LWL function is absent from dispatch");
+}
+
+void complementary_lwl_lwr_stays_native() {
+    const auto result = run_case(
+        "lwl-lwr",
+        {
+            0x89280000u,  // lwl t0,0(t1)
+            0x99280003u,  // lwr t0,3(t1) -- architectural forwarding pair
+            0x03E00008u,  // jr ra
+            0x00000000u,  // nop
+        },
+        {function_at(kBase, kBase + 12u, {kBase})});
+    expect(result.stats.functions_interpreted == 0,
+           "complementary LWL/LWR does not fall back");
+    expect(result.stats.functions_emitted == 1,
+           "complementary LWL/LWR remains native");
+}
+
+}  // namespace
+
+int main() {
+    BiosConfig config{};
+    config.config_path = "test://full-function-emitter";
+    config.load_address = kBase;
+    config.text_size = 0x1000u;
+    BiosAddrCopy copy;
+    copy.name = "synthetic RAM-backed BIOS code";
+    copy.rom_lo = 0x1FC00000u;
+    copy.rom_hi = 0x1FC01000u;
+    copy.ram_lo = 0x00000500u;
+    copy.runtime_base = 0x00000500u;
+    copy.key_is_ram = true;
+    config.address_copies.push_back(copy);
+    BiosAddressModel model = BiosAddressModel::from_config(config);
+    FunctionDiscovery::set_address_model(&model);
+    FullFunctionEmitter::set_address_model(&model);
+
+    delay_slot_load_falls_back();
+    label_split_load_falls_back();
+    fragment_split_load_falls_back();
+    noncomplementary_lwl_falls_back();
+    complementary_lwl_lwr_stays_native();
+
+    if (failures != 0) {
+        std::fprintf(stderr, "%d full-function emitter test(s) failed\n", failures);
+        return 1;
+    }
+    std::puts("Full-function emitter fail-closed tests passed");
+    return 0;
+}


### PR DESCRIPTION
## Summary

- fail closed when the full-function BIOS emitter finds a load-delay shape it cannot model
- omit the affected function and its continuation keys from native dispatch so RAM-backed BIOS code uses the interpreter
- keep unsupported-instruction fatal stubs separate from correctness fallbacks
- refuse generation for an unsafe pure-ROM function, where the RAM interpreter is unavailable
- report interpreter fallbacks in the CLI and a generated `*_interpreted_functions.json`

The original Medal of Honor regression in #106 was withdrawn; this PR addresses the remaining confirmed emitted-code-versus-hardware divergence without relying on that repro.

## Validation

- built all recompiler targets
- focused `full_function_emitter_test` passes
- existing `recompiler_patch_test` passes
- OpenBIOS full regeneration succeeds: 650 emitted, 0 interpreted, 4 pre-existing unsupported skips
- full CTest: 37/43 pass; the six failures are unrelated existing runtime guard/host-encoding expectations

Synthetic coverage includes:

- load in a branch delay slot with a dependent successor
- dependent pair split by a label
- dependent pair crossing a fragment boundary
- non-complementary LWL/LWR dependency
- complementary LWL/LWR remaining native
- entry and continuation dispatch-key exclusion

Closes #106.
