### PR TITLE
Preserve $zero for COP2 register reads

### DIFF
--- a/recompiler/src/code_generator.cpp
+++ b/recompiler/src/code_generator.cpp
@@ -1500,17 +1500,21 @@ std::string CodeGenerator::translate_instruction(uint32_t addr, uint32_t instr) 
                     const std::string gte_read = fmt::format(
                         "\n#ifdef PSX_ENABLE_BLOCK_CYCLES\n    psx_gte_read(cpu, {});\n#endif\n    ", rt);
                     if (cop_op == 0x00) { // MFC2 - move from COP2 data
-                        if (PSXRecompGTERegisters::data_read_needs_helper(static_cast<uint8_t>(rd))) {
-                            code = gte_read + fmt::format("{} = gte_read_data(cpu, {});  /* mfc2 */", reg_name(rt), rd);
-                        } else {
-                            code = gte_read + fmt::format("{} = cpu->gte_data[{}];  /* mfc2 */", reg_name(rt), rd);
-                        }
+                        const std::string value =
+                            PSXRecompGTERegisters::data_read_needs_helper(static_cast<uint8_t>(rd))
+                                ? fmt::format("gte_read_data(cpu, {})", rd)
+                                : fmt::format("cpu->gte_data[{}]", rd);
+                        code = gte_read + (rt == 0
+                            ? fmt::format("(void){};  /* mfc2 to $zero: read preserved, write discarded */", value)
+                            : fmt::format("{} = {};  /* mfc2 */", reg_name(rt), value));
                     } else if (cop_op == 0x02) { // CFC2 - move from COP2 control
-                        if (PSXRecompGTERegisters::ctrl_read_needs_helper(static_cast<uint8_t>(rd))) {
-                            code = gte_read + fmt::format("{} = gte_read_ctrl(cpu, {});  /* cfc2 */", reg_name(rt), rd);
-                        } else {
-                            code = gte_read + fmt::format("{} = cpu->gte_ctrl[{}];  /* cfc2 */", reg_name(rt), rd);
-                        }
+                        const std::string value =
+                            PSXRecompGTERegisters::ctrl_read_needs_helper(static_cast<uint8_t>(rd))
+                                ? fmt::format("gte_read_ctrl(cpu, {})", rd)
+                                : fmt::format("cpu->gte_ctrl[{}]", rd);
+                        code = gte_read + (rt == 0
+                            ? fmt::format("(void){};  /* cfc2 to $zero: read preserved, write discarded */", value)
+                            : fmt::format("{} = {};  /* cfc2 */", reg_name(rt), value));
                     } else if (cop_op == 0x04) { // MTC2 - move to COP2 data
                         if (PSXRecompGTERegisters::data_write_needs_helper(static_cast<uint8_t>(rd))) {
                             code = gte_stall + fmt::format("gte_write_data(cpu, {}, {});  /* mtc2 */", rd, reg_name(rt));

--- a/recompiler/tests/recompiler_patch_test.cpp
+++ b/recompiler/tests/recompiler_patch_test.cpp
@@ -814,6 +814,19 @@ void gte_codegen_classification_tests() {
                 all_ok = false;
             }
         };
+        const auto expect_zero_destination = [&](uint32_t word,
+                                                 const std::string& read,
+                                                 const char *kind) {
+            const std::string code = generate_first_instruction(word, {}, false);
+            if (code.find("cpu->gpr[0] =") != std::string::npos ||
+                code.find(read) == std::string::npos ||
+                code.find("psx_gte_read(cpu, 0)") == std::string::npos) {
+                fmt::print(stderr,
+                           "FAIL  full-game GTE {} reg {} writes $zero or drops read/timing\n",
+                           kind, reg);
+                all_ok = false;
+            }
+        };
 
         const uint32_t cop2 = 0x12u << 26;
         expect(cop2 | (0x00u << 21) | (2u << 16) | (uint32_t(reg) << 11),
@@ -822,6 +835,18 @@ void gte_codegen_classification_tests() {
         expect(cop2 | (0x02u << 21) | (2u << 16) | (uint32_t(reg) << 11),
                fmt::format("gte_read_ctrl(cpu, {})", reg),
                PSXRecompGTERegisters::ctrl_read_needs_helper(reg), "CFC2");
+        expect_zero_destination(
+            cop2 | (0x00u << 21) | (0u << 16) | (uint32_t(reg) << 11),
+            PSXRecompGTERegisters::data_read_needs_helper(reg)
+                ? fmt::format("gte_read_data(cpu, {})", reg)
+                : fmt::format("cpu->gte_data[{}]", reg),
+            "MFC2");
+        expect_zero_destination(
+            cop2 | (0x02u << 21) | (0u << 16) | (uint32_t(reg) << 11),
+            PSXRecompGTERegisters::ctrl_read_needs_helper(reg)
+                ? fmt::format("gte_read_ctrl(cpu, {})", reg)
+                : fmt::format("cpu->gte_ctrl[{}]", reg),
+            "CFC2");
         expect(cop2 | (0x04u << 21) | (2u << 16) | (uint32_t(reg) << 11),
                fmt::format("gte_write_data(cpu, {}", reg),
                PSXRecompGTERegisters::data_write_needs_helper(reg), "MTC2");


### PR DESCRIPTION
## Summary

- discard MFC2/CFC2 destination writes when `rt == 0` in the full-game emitter
- preserve the COP2 read expression and `psx_gte_read(cpu, 0)` timing/load-delay bookkeeping
- cover all 32 data registers and all 32 control registers with synthetic zero-destination regressions

## Why

The strict translator already uses its zero-register-aware GPR writer, but the full-game emitter assigned COP2 reads directly to `cpu->gpr[rt]`. An instruction such as `mfc2 $zero,$9` could therefore make architectural `$zero` nonzero and alter later branch behavior.

This keeps the read-side behavior and timing while enforcing the R3000A invariant that GPR 0 remains zero. It is game-agnostic and requires regeneration to affect an existing game project.

## Found in

This was encountered in **Crash Bandicoot 2: Cortex Strikes Back (USA, NTSC-U), SCUS-94154**. The same terminal failure class was also reproduced in the **USA 1997-09-30 beta**. The retail build corrupted `$zero` during the New Game intro transition and later dispatched through an invalid target. The title route passes after regeneration with this generic fix.

## Validation

- configured and built the current upstream `master` recompiler from scratch (148 build steps)
- `recompiler_patch_test`, `full_function_emitter_test`, and `l2_structural_test`: 3/3 pass
- repeated fresh clean-start title routes pass the former transition and reach controllable gameplay
- a separate save-backed route also reaches controllable gameplay

The current repository-wide CTest run is 40/47 passing, with seven unrelated failures in existing runtime/package assertions or host GCC discovery. None touches the two changed files; the three relevant recompiler tests are green.

No generated game code, disc data, BIOS data, title configuration, or other proprietary material is included.