### PR TITLE
Bound overlay captures and compact legacy vaults

### DIFF
--- a/runtime/src/overlay_capture.c
+++ b/runtime/src/overlay_capture.c
@@ -784,7 +784,38 @@ static uint64_t write_and_commit_snapshot(uint32_t bw,
     return capture_commit_temp(temp_path, reason, sequence);
 }
 
-static uint64_t overlay_capture_write_current(const char *reason)
+static void capture_executed_pages(uint32_t *bitmap, uint32_t bw,
+                                   const uint32_t *exec_pc_bitmap,
+                                   uint32_t scope_lo, uint32_t scope_hi,
+                                   int include_halo)
+{
+    const uint32_t ram_size = 2u * 1024u * 1024u;
+    memset(bitmap, 0, (size_t)bw * sizeof(uint32_t));
+    if (scope_hi > ram_size) scope_hi = ram_size;
+    if (scope_lo >= scope_hi) return;
+    uint32_t first_page = scope_lo >> 12;
+    uint32_t last_page = (scope_hi - 1u) >> 12;
+    uint32_t scan_lo = include_halo && first_page ? first_page - 1u : first_page;
+    uint32_t scan_hi = include_halo && last_page + 1u < ram_size / 4096u
+                     ? last_page + 1u : last_page;
+    for (uint32_t page = scan_lo; page <= scan_hi; page++) {
+        uint32_t first_exec_word = page * (4096u / 4u);
+        int observed = 0;
+        for (uint32_t b = 0; b < 4096u / 4u / 32u; b++) {
+            if (exec_pc_bitmap[(first_exec_word >> 5) + b]) {
+                observed = 1;
+                break;
+            }
+        }
+        if (observed && (page >> 5) < bw)
+            bitmap[page >> 5] |= 1u << (page & 31u);
+    }
+}
+
+static uint64_t overlay_capture_write_current(const char *reason,
+                                              uint32_t scope_lo,
+                                              uint32_t scope_hi,
+                                              int include_halo)
 {
     extern uint8_t *memory_get_ram_ptr(void);
     uint32_t bw = dirty_ram_get_bitmap_word_count();
@@ -793,7 +824,8 @@ static uint64_t overlay_capture_write_current(const char *reason)
     if (!s_active) return 0;
     bitmap = (uint32_t *)malloc((size_t)bw * sizeof(uint32_t));
     if (!bitmap) return 0;
-    for (uint32_t i = 0; i < bw; i++) bitmap[i] = dirty_ram_get_bitmap_word(i);
+    capture_executed_pages(bitmap, bw, g_dirty_ram_exec_pc_bitmap,
+                           scope_lo, scope_hi, include_halo);
     sig = write_and_commit_snapshot(bw, bitmap,
                                     g_dirty_ram_dispatch_pc_bitmap,
                                     g_dirty_ram_exec_pc_bitmap,
@@ -806,7 +838,12 @@ static uint64_t overlay_capture_write_current(const char *reason)
 
 void overlay_capture_write_json(void)
 {
-    (void)overlay_capture_write_current("shutdown-or-manual");
+    /* Sticky dirty pages describe everything written since boot. They do not
+     * describe a coherent code variant: mutable data between two code pages
+     * can otherwise merge them into a giant region that changes every run.
+     * Final/manual captures use the same executed-page scope as autocapture. */
+    (void)overlay_capture_write_current("shutdown-or-manual",
+                                        0, 2u * 1024u * 1024u, 0);
 }
 
 void overlay_capture_before_dma(uint32_t load_addr, uint32_t size)
@@ -845,7 +882,8 @@ void overlay_capture_before_dma(uint32_t load_addr, uint32_t size)
          * Fall back to a synchronous durable commit rather than let the RAM
          * overwrite bind old evidence to new bytes. If storage itself fails,
          * report the unavoidable loss but still clear the stale association. */
-        if (!overlay_capture_write_current("preserve-sync-fallback"))
+        if (!overlay_capture_write_current("preserve-sync-fallback",
+                                           evidence_lo, evidence_hi, 1))
             fprintf(stderr,
                 "psxrecomp: ERROR: could not preserve outgoing overlay evidence; discarding stale epoch\n");
     }
@@ -1088,46 +1126,10 @@ static AutocapWriteJob *capture_snapshot_create(uint32_t scope_lo,
     memcpy(job->exec_pc_bitmap, g_dirty_ram_exec_pc_bitmap,
            sizeof(g_dirty_ram_exec_pc_bitmap));
     if (scoped) {
-        memset(job->bitmap, 0, (size_t)bw * sizeof(uint32_t));
-        uint32_t first_page = scope_lo >> 12;
-        uint32_t last_page = (scope_hi - 1u) >> 12;
-        for (uint32_t page = first_page; page <= last_page; page++) {
-            uint32_t first_exec_word = page * (4096u / 4u);
-            int observed = 0;
-            for (uint32_t b = 0; b < 4096u / 4u / 32u; b++) {
-                if (job->exec_pc_bitmap[(first_exec_word >> 5) + b]) {
-                    observed = 1;
-                    break;
-                }
-            }
-            if (observed)
-                job->bitmap[page >> 5] |= 1u << (page & 31u);
-        }
-        /* Preserve a one-page EXECUTED halo on both sides of a scoped DMA
-         * overwrite.  The overwritten page can contain either the ...FFC
-         * control transfer or the ...000 delay slot; the paired instruction
-         * may live in the neighboring page and must come from this same
-         * coherent pre-write RAM snapshot.  Only executed neighbors qualify,
-         * so a sector overwrite cannot pull unrelated dirty history into an
-         * unbounded capture.  Evidence clearing remains limited to the pages
-         * actually overwritten by DMA. */
-        uint32_t halo_lo = first_page > 0u ? first_page - 1u : first_page;
-        uint32_t ram_pages = (uint32_t)(ram_size >> 12);
-        uint32_t halo_hi = last_page + 1u < ram_pages
-                         ? last_page + 1u : last_page;
-        for (uint32_t page = halo_lo; page <= halo_hi; page++) {
-            if (page >= first_page && page <= last_page) continue;
-            uint32_t first_exec_word = page * (4096u / 4u);
-            int observed = 0;
-            for (uint32_t b = 0; b < 4096u / 4u / 32u; b++) {
-                if (job->exec_pc_bitmap[(first_exec_word >> 5) + b]) {
-                    observed = 1;
-                    break;
-                }
-            }
-            if (observed)
-                job->bitmap[page >> 5] |= 1u << (page & 31u);
-        }
+        /* DMA preservation includes a one-page executed halo so an ...FFC
+         * control transfer and its ...000 delay slot remain coherent. */
+        capture_executed_pages(job->bitmap, bw, job->exec_pc_bitmap,
+                               scope_lo, scope_hi, 1);
     } else {
         for (uint32_t i = 0; i < bw; i++)
             job->bitmap[i] = dirty_ram_get_bitmap_word(i);
@@ -1141,8 +1143,7 @@ static int autocap_write_start(void)
 {
     /* Periodic convergence needs executed code, not every sticky dirty page in
      * RAM. Evidence-scoping keeps the background manifest proportional to live
-     * coverage and avoids multi-megabyte rewrites every cooldown. Shutdown still
-     * emits the legacy full current snapshot once. */
+     * coverage and avoids multi-megabyte rewrites every cooldown. */
     AutocapWriteJob *job = capture_snapshot_create(
         0, 2u * 1024u * 1024u, 1);
     if (!job) return 0;

--- a/runtime/tests/test_overlay_capture_retry.cpp
+++ b/runtime/tests/test_overlay_capture_retry.cpp
@@ -62,6 +62,11 @@ void set_exec(uint32_t phys) {
     g_dirty_pages[page >> 5] |= 1u << (page & 31u);
 }
 
+void set_dirty_page(uint32_t phys) {
+    const uint32_t page = phys >> 12;
+    g_dirty_pages[page >> 5] |= 1u << (page & 31u);
+}
+
 bool wait_for_failed_write() {
     for (int i = 0; i < 200; ++i) {
         overlay_autocapture_tick();
@@ -173,6 +178,16 @@ int main() {
         return fail("provider spawn failure was not retried exactly once", root);
     if (!bit_is_set(g_dirty_ram_exec_pc_bitmap, 0x10004u))
         return fail("provider retry mutated the newer live epoch", root);
+
+    /* A dirty but never-executed neighbor must not inflate the final snapshot
+     * into a mutable multi-page region. This is the shutdown path that made
+     * long coverage sessions grow by gigabytes. */
+    set_dirty_page(0x11000u);
+    g_ram[0x11000] = 0x77;
+    overlay_capture_write_json();
+    const std::string final_epoch = read_all(capture);
+    if (final_epoch.find("\"size\": 8196") != std::string::npos)
+        return fail("final snapshot included dirty unexecuted pages", root);
 
     overlay_capture_wait_pending();
     std::filesystem::remove_all(root, ignored);

--- a/tools/coverage_vault.py
+++ b/tools/coverage_vault.py
@@ -23,13 +23,19 @@ Usage:
   coverage_vault.py merge --vault DIR [--captures captures.json]
                           [--addendum captures.addendum.jsonl] [--cache CACHE_DIR]
   coverage_vault.py stats --vault DIR
+  coverage_vault.py compact --vault DIR --output compacted.json
+  coverage_vault.py compact --vault DIR --apply
+                            [--prune-cache] [--prune-stale-temp]
+                            [--drop-invalid-evidence]
   coverage_vault.py compact-addendum --addendum captures.addendum.jsonl
                                       --persist-dir IMMUTABLE_DIR
 """
-import argparse, json, os, shutil, hashlib, sys, contextlib
+import argparse, base64, json, os, shutil, hashlib, sys, contextlib, re, time
 
 CAP_NAME = "overlay_captures.json"
 CACHE_SUB = "cache"
+EVIDENCE_FIELDS = ("executed_pcs", "dispatch_entry_pcs",
+                   "static_dispatch_entry_pcs", "function_entry_pcs", "seeds")
 
 def _variant_key(region):
     b = region.get("bytes_b64", "") or ""
@@ -67,6 +73,190 @@ def _load_list(path):
                     tgt[fld] = sorted(set(tgt.get(fld, [])) |
                                       set(r.get(fld, [])))
     return list(index.values())
+
+def _iter_json_array(path, chunk_size=1024 * 1024):
+    """Stream objects from a top-level JSON array without loading the file.
+
+    Legacy Tomba 2 manifests exceeded 1 GiB and contain tens of millions of PC
+    strings. json.load() expands those strings several-fold in memory, which is
+    exactly why interrupted merges left multi-gigabyte temporary files behind.
+    """
+    decoder = json.JSONDecoder()
+    with open(path, encoding="utf-8") as source:
+        buffer = ""
+        eof = False
+
+        def fill():
+            nonlocal buffer, eof
+            chunk = source.read(chunk_size)
+            if chunk:
+                buffer += chunk
+            else:
+                eof = True
+
+        fill()
+        while not buffer.strip() and not eof:
+            fill()
+        start = len(buffer) - len(buffer.lstrip())
+        if start >= len(buffer) or buffer[start] != "[":
+            raise ValueError("root is not a JSON array: %s" % path)
+        buffer = buffer[start + 1:]
+        expect_value = True
+        while True:
+            while True:
+                stripped = buffer.lstrip()
+                buffer = stripped
+                if buffer or eof:
+                    break
+                fill()
+            if not buffer:
+                raise ValueError("unterminated JSON array: %s" % path)
+            if buffer[0] == "]":
+                if buffer[1:].strip() or not eof:
+                    tail = buffer[1:] + source.read()
+                    if tail.strip():
+                        raise ValueError("trailing data after JSON array: %s" % path)
+                return
+            if not expect_value:
+                if buffer[0] != ",":
+                    raise ValueError("expected ',' between array items: %s" % path)
+                buffer = buffer[1:]
+                expect_value = True
+                continue
+            while True:
+                try:
+                    value, end = decoder.raw_decode(buffer)
+                    break
+                except json.JSONDecodeError:
+                    if eof:
+                        raise ValueError("invalid or truncated JSON array: %s" % path)
+                    fill()
+            if not isinstance(value, dict):
+                raise ValueError("capture array item is not an object: %s" % path)
+            yield value
+            buffer = buffer[end:]
+            expect_value = False
+
+def _address(value, field):
+    try:
+        return int(value, 0) if isinstance(value, str) else int(value)
+    except (TypeError, ValueError):
+        raise ValueError("invalid %s address: %r" % (field, value))
+
+def _compact_region(region, drop_invalid_evidence=False):
+    """Split one legacy broad capture into execution-evidence page runs.
+
+    The four-byte tail matches write_json_window(): a branch in the last word
+    of a retained page needs the next page's delay-slot instruction. Every
+    evidence address must lie in the original byte image; malformed input fails
+    closed rather than silently losing coverage.
+    """
+    load = _address(region.get("load_addr"), "load_addr")
+    size = region.get("size")
+    if not isinstance(size, int) or size <= 0:
+        raise ValueError("invalid capture size at 0x%08X: %r" % (load, size))
+    try:
+        image = base64.b64decode(region.get("bytes_b64", ""), validate=True)
+    except Exception as exc:
+        raise ValueError("invalid bytes_b64 at 0x%08X: %s" % (load, exc))
+    if len(image) != size:
+        raise ValueError("capture size mismatch at 0x%08X: size=%d bytes=%d" %
+                         (load, size, len(image)))
+    phys_lo = load & 0x1FFFFF
+    phys_hi = phys_lo + size
+    if phys_hi > 2 * 1024 * 1024:
+        raise ValueError("capture exceeds PSX RAM at 0x%08X" % load)
+
+    parsed = {}
+    pages = set()
+    evidence_entries = 0
+    invalid_evidence = 0
+    for field in EVIDENCE_FIELDS:
+        values = region.get(field, []) or []
+        if not isinstance(values, list):
+            raise ValueError("%s is not a list at 0x%08X" % (field, load))
+        entries = []
+        for value in values:
+            address = _address(value, field)
+            phys = address & 0x1FFFFF
+            if phys < phys_lo or phys >= phys_hi or (phys & 3):
+                if not drop_invalid_evidence:
+                    raise ValueError(
+                        "%s address 0x%08X is outside/alignment-invalid for "
+                        "capture 0x%08X+%d (use --drop-invalid-evidence only "
+                        "for a known-corrupt legacy vault)" %
+                        (field, address, load, size))
+                invalid_evidence += 1
+                continue
+            entries.append((phys, "0x%08X" % address))
+            pages.add(phys >> 12)
+            evidence_entries += 1
+        parsed[field] = entries
+    if not pages:
+        return [], evidence_entries, invalid_evidence
+
+    ordered = sorted(pages)
+    runs = []
+    first = previous = ordered[0]
+    for page in ordered[1:] + [None]:
+        if page is not None and page == previous + 1:
+            previous = page
+            continue
+        run_lo = max(phys_lo, first << 12)
+        run_hi = min(phys_hi, ((previous + 1) << 12) + 4)
+        compact = {k: v for k, v in region.items()
+                   if k not in EVIDENCE_FIELDS and
+                      k not in ("load_addr", "size", "bytes_b64")}
+        compact["load_addr"] = "0x%08X" % (load + run_lo - phys_lo)
+        compact["size"] = run_hi - run_lo
+        compact["bytes_b64"] = base64.b64encode(
+            image[run_lo - phys_lo:run_hi - phys_lo]).decode("ascii")
+        for field in EVIDENCE_FIELDS:
+            compact[field] = sorted({text for phys, text in parsed[field]
+                                     if run_lo <= phys < run_hi})
+        runs.append(compact)
+        if page is None:
+            break
+        first = previous = page
+    return runs, evidence_entries, invalid_evidence
+
+def compact_capture_manifest(source, output=None, drop_invalid_evidence=False):
+    """Stream, crop, and content-deduplicate a legacy capture manifest."""
+    index = {}
+    stats = {"source_regions": 0, "source_bytes": 0,
+             "source_evidence_entries": 0, "invalid_evidence_entries": 0,
+             "dropped_data_regions": 0}
+    for region in _iter_json_array(source):
+        stats["source_regions"] += 1
+        stats["source_bytes"] += int(region.get("size", 0) or 0)
+        compacted, evidence_entries, invalid_evidence = _compact_region(
+            region, drop_invalid_evidence)
+        stats["source_evidence_entries"] += evidence_entries
+        stats["invalid_evidence_entries"] += invalid_evidence
+        if not compacted:
+            stats["dropped_data_regions"] += 1
+        for record in compacted:
+            key = _variant_key(record)
+            if key not in index:
+                index[key] = record
+                continue
+            target = index[key]
+            for field in EVIDENCE_FIELDS:
+                target[field] = sorted(set(target.get(field, [])) |
+                                       set(record.get(field, [])))
+    records = sorted(index.values(), key=lambda r: (
+        _address(r.get("load_addr"), "load_addr"), _variant_key(r)))
+    stats["output_variants"] = len(records)
+    stats["output_bytes"] = sum(r["size"] for r in records)
+    stats["output_evidence_entries"] = sum(
+        len(r.get(field, [])) for r in records for field in EVIDENCE_FIELDS)
+    stats["max_output_region"] = max((r["size"] for r in records), default=0)
+    if stats["source_evidence_entries"] and not records:
+        raise RuntimeError("compaction lost all execution evidence")
+    if output:
+        os.makedirs(os.path.dirname(os.path.abspath(output)), exist_ok=True)
+        _atomic_write_json(output, records)
+    return records, stats
 
 def _load_addendum(path):
     """Load every valid append-only history record, ignoring a torn tail.
@@ -378,14 +568,105 @@ def cmd_stats(vault):
     print("  captures: %d variant(s), %d executed PC(s)" % (len(regs), pcs))
     print("  cache:    %d DLL(s)" % ndll)
 
+def _print_compact_stats(source, stats):
+    print("coverage_vault: compacted analysis for %s" % source)
+    print("  regions: %d -> %d (%d data-only dropped)" %
+          (stats["source_regions"], stats["output_variants"],
+           stats["dropped_data_regions"]))
+    print("  bytes:   %d -> %d (saved %d; max output region %d)" %
+          (stats["source_bytes"], stats["output_bytes"],
+           stats["source_bytes"] - stats["output_bytes"],
+           stats["max_output_region"]))
+    print("  evidence entries: %d source -> %d deduplicated" %
+          (stats["source_evidence_entries"],
+           stats["output_evidence_entries"]))
+    if stats["invalid_evidence_entries"]:
+        print("  invalid legacy evidence dropped: %d" %
+              stats["invalid_evidence_entries"])
+
+def _prune_stale_manifest_temps(vault_json, minimum_age_hours=24):
+    directory = os.path.dirname(vault_json) or "."
+    basename = os.path.basename(vault_json)
+    pattern = re.compile(re.escape(basename) + r"\.\d+\.tmp$")
+    cutoff = time.time() - minimum_age_hours * 3600
+    removed = []
+    for name in os.listdir(directory):
+        path = os.path.join(directory, name)
+        if (pattern.fullmatch(name) and os.path.isfile(path) and
+                os.path.getmtime(path) <= cutoff):
+            size = os.path.getsize(path)
+            os.unlink(path)
+            removed.append((path, size))
+    return removed
+
+def cmd_compact(vault, output=None, apply=False, prune_cache=False,
+                prune_stale_temp=False, stale_temp_hours=24,
+                drop_invalid_evidence=False):
+    vault = os.path.abspath(vault)
+    source = os.path.join(vault, CAP_NAME)
+    if not os.path.isfile(source):
+        raise ValueError("vault manifest does not exist: %s" % source)
+    if apply and output:
+        raise ValueError("compact accepts either --apply or --output, not both")
+    if not apply and not output:
+        raise ValueError("compact requires --output for a preview or --apply")
+    if (prune_cache or prune_stale_temp) and not apply:
+        raise ValueError("pruning requires --apply")
+
+    if apply:
+        with _exclusive_lock(source):
+            records, stats = compact_capture_manifest(
+                source, drop_invalid_evidence=drop_invalid_evidence)
+            _atomic_write_json(source, records)
+            removed_temps = (_prune_stale_manifest_temps(
+                source, stale_temp_hours) if prune_stale_temp else [])
+            cache = os.path.join(vault, CACHE_SUB)
+            cache_bytes = 0
+            cache_files = 0
+            if prune_cache and os.path.isdir(cache):
+                for root, _dirs, files in os.walk(cache):
+                    for name in files:
+                        path = os.path.join(root, name)
+                        cache_files += 1
+                        cache_bytes += os.path.getsize(path)
+                shutil.rmtree(cache)
+    else:
+        records, stats = compact_capture_manifest(
+            source, output, drop_invalid_evidence)
+        removed_temps = []
+        cache_bytes = cache_files = 0
+
+    _print_compact_stats(source, stats)
+    if output:
+        print("  preview: %s" % os.path.abspath(output))
+    if removed_temps:
+        print("  stale temp files removed: %d (%d bytes)" %
+              (len(removed_temps), sum(size for _path, size in removed_temps)))
+    if cache_files:
+        print("  obsolete cache files removed: %d (%d bytes)" %
+              (cache_files, cache_bytes))
+    return stats
+
 def main():
     ap = argparse.ArgumentParser()
-    ap.add_argument("cmd", choices=["merge", "stats", "compact-addendum"])
+    ap.add_argument("cmd", choices=["merge", "stats", "compact",
+                                    "compact-addendum"])
     ap.add_argument("--vault", help="vault directory (kept gitignored/private)")
     ap.add_argument("--captures", help="source overlay_captures.json to merge in")
     ap.add_argument("--addendum", help="append-only overlay capture history (.jsonl)")
     ap.add_argument("--cache", help="source cache dir (e.g. build/cache/<game_id>) to merge in")
     ap.add_argument("--persist-dir", help="immutable capture snapshot directory")
+    ap.add_argument("--output", help="write a compacted preview here; leaves vault unchanged")
+    ap.add_argument("--apply", action="store_true",
+                    help="atomically replace the vault manifest with compacted evidence")
+    ap.add_argument("--prune-cache", action="store_true",
+                    help="with --apply, remove old content-keyed cache generations")
+    ap.add_argument("--prune-stale-temp", action="store_true",
+                    help="with --apply, remove old <manifest>.<pid>.tmp files")
+    ap.add_argument("--stale-temp-hours", type=float, default=24,
+                    help="minimum age for --prune-stale-temp (default: 24)")
+    ap.add_argument("--drop-invalid-evidence", action="store_true",
+                    help="drop impossible unaligned/out-of-region PCs from a known-corrupt legacy vault")
     a = ap.parse_args()
     if a.cmd == "compact-addendum":
         if not a.addendum or not a.persist_dir:
@@ -394,6 +675,14 @@ def main():
         return 0
     if not a.vault:
         ap.error("%s requires --vault" % a.cmd)
+    if a.cmd == "compact":
+        try:
+            cmd_compact(a.vault, a.output, a.apply, a.prune_cache,
+                        a.prune_stale_temp, a.stale_temp_hours,
+                        a.drop_invalid_evidence)
+        except (ValueError, RuntimeError) as exc:
+            ap.error(str(exc))
+        return 0
     if a.cmd == "stats":
         cmd_stats(a.vault)
         return 0

--- a/tools/test_coverage_vault.py
+++ b/tools/test_coverage_vault.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import importlib.util
+import base64
 import json
 import os
 import pathlib
@@ -16,6 +17,72 @@ SPEC.loader.exec_module(MOD)
 
 
 class CoverageVaultHistoryTests(unittest.TestCase):
+    def test_streaming_array_reader_handles_chunk_boundaries(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            source = os.path.join(tmp, "large.json")
+            records = [{"value": "x" * 100}, {"value": "y" * 137}]
+            with open(source, "w", encoding="utf-8") as out:
+                json.dump(records, out)
+            self.assertEqual(list(MOD._iter_json_array(source, chunk_size=7)),
+                             records)
+
+    def test_compaction_splits_execution_pages_and_collapses_mutable_gap(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            source = os.path.join(tmp, "overlay_captures.json")
+            output = os.path.join(tmp, "compacted.json")
+            first = bytearray(3 * 4096)
+            second = bytearray(first)
+            first[0:4] = second[0:4] = b"CODE"
+            first[8192:8196] = second[8192:8196] = b"TAIL"
+            first[4096 + 100] = 0x11
+            second[4096 + 100] = 0x22  # mutable, never-executed middle page
+            records = []
+            for image, dispatch in ((first, "0x80010000"),
+                                    (second, "0x80012000")):
+                records.append({
+                    "schema": "psxrecomp overlay capture v2",
+                    "load_addr": "0x80010000", "size": len(image),
+                    "bytes_b64": base64.b64encode(image).decode("ascii"),
+                    "executed_pcs": ["0x80010000", "0x80012000"],
+                    "dispatch_entry_pcs": [dispatch],
+                    "function_entry_pcs": [], "seeds": [dispatch],
+                })
+            with open(source, "w", encoding="utf-8") as out:
+                json.dump(records, out)
+            compacted, stats = MOD.compact_capture_manifest(source, output)
+            self.assertEqual(stats["source_regions"], 2)
+            self.assertEqual(stats["output_variants"], 2)
+            self.assertEqual(stats["max_output_region"], 4100)
+            self.assertEqual([r["load_addr"] for r in compacted],
+                             ["0x80010000", "0x80012000"])
+            self.assertEqual(compacted[0]["size"], 4100)
+            self.assertEqual(compacted[1]["size"], 4096)
+            self.assertEqual(compacted[0]["dispatch_entry_pcs"],
+                             ["0x80010000"])
+            self.assertEqual(compacted[1]["dispatch_entry_pcs"],
+                             ["0x80012000"])
+            self.assertEqual(base64.b64decode(compacted[0]["bytes_b64"])[:4],
+                             b"CODE")
+            self.assertEqual(base64.b64decode(compacted[1]["bytes_b64"])[:4],
+                             b"TAIL")
+            with open(output, encoding="utf-8") as saved:
+                self.assertEqual(json.load(saved), compacted)
+
+    def test_compaction_fails_closed_on_out_of_region_evidence(self):
+        image = bytes(4096)
+        region = {
+            "load_addr": "0x80010000", "size": len(image),
+            "bytes_b64": base64.b64encode(image).decode("ascii"),
+            "executed_pcs": ["0x80012000"],
+        }
+        with self.assertRaisesRegex(ValueError, "outside/alignment-invalid"):
+            MOD._compact_region(region)
+        compacted, evidence, invalid = MOD._compact_region(
+            region, drop_invalid_evidence=True)
+        self.assertEqual(compacted, [])
+        self.assertEqual(evidence, 0)
+        self.assertEqual(invalid, 1)
+
     def test_capture_merge_preserves_static_dispatch_provenance(self):
         with tempfile.TemporaryDirectory() as tmp:
             vault = os.path.join(tmp, 'captures.json')


### PR DESCRIPTION
## Summary

- scope final/manual overlay captures to pages with execution evidence, matching periodic captures
- preserve the executed neighbor-page halo used for MIPS delay slots during DMA handoff
- add a streaming, fail-closed vault compactor with optional cache and stale-temp cleanup

This addresses the capture-growth problem uncovered while investigating #92. It does not claim to complete the separate perspective/geometry work.

## Tomba 2 result

- capture variants: 1,693 -> 661
- captured byte payload: 494,376,512 -> 54,475,340
- manifest on disk: 1.145 GB -> 189.9 MB
- whole vault after current cache rebuild: 242.2 MB (previously about 9.28 GB)
- removed 11 abandoned temp writes (7.31 GB) and rebuilt 256 unique current cache DLLs

Five impossible, unaligned/out-of-region PCs in this known-corrupt legacy vault were dropped only with the explicit opt-in flag. Normal compaction fails closed on that input.

## Validation

- all 661 compacted Tomba 2 variants passed a full regeneration build
- rebuilt cache copied and SHA-256 checked: 512 DLL/ranges files, zero missing or mismatched
- `tools/test_coverage_vault.py`: 8 tests pass
- `runtime/tests/test_capture_history.py`: pass
- `overlay_capture_retry_test`: pass, including dirty-but-unexecuted shutdown coverage
- `git diff --check`: pass