### PR TITLE
recompiler: publish PC at CPS unit-edge fall-through instead of falling off

### DIFF
--- a/recompiler/src/code_generator.cpp
+++ b/recompiler/src/code_generator.cpp
@@ -2405,6 +2405,16 @@ std::string CodeGenerator::translate_basic_block(
             ss << config_.indent
                << fmt::format("func_{:08X}(cpu); return;  /* fallthrough to split piece */\n",
                               next_addr);
+        } else if (cps_enabled_) {
+            // Unit-edge fall-through with no known successor function (e.g. a
+            // partial overlay capture). Falling off the body would leave
+            // cpu->pc == 0 (the continuation-entry prologue cleared it), which
+            // the trampoline reads as a normal guest exit — a silent shutdown.
+            // Publish the PC so dispatch can route it instead.
+            ss << emit_interrupt_check(next_addr, config_.indent);
+            ss << config_.indent
+               << fmt::format("cpu->pc = 0x{:08X}u; return;  /* CPS fallthrough past unit edge */\n",
+                              next_addr);
         } else {
             ss << emit_interrupt_check(next_addr, config_.indent);
         }


### PR DESCRIPTION
## What changed and why

A basic block that ends with **no control flow, no successors, and no known function at the next address** gets only its interrupt check emitted — then the generated C function simply ends. Under CPS the continuation-entry prologue has already cleared `cpu->pc`, so when execution reaches that edge the function returns with `pc == 0` and the flat trampoline reads it as a normal guest exit: the runtime shuts down **silently** (exit code 0, no crash report, `unknown_dispatch_log` empty).

The trigger is a compile unit that does not extend past the block — typical of a **partial overlay capture** whose discovery ended mid-stream.

The fix emits `cpu->pc = next_addr; return;` at the unit edge — the same publish contract every other CPS block terminator already follows — so the trampoline can route the continuation (another overlay variant, static code, or the dirty-RAM interp). 10 insertions in `translate_basic_block`; alias-group bodies share the same block translator, so they are covered too. Legacy codegen (`PSX_CPS=0`) is byte-identical to before.

## Game-agnostic?

Yes. No title checks, no addresses, no game data — it fires on a structural CFG condition any partial overlay capture can produce on any title. It was **found on Ehrgeiz (SLUS-00809)**: the capture store held a truncated 0x3C-byte variant of a 0x144-byte function (a later capture had the full extent, byte-identical prefix). Every cold boot ran ~4.6M dispatches into module code, entered the truncated variant, walked off the edge, and exited silently at PC=0 — while savestate resumes masked the bug. With the fix, the same capture store cold-boots to gameplay. The bug reproduces identically under HLE boot-skip and pure LLE boot (`PSX_BIOS_HLE=0`); it is a codegen defect, not a backend one. (The Ehrgeiz game repo is not yet public, so no repo link — the repro above is self-contained: any truncated capture of a function whose last block falls through past the unit edge.)

## Verification

- **Codegen diff on the exact poisoned capture**: before — the function body ends with a bare `psx_check_interrupts_at(...)` and falls off; after — `cpu->pc = 0x80040004u; return;  /* CPS fallthrough past unit edge */`.
- **End to end, pixels on screen**: Ehrgeiz cold boot with the regenerated overlay cache reaches the TOP menu and arcade gameplay (screenshot-verified over the TCP debug server); savestate save/load work. Previously the silent exit was 100% reproducible on cold boot.
- **Automated tests**: `ctest` in `recompiler/build` — identical results on `master` and this branch (same set of pre-existing environment/packaging failures on both, no new failures).

## Tested on

Windows 11, recompiler built with MSVC 19.44 (VS 2022, Ninja, Release), runtime built with MinGW-w64 gcc (RelWithDebInfo). Game: Ehrgeiz SLUS-00809 (NTSC-U) — boots, intro FMV plays, menu and arcade gameplay reachable, savestates save/load, overlay autocompile pipeline active (gcc backend). Not re-tested on other game repos; risk there is bounded by the points below.

## Pin bump / regen

- Consuming the fix in a game repo requires the usual **submodule pin bump**.
- This is an **emitter change**: it bumps the overlay codegen hash, so overlay caches auto-invalidate and rebuild on first run (by design), and generated game C should be **regenerated** with the rebuilt recompiler.

## Risks / limitations

- A path that hit this edge before the fix always exited silently (or died), so the publish cannot regress previously-working behavior; worst case, a published PC that nothing can dispatch now fails **loudly** through the existing `psx_unknown_dispatch` fail-fast instead of exiting silently.
- The deeper questions of why discovery produced a truncated capture variant, and why variant selection preferred it over a newer complete one, are left open — this PR only makes the emitted code honor the CPS contract at the edge.