### PR TITLE
runtime: add SBI subchannel replacements for LibCrypt

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -189,6 +189,14 @@ if(BUILD_TESTING)
     target_link_libraries(iso_reader_cdda_test PRIVATE chdr-static)
     add_test(NAME iso_reader_cdda_test COMMAND iso_reader_cdda_test)
 
+    add_executable(iso_reader_sbi_test
+        tests/test_iso_reader_sbi.cpp
+        src/iso_reader.cpp
+        src/cue_sheet.cpp)
+    target_include_directories(iso_reader_sbi_test PRIVATE include)
+    target_link_libraries(iso_reader_sbi_test PRIVATE chdr-static)
+    add_test(NAME iso_reader_sbi_test COMMAND iso_reader_sbi_test)
+
     add_executable(mod_packages_test
         tests/test_mod_packages.cpp
         src/mod_packages.cpp

--- a/runtime/include/boot_state.h
+++ b/runtime/include/boot_state.h
@@ -38,10 +38,11 @@ extern "C" {
 #define BOOT_STATE_MAGIC   0x50535842u  /* "PSXB" */
 /* v1 = incomplete RAM-only; v2 = full machine but host-struct memcpy (padding);
  * v3 = little-endian field wire (portable Win/Linux/macOS ARM);
- * v4 = v3 + optional zlib on large sections (section pad bit0 = compressed). */
-#define BOOT_STATE_VERSION 4u
-/* Older readers reject v4; load still accepts v3 uncompressed blobs. */
-#define BOOT_STATE_VERSION_MIN_READ 3u
+ * v4 = v3 + optional zlib on large sections (section pad bit0 = compressed);
+ * v5 = v4 + CD-ROM Sub-Q replacement state. */
+#define BOOT_STATE_VERSION 5u
+/* v5 intentionally breaks older savestates after the CD-ROM wire grew. */
+#define BOOT_STATE_VERSION_MIN_READ 5u
 /* Section pad bit0: payload is u32 LE uncompressed_len + zlib deflate bytes. */
 #define BOOT_STATE_SEC_ZLIB 1u
 

--- a/runtime/include/iso_reader.h
+++ b/runtime/include/iso_reader.h
@@ -1,9 +1,11 @@
 #pragma once
 
 #include <cstdint>
+#include <array>
 #include <string>
 #include <fstream>
 #include <memory>
+#include <unordered_map>
 #include <vector>
 
 /**
@@ -111,6 +113,14 @@ public:
     bool ReadRawSector(uint32_t lba, uint8_t* buffer);
 
     /**
+     * Read generated or SBI-replacement subchannel Q for a disc LBA.
+     * SBI records intentionally carry invalid CRC data; valid is false for
+     * those sectors so the CD controller can retain its last valid Q packet.
+     */
+    bool ReadSubChannelQ(uint32_t lba, uint8_t* buffer, bool* valid) const;
+    bool HasSubChannelReplacements() const { return !subq_replacements_.empty(); }
+
+    /**
      * Check if a file is currently open
      * @return true if file is open
      */
@@ -215,6 +225,8 @@ private:
      */
     BinSegment* SegmentForLBA(uint32_t lba);
 
+    bool LoadSBICompanion(const std::string& image_path);
+
     bool is_open_;
     std::string volume_id_;
     std::string bin_path_;          // first (data) segment; kept for callers
@@ -222,6 +234,7 @@ private:
     std::vector<CDTrack> tracks_;   // from the .cue TOC; >=1 entry after Open()
     std::vector<BinSegment> segments_;  // cue FILE entries in disc order; >=1 after Open()
     std::unique_ptr<CHDState> chd_; // present only for a directly mounted CHD
+    std::unordered_map<uint32_t, std::array<uint8_t, 12>> subq_replacements_;
 };
 
 } // namespace PS1

--- a/runtime/src/cdrom.c
+++ b/runtime/src/cdrom.c
@@ -36,6 +36,9 @@
 extern void* iso_open(const char* path);
 extern int iso_read_sector(void* handle, uint32_t lba, uint8_t* buffer, int size);
 extern int iso_read_raw_sector(void* handle, uint32_t lba, uint8_t* buffer, int size);
+extern int iso_read_subq(void* handle, uint32_t lba, uint8_t* buffer, int size,
+                         int* valid);
+extern int iso_has_subq_replacements(void* handle);
 extern uint32_t iso_sector_count(void* handle);
 extern void iso_close(void* handle);
 /* Multi-track TOC accessors (CD-DA / multi-track discs). track is 1-based. */
@@ -684,6 +687,18 @@ static void exec_command(uint8_t cmd);
 
 /* ISO reader */
 static void* iso_handle = NULL;
+static uint8_t last_valid_subq[12];
+static int last_valid_subq_available;
+static int subq_replacements_active;
+
+static void update_last_valid_subq(uint32_t lba) {
+    uint8_t subq[12];
+    int valid = 0;
+    if (iso_read_subq(iso_handle, lba, subq, sizeof(subq), &valid) && valid) {
+        memcpy(last_valid_subq, subq, sizeof(last_valid_subq));
+        last_valid_subq_available = 1;
+    }
+}
 
 static CDROMTraceEntry cdrom_trace[CDROM_TRACE_CAP];
 static uint64_t cdrom_trace_seq;
@@ -1316,6 +1331,7 @@ static int read_sector_at(int min, int sec, int sect) {
         } else if (!iso_read_sector(iso_handle, lba, user_data, SECTOR_SIZE)) {
             memset(user_data, 0, sizeof(user_data));
         }
+        if (subq_replacements_active) update_last_valid_subq((uint32_t)lba);
     } else {
         memset(user_data, 0, sizeof(user_data));
     }
@@ -2013,18 +2029,23 @@ static void exec_command(uint8_t cmd) {
         } else {
             lba = msf_to_lba(seek_min, seek_sec, seek_sect);
         }
-        int rm, rs, rf;
-        int am, as, af;
-        lba_to_msf(lba - track_lba, 0, &rm, &rs, &rf);
-        lba_to_msf(lba, 150, &am, &as, &af);
-        response_push(bin_to_bcd(track));
-        response_push(0x01);
-        response_push(bin_to_bcd(rm));
-        response_push(bin_to_bcd(rs));
-        response_push(bin_to_bcd(rf));
-        response_push(bin_to_bcd(am));
-        response_push(bin_to_bcd(as));
-        response_push(bin_to_bcd(af));
+        if (subq_replacements_active) update_last_valid_subq((uint32_t)lba);
+        if (subq_replacements_active && last_valid_subq_available) {
+            for (int i = 1; i <= 8; ++i) response_push(last_valid_subq[i]);
+        } else {
+            int rm, rs, rf;
+            int am, as, af;
+            lba_to_msf(lba - track_lba, 0, &rm, &rs, &rf);
+            lba_to_msf(lba, 150, &am, &as, &af);
+            response_push(bin_to_bcd(track));
+            response_push(0x01);
+            response_push(bin_to_bcd(rm));
+            response_push(bin_to_bcd(rs));
+            response_push(bin_to_bcd(rf));
+            response_push(bin_to_bcd(am));
+            response_push(bin_to_bcd(as));
+            response_push(bin_to_bcd(af));
+        }
         set_irq(CDIRQ_ACK);
         break;
     }
@@ -2478,6 +2499,9 @@ void cdrom_init(const char* cue_path) {
             iso_handle = NULL;
         }
         iso_handle = iso_open(cue_path);
+        last_valid_subq_available = 0;
+        subq_replacements_active = iso_has_subq_replacements(iso_handle);
+        if (subq_replacements_active) update_last_valid_subq(0);
     }
 
     stat_reg = has_disc() ? CDSTAT_MOTOR : CDSTAT_SHELL;
@@ -2924,6 +2948,7 @@ static int cdrom_snap_emit(PstW *w) {
     WB(response_fifo); WI(response_read); WI(response_count);
     WB(sector_buffer); WI(sector_read_pos); WI(sector_available); WI(sector_size);
     WB(last_sector_buffer); WI(last_sector_lba); WI(last_sector_size);
+    WB(last_valid_subq); WI(last_valid_subq_available);
     /* last_sector_frame is host s_frame_count — zero on the wire so netplay
      * digests/pins are not forked by present-skip / FPS skew. */
     WU(0u); W8(last_sector_mode); W8(last_sector_have_raw);
@@ -2971,6 +2996,7 @@ static int cdrom_snap_parse(PstR *r) {
     RB(response_fifo); RI(response_read); RI(response_count);
     RB(sector_buffer); RI(sector_read_pos); RI(sector_available); RI(sector_size);
     RB(last_sector_buffer); RI(last_sector_lba); RI(last_sector_size);
+    RB(last_valid_subq); RI(last_valid_subq_available);
     RU(last_sector_frame); R8(last_sector_mode); R8(last_sector_have_raw);
     R8(last_sector_raw_mode); R8(last_sector_xa_file); R8(last_sector_xa_channel);
     R8(last_sector_xa_submode); R8(last_sector_xa_coding);

--- a/runtime/src/iso_reader.cpp
+++ b/runtime/src/iso_reader.cpp
@@ -22,6 +22,33 @@ constexpr size_t RAW_DATA_OFFSET = 24;
 // Primary Volume Descriptor location
 constexpr uint32_t PVD_SECTOR = 16;
 
+constexpr uint32_t CD_FRAMES_PER_SECOND = 75;
+constexpr uint32_t CD_FRAMES_PER_MINUTE = 60 * CD_FRAMES_PER_SECOND;
+constexpr uint32_t CD_LEAD_IN_FRAMES = 2 * CD_FRAMES_PER_SECOND;
+
+static bool valid_bcd(uint8_t value) {
+    return (value & 0x0f) <= 9 && (value >> 4) <= 9;
+}
+
+static uint32_t bcd_to_binary(uint8_t value) {
+    return (value >> 4) * 10u + (value & 0x0f);
+}
+
+static uint8_t binary_to_bcd(uint32_t value) {
+    return static_cast<uint8_t>(((value / 10u) << 4) | (value % 10u));
+}
+
+static uint16_t subq_crc(const uint8_t* data) {
+    uint16_t crc = 0;
+    for (int i = 0; i < 10; ++i) {
+        crc ^= static_cast<uint16_t>(data[i]) << 8;
+        for (int bit = 0; bit < 8; ++bit)
+            crc = (crc & 0x8000) ? static_cast<uint16_t>((crc << 1) ^ 0x1021)
+                                : static_cast<uint16_t>(crc << 1);
+    }
+    return static_cast<uint16_t>(~crc);
+}
+
 enum class CHDTrackMode {
     Mode1,
     Mode1Raw,
@@ -236,6 +263,10 @@ bool ISOReader::Open(const std::string& filename) {
             root_dir_.lba = 0;
             root_dir_.size = 0;
         }
+        if (!LoadSBICompanion(filename)) {
+            Close();
+            return false;
+        }
         return true;
     }
 
@@ -337,6 +368,11 @@ bool ISOReader::Open(const std::string& filename) {
         root_dir_.size = 0;
     }
 
+    if (!LoadSBICompanion(filename)) {
+        Close();
+        return false;
+    }
+
     return true;
 }
 
@@ -349,11 +385,85 @@ void ISOReader::Close() {
     }
     segments_.clear();
     tracks_.clear();
+    subq_replacements_.clear();
     bin_path_.clear();
     volume_id_.clear();
     root_dir_.lba = 0;
     root_dir_.size = 0;
     is_open_ = false;
+}
+
+bool ISOReader::LoadSBICompanion(const std::string& image_path) {
+    std::filesystem::path path(image_path);
+    path.replace_extension(".sbi");
+    if (!std::filesystem::exists(path)) return true;
+
+    std::ifstream file(path, std::ios::binary);
+    if (!file.is_open()) return false;
+    char header[4] = {};
+    file.read(header, sizeof(header));
+    if (file.gcount() != sizeof(header) ||
+        std::memcmp(header, "SBI\0", sizeof(header)) != 0) {
+        return false;
+    }
+
+    while (true) {
+        uint8_t record[14] = {};
+        file.read(reinterpret_cast<char*>(record), sizeof(record));
+        if (file.gcount() == 0 && file.eof()) break;
+        if (file.gcount() != sizeof(record) || record[3] != 1 ||
+            !valid_bcd(record[0]) || !valid_bcd(record[1]) ||
+            !valid_bcd(record[2])) {
+            return false;
+        }
+        const uint32_t absolute_frame =
+            bcd_to_binary(record[0]) * CD_FRAMES_PER_MINUTE +
+            bcd_to_binary(record[1]) * CD_FRAMES_PER_SECOND +
+            bcd_to_binary(record[2]);
+        if (absolute_frame < CD_LEAD_IN_FRAMES) return false;
+        const uint32_t lba = absolute_frame - CD_LEAD_IN_FRAMES;
+        std::array<uint8_t, 12> subq = {};
+        std::memcpy(subq.data(), record + 4, 10);
+        const uint16_t invalid_crc = static_cast<uint16_t>(subq_crc(subq.data()) ^ 0xffff);
+        subq[10] = static_cast<uint8_t>(invalid_crc);
+        subq[11] = static_cast<uint8_t>(invalid_crc >> 8);
+        if (!subq_replacements_.emplace(lba, subq).second) return false;
+    }
+    return !subq_replacements_.empty();
+}
+
+bool ISOReader::ReadSubChannelQ(uint32_t lba, uint8_t* buffer, bool* valid) const {
+    if (!buffer || !valid || !is_open_) return false;
+    const auto replacement = subq_replacements_.find(lba);
+    if (replacement != subq_replacements_.end()) {
+        std::memcpy(buffer, replacement->second.data(), replacement->second.size());
+        *valid = false;
+        return true;
+    }
+
+    int track = 1;
+    for (const CDTrack& candidate : tracks_) {
+        if (candidate.start_lba > lba) break;
+        track = candidate.number;
+    }
+    const uint32_t track_lba = TrackStartLBA(track);
+    const uint32_t relative = lba >= track_lba ? lba - track_lba : 0;
+    const uint32_t absolute = lba + 150;
+    std::memset(buffer, 0, 12);
+    buffer[0] = TrackIsAudio(track) ? 0x01 : 0x41;
+    buffer[1] = binary_to_bcd(static_cast<uint32_t>(track));
+    buffer[2] = 0x01;
+    buffer[3] = binary_to_bcd(relative / CD_FRAMES_PER_MINUTE);
+    buffer[4] = binary_to_bcd((relative / CD_FRAMES_PER_SECOND) % 60);
+    buffer[5] = binary_to_bcd(relative % CD_FRAMES_PER_SECOND);
+    buffer[6] = binary_to_bcd(absolute / CD_FRAMES_PER_MINUTE);
+    buffer[7] = binary_to_bcd((absolute / CD_FRAMES_PER_SECOND) % 60);
+    buffer[8] = binary_to_bcd(absolute % CD_FRAMES_PER_SECOND);
+    const uint16_t crc = subq_crc(buffer);
+    buffer[10] = static_cast<uint8_t>(crc);
+    buffer[11] = static_cast<uint8_t>(crc >> 8);
+    *valid = true;
+    return true;
 }
 
 BinSegment* ISOReader::SegmentForLBA(uint32_t lba) {

--- a/runtime/src/iso_reader_c.cpp
+++ b/runtime/src/iso_reader_c.cpp
@@ -36,6 +36,20 @@ int iso_read_raw_sector(void* handle, uint32_t lba, uint8_t* buffer, int size) {
     return 1;
 }
 
+int iso_read_subq(void* handle, uint32_t lba, uint8_t* buffer, int size,
+                  int* valid) {
+    if (!handle || !buffer || size < 12 || !valid) return 0;
+    bool crc_valid = false;
+    if (!static_cast<PS1::ISOReader*>(handle)->ReadSubChannelQ(
+            lba, buffer, &crc_valid)) return 0;
+    *valid = crc_valid ? 1 : 0;
+    return 1;
+}
+
+int iso_has_subq_replacements(void* handle) {
+    return handle && static_cast<PS1::ISOReader*>(handle)->HasSubChannelReplacements();
+}
+
 uint32_t iso_sector_count(void* handle) {
     if (!handle) return 0;
     auto* reader = static_cast<PS1::ISOReader*>(handle);

--- a/runtime/tests/test_iso_reader_sbi.cpp
+++ b/runtime/tests/test_iso_reader_sbi.cpp
@@ -1,0 +1,72 @@
+#include "iso_reader.h"
+
+#include <array>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <vector>
+
+static int failures;
+
+static void check(bool condition, const char* message) {
+    if (!condition) {
+        std::cerr << "FAIL: " << message << '\n';
+        ++failures;
+    }
+}
+
+static void write_file(const std::filesystem::path& path,
+                       const std::vector<uint8_t>& bytes) {
+    std::ofstream out(path, std::ios::binary);
+    out.write(reinterpret_cast<const char*>(bytes.data()),
+              static_cast<std::streamsize>(bytes.size()));
+}
+
+int main() {
+    const auto root = std::filesystem::current_path() / "iso_reader_sbi_scratch";
+    std::filesystem::remove_all(root);
+    std::filesystem::create_directories(root);
+    const auto image = root / "protected.bin";
+    write_file(image, std::vector<uint8_t>(2352 * 20));
+
+    const std::array<uint8_t, 10> replacement = {
+        0x41, 0x01, 0x01, 0x23, 0x06, 0x05, 0x00, 0x03, 0x08, 0x01};
+    // SBI positions are absolute MSF. 00:02:00 is disc LBA zero after the
+    // standard 150-frame lead-in.
+    std::vector<uint8_t> sbi = {'S', 'B', 'I', 0, 0x00, 0x02, 0x00, 0x01};
+    sbi.insert(sbi.end(), replacement.begin(), replacement.end());
+    write_file(root / "protected.sbi", sbi);
+
+    PS1::ISOReader reader;
+    check(reader.Open(image.string()), "valid same-basename SBI mounts");
+    std::array<uint8_t, 12> subq = {};
+    bool valid = true;
+    check(reader.ReadSubChannelQ(0, subq.data(), &valid),
+          "replacement sub-Q can be read");
+    check(!valid, "SBI replacement is reported with intentionally invalid CRC");
+    check(std::equal(replacement.begin(), replacement.end(), subq.begin()),
+          "SBI replacement payload is preserved");
+
+    check(reader.ReadSubChannelQ(1, subq.data(), &valid),
+          "ordinary sub-Q can be generated");
+    check(valid, "ordinary generated sub-Q has valid CRC");
+    check(subq[0] == 0x41 && subq[1] == 0x01 && subq[2] == 0x01,
+          "generated data-track identity is correct");
+    check(subq[6] == 0x00 && subq[7] == 0x02 && subq[8] == 0x01,
+          "generated absolute position includes the 150-sector lead-in");
+    reader.Close();
+
+    write_file(root / "protected.sbi", {'B', 'A', 'D'});
+    check(!reader.Open(image.string()), "malformed SBI fails the mount closed");
+
+    std::filesystem::remove(root / "protected.sbi");
+    check(reader.Open(image.string()), "image without SBI still mounts");
+    check(!reader.HasSubChannelReplacements(),
+          "image without SBI keeps the compatibility path inactive");
+    check(reader.ReadSubChannelQ(0, subq.data(), &valid) && valid,
+          "image without SBI generates valid sub-Q");
+    reader.Close();
+    std::filesystem::remove_all(root);
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
## Summary

- load a same-basename `.sbi` companion when a disc image is mounted
- convert absolute SBI MSF positions to disc-relative LBA values
- expose replacement Sub-Q data to the CD-ROM controller
- retain the last valid Sub-Q packet when an SBI sector carries the intentional bad CRC
- fail the disc mount closed for malformed or duplicate SBI records
- keep the existing CD-ROM path inactive and unchanged when no SBI file is present

## Found in

This was encountered in **Ape Escape (Europe, PAL), SCES-01564**. Without valid LibCrypt subchannel data, the game reached its menu but disabled navigation. With this generic SBI path and the matching verified SBI file, the same build accepted input and reached playable gameplay.

No SBI data, disc image, generated game source, or title-specific behavior is included in this PR.

## Validation

- `iso_reader_sbi_test`: PASS
  - same-basename SBI intake
  - `00:02:00` absolute MSF maps to disc LBA 0
  - replacement payload and intentionally invalid CRC behavior
  - ordinary generated Sub-Q remains valid
  - malformed SBI fails closed
  - no-SBI image mounts and keeps replacement handling inactive
- Manual route: Ape Escape Europe PAL (`SCES-01564`) slow boot -> menu navigation -> gameplay: PASS
- User result: `ape escape works`

The manual result is a bounded route pass, not a full-game correctness claim.