### PR TITLE
fix(sched): require coherent deferred switch boundaries

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -35,6 +35,12 @@ if(BUILD_TESTING)
     add_test(NAME cause_ip2_combinational_test
              COMMAND cause_ip2_combinational_test)
 
+    add_executable(deferred_switch_boundary_test
+        tests/test_deferred_switch_boundary.c)
+    target_include_directories(deferred_switch_boundary_test PRIVATE include)
+    add_test(NAME deferred_switch_boundary_test
+             COMMAND deferred_switch_boundary_test)
+
     add_executable(psx_cyc_batch_test tests/test_psx_cyc_batch.c)
     target_include_directories(psx_cyc_batch_test PRIVATE include)
     target_compile_definitions(psx_cyc_batch_test PRIVATE

--- a/runtime/include/interrupts.h
+++ b/runtime/include/interrupts.h
@@ -9,6 +9,33 @@ extern "C" {
 
 struct CPUState;
 
+/* A deferred cooperative thread switch may snapshot CPUState only after the
+ * guest PC and all architectural registers reach the same committed boundary.
+ *
+ * Site 0 is an ordinary compiled block leader. Site 1 is a dirty-RAM transfer
+ * boundary after the instruction and delay slot retire. Other interpreter
+ * pump sites can still have a hidden call/return obligation.
+ *
+ * A site-1 poll can publish its resume PC before CPUState.pc reflects that
+ * boundary. Require both views to identify the same guest address. KSEG
+ * aliases are equivalent. */
+static inline int psx_deferred_switch_boundary_materialized(
+    int dirty_pump_site,
+    int dispatch_depth,
+    int call_unit_depth,
+    uint32_t cpu_pc,
+    uint32_t resume_pc)
+{
+    uint32_t resume_phys = resume_pc & 0x1FFFFFFFu;
+
+    if (dispatch_depth > 1 || call_unit_depth != 0) return 0;
+    if (resume_phys < 0x00010000u) return 0;
+    if (dirty_pump_site == 0) return 1;
+    if (dirty_pump_site != 1) return 0;
+
+    return ((cpu_pc ^ resume_pc) & 0x1FFFFFFFu) == 0u;
+}
+
 /* IRQ bit positions in I_STAT/I_MASK */
 #define IRQ_VBLANK  0
 #define IRQ_GPU     1

--- a/runtime/src/interrupts.c
+++ b/runtime/src/interrupts.c
@@ -46,6 +46,7 @@
  * static BIOS exception handler is NOT interp code, so we clear it around the
  * handler dispatch (see psx_check_interrupts). */
 extern int g_dirty_interp_active;
+extern int g_call_unit_depth;
 extern uint32_t g_dirty_safe_resume_pc;
 
 /* IRQ-delivery context ring (MMX6 VSync-vs-CD-DMA hunt; dumped via `irqctx_ring`). */
@@ -1231,10 +1232,14 @@ void psx_check_interrupts(CPUState* cpu) {
                 s_defer_switch_target  = 0;
                 s_defer_switch_from    = 0;
                 debug_server_log_thread_event(33, cpu, from_tcb, to_tcb, resume_pc);
-            } else if (g_cosim_dirty_pump_site != 0) {
-                /* Not a real suspend boundary: dirty interpreter pump sites expose
-                 * committed PCs for IRQ timing, but the matching CPUState may not
-                 * be materialized yet. */
+            } else if (!psx_deferred_switch_boundary_materialized(
+                           g_cosim_dirty_pump_site,
+                           g_psx_dispatch_depth,
+                           g_call_unit_depth,
+                           cpu->pc,
+                           resume_pc)) {
+                /* Keep the switch pending until CPUState and the published resume
+                 * PC describe one fully committed guest boundary. */
             } else if (resume_pc != 0u && (resume_pc & 0x3u) == 0u &&
                        psx_is_dispatchable(resume_pc)) {
                 /* Materialized clean boundary: re-save the deferred thread cleanly

--- a/runtime/tests/test_deferred_switch_boundary.c
+++ b/runtime/tests/test_deferred_switch_boundary.c
@@ -1,0 +1,55 @@
+#include "interrupts.h"
+
+#include <stdio.h>
+
+static int failures;
+
+#define CHECK(condition, message) do {                                      \
+    if (!(condition)) {                                                     \
+        fprintf(stderr, "FAIL: %s\n", (message));                          \
+        failures++;                                                         \
+    }                                                                       \
+} while (0)
+
+int main(void)
+{
+    CHECK(psx_deferred_switch_boundary_materialized(
+              0, 1, 0, 0u, 0x80012340u),
+          "an ordinary outermost block leader is materialized");
+    CHECK(psx_deferred_switch_boundary_materialized(
+              1, 1, 0, 0x80012340u, 0x80012340u),
+          "an exact site-1 PC match is materialized");
+    CHECK(psx_deferred_switch_boundary_materialized(
+              1, 1, 0, 0xA0012340u, 0x80012340u),
+          "KSEG aliases identify the same guest PC");
+
+    CHECK(!psx_deferred_switch_boundary_materialized(
+              1, 2, 0, 0x80012340u, 0x80012340u),
+          "a nested dispatch is not materialized");
+    CHECK(!psx_deferred_switch_boundary_materialized(
+              1, 1, 1, 0x80012340u, 0x80012340u),
+          "a live call-unit frame is not materialized");
+    CHECK(!psx_deferred_switch_boundary_materialized(
+              2, 1, 0, 0x80012340u, 0x80012340u),
+          "other dirty interpreter pump sites remain ineligible");
+    CHECK(!psx_deferred_switch_boundary_materialized(
+              1, 1, 0, 0x80012340u, 0x80056780u),
+          "different live and published PCs are not materialized");
+    CHECK(!psx_deferred_switch_boundary_materialized(
+              1, 1, 0, 0u, 0x80012340u),
+          "an unpublished live PC is not materialized");
+    CHECK(!psx_deferred_switch_boundary_materialized(
+              1, 1, 0, 0x80012340u, 0u),
+          "a missing resume PC is not materialized");
+    CHECK(!psx_deferred_switch_boundary_materialized(
+              0, 1, 0, 0u, 0x80000FF0u),
+          "low BIOS and kernel RAM remains ineligible");
+
+    if (failures != 0) {
+        fprintf(stderr, "FAILED (%d)\n", failures);
+        return 1;
+    }
+
+    printf("test_deferred_switch_boundary: all checks passed\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary

- require a coherent materialized guest boundary before a deferred thread switch
- permit title-neutral dirty-RAM transfer boundaries only when the live and published guest PCs match, allowing KSEG aliases
- add focused regression coverage for accepted and rejected boundary states

## Found in

Metal Gear Solid (Europe), Disc 1 (`SLES-01370`). During the first memory-card scan, a deferred switch could save an idle-loop resume PC together with a live callback register context. Restoring that mixed context prevented the cinematic-to-codec handoff.

## Validation

- Full 23,258-frame canonical PAL route completed with no fatal or unknown dispatch.
- Focused MinGW boundary test passed.
- Focused and six adjacent MSVC tests passed: deferred switching, CAUSE/IP2, cycle boundaries, instruction cache, chain handler, and CD-ROM IRQ mask.
- Independent control: Crash Bandicoot 2 (USA), `SCUS-94154`, completed its qualified clean Cross route through frame 8001 with no fatal or unknown dispatch.
- The implementation contains no title address, serial, region check, or game-specific switch.

## Notes

A broad MSVC build still encounters pre-existing GNU/MSVC portability failures in unchanged source. The changed `interrupts.c` compiles successfully.