### PR TITLE
build: keep SDL3 main implementation in one translation unit

### DIFF
--- a/runtime/include/psx_sdl.h
+++ b/runtime/include/psx_sdl.h
@@ -11,7 +11,6 @@
 #define SDL_ENABLE_OLD_NAMES
 #define SDL_FUNCTION_POINTER_IS_VOID_POINTER
 #include <SDL3/SDL.h>
-#include <SDL3/SDL_main.h>
 
 #ifndef SDL_WINDOW_SHOWN
 #define SDL_WINDOW_SHOWN 0

--- a/runtime/src/main.cpp
+++ b/runtime/src/main.cpp
@@ -89,6 +89,14 @@ extern "C" void psx_game_codegen_forward_if_built(int argc, char** argv);
 #endif
 #endif
 #include "psx_sdl.h"
+#if defined(PSX_SDL3)
+/*
+ * SDL_main.h is a single-header implementation in SDL3. Keep it in the one
+ * translation unit that defines main(); including it through psx_sdl.h makes
+ * every SDL-using source emit WinMain under MinGW.
+ */
+#include <SDL3/SDL_main.h>
+#endif
 #include "psx_sdl_audio.h"
 #if defined(PSX_WEB)
 #include <emscripten/emscripten.h>


### PR DESCRIPTION
## Summary

- remove SDL3's single-header entry-point implementation from the shared `psx_sdl.h` compatibility header
- include `SDL_main.h` only in `main.cpp`, the translation unit that owns `main()`
- restore the invariant already enforced by `test_sdl3_main_single_include.py`

## Found in

This was encountered while rebuilding **Heart of Darkness (USA, NTSC-U), SLUS-00696** with current upstream PSXRecomp and the packaged MinGW GCC toolchain. The link failed because every runtime translation unit that included `psx_sdl.h` emitted a `WinMain` definition.

The game itself does not require title-specific behavior. It reaches playable gameplay on current upstream once the generic Windows build is linked correctly.

## Validation

- `runtime/tests/test_sdl3_main_single_include.py`: failed before the change and passes after it
- fresh MinGW configure and full `psx-runtime` link: PASS
- exact fixed executable SHA-256: `5BE0C23CE2D4E7D80730D986582F14AEB9C3EC7FE9EB99EF7542073DCBF28C84`
- fresh silent headless boot: 2,147 frames, no fatal reason
- equivalent current-upstream visible control: Heart of Darkness USA slow boot -> main menu -> opening -> playable gameplay: PASS

The gameplay result is a bounded route pass, not a full-game correctness claim. No disc data, BIOS data, generated game source, or title-specific code is included.