### PR TITLE
autocompile: PGXP load-delay shard fix, host-time capture pacing, wedge visibility

### DIFF
--- a/recompiler/src/code_generator.cpp
+++ b/recompiler/src/code_generator.cpp
@@ -1909,8 +1909,23 @@ std::string CodeGenerator::translate_basic_block(
                 const size_t pos = emitted.find(lhs);
                 if (pos != std::string::npos) {
                     const std::string temp = fmt::format("psx_ldd_{:08X}", addr);
-                    emitted.replace(pos, lhs.size(), "uint32_t " + temp + " =");
+                    // Declare the temp in the pair block, not inline at the
+                    // load: with PGXP the load already sits in its own
+                    // `{ uint32_t _pgxa = ...; <load> PGXP_LOAD(...); }`
+                    // wrapper, so an inline declaration would go out of
+                    // scope before the writeback below.
+                    emitted.replace(pos, lhs.size(), temp + " =");
+                    // Point the PGXP hook at the temp: the writeback is
+                    // deferred, so the GPR still holds the pre-load value.
+                    const std::string pgxp_tail =
+                        fmt::format(", _pgxa, cpu->gpr[{}]);", load_dest);
+                    const size_t hook = emitted.rfind(pgxp_tail);
+                    if (hook != std::string::npos)
+                        emitted.replace(hook, pgxp_tail.size(),
+                                        fmt::format(", _pgxa, {});", temp));
                     ss << config_.indent << "{ /* MIPS-I load-delay pair */\n";
+                    ss << config_.indent
+                       << fmt::format("    uint32_t {} = 0;\n", temp);
                     delayed_load_addr = addr;
                     delayed_load_dest = static_cast<uint32_t>(load_dest);
                     delayed_load_active = true;

--- a/runtime/src/debug_server.c
+++ b/runtime/src/debug_server.c
@@ -11700,6 +11700,14 @@ static void handle_autocompile_status(int id, const char *json)
     extern uint64_t overlay_autocapture_last_insns_delta(void);
     extern void overlay_autocapture_get_futility(uint32_t *backoff,
                                                  uint32_t *futile);
+    extern const char *overlay_autocapture_gate_name(void);
+    extern uint64_t overlay_autocapture_ms_since_sample(void);
+    extern void overlay_autocapture_get_gates(int *capture_active,
+                                              int *write_state,
+                                              int *write_job_pending,
+                                              unsigned *write_job_attempts,
+                                              int *provider_pending,
+                                              unsigned *provider_attempts);
     (void)json;
     int      ac_en = 0;
     uint32_t trig = 0;
@@ -11707,15 +11715,33 @@ static void handle_autocompile_status(int id, const char *json)
     uint32_t backoff = 0, futile = 0;
     overlay_autocapture_get_status(&ac_en, &trig, &delta);
     overlay_autocapture_get_futility(&backoff, &futile);
+    int cap_active = 0, wstate = 0, wjob = 0, ppend = 0;
+    unsigned wattempts = 0, pattempts = 0;
+    overlay_autocapture_get_gates(&cap_active, &wstate, &wjob, &wattempts,
+                                  &ppend, &pattempts);
+    /* Pressure sampling is host-time paced, so a long dry stretch means a
+     * tick gate latched: autocapture is wedged and nothing new will compile
+     * until restart. Say so instead of looking merely idle. */
+    uint64_t dry_ms = overlay_autocapture_ms_since_sample();
+    int wedged = (ac_en && dry_ms > 30000ull);
     char comp[4096];
     autocompile_status_json(comp, sizeof(comp));
     send_fmt("{\"id\":%d,\"ok\":true,\"autocapture_enabled\":%d,"
              "\"triggers\":%u,\"futile_skips\":%u,\"backoff_mult\":%u,"
              "\"last_pressure\":%llu,"
-             "\"last_insns_pressure\":%llu,\"compile\":%s}\n",
+             "\"last_insns_pressure\":%llu,"
+             "\"autocapture\":{\"wedged\":%d,\"gate\":\"%s\","
+             "\"ms_since_sample\":%llu,\"capture_active\":%d,"
+             "\"write_state\":%d,\"write_job_pending\":%d,"
+             "\"write_job_attempts\":%u,\"provider_pending\":%d,"
+             "\"provider_attempts\":%u},"
+             "\"compile\":%s}\n",
              id, ac_en, trig, futile, backoff,
              (unsigned long long)delta,
-             (unsigned long long)overlay_autocapture_last_insns_delta(), comp);
+             (unsigned long long)overlay_autocapture_last_insns_delta(),
+             wedged, overlay_autocapture_gate_name(),
+             (unsigned long long)dry_ms, cap_active, wstate, wjob, wattempts,
+             ppend, pattempts, comp);
 }
 
 /* (sljit removed 2026-07-15: the sljit_status, sljit_async, and sljit_try TCP

--- a/runtime/src/overlay_capture.c
+++ b/runtime/src/overlay_capture.c
@@ -938,6 +938,13 @@ int overlay_capture_count(void)
 #define AUTOCAP_MIN_DISPATCHES  128u   /* catches ~120/s FMV helper gaps    */
 #define AUTOCAP_MIN_INSNS       100000ull /* long compute gap pressure gate */
 #define AUTOCAP_COOLDOWN_FRAMES 300u   /* >= ~5 s between auto-fires        */
+/* Host-time twins of the two frame gates, at their 60 Hz equivalents. Each
+ * gate opens on whichever budget expires FIRST: frame counting alone
+ * deadlocks recovery, because the stall autocapture exists to fix is exactly
+ * when vblanks stop arriving (at 0.26 fps, 120 frames is ~8 minutes of wall
+ * clock). At full speed the budgets coincide, so cadence is unchanged. */
+#define AUTOCAP_CHECK_MS        2000ull
+#define AUTOCAP_COOLDOWN_MS     5000ull
 #define AUTOCAP_BACKOFF_MAX     64u    /* futile-retry ceiling: 64*5s ≈ 5min */
 #define AUTOCAP_WRITE_RETRY_MAX_FRAMES 60u /* cap failed-I/O retry at ~1 s */
 
@@ -957,6 +964,10 @@ static uint32_t s_autocap_futile     = 0;    /* futile skips (telemetry)      */
 static uint64_t s_autocap_provider_sig_pending = 0;
 static uint64_t s_autocap_provider_retry_frame = 0;
 static unsigned s_autocap_provider_attempts = 0;
+static uint64_t s_autocap_last_check_ms = 0; /* host twin of last_check      */
+static uint64_t s_autocap_next_ok_ms    = 0; /* host twin of next_ok         */
+
+static uint64_t autocap_now_ms(void) { return (uint64_t)SDL_GetTicks64(); }
 
 typedef struct {
     uint8_t *ram;
@@ -1065,6 +1076,8 @@ static int autocap_provider_request_try(const CodeProvider *cp, uint64_t frame)
             s_autocap_backoff <<= 1;
         s_autocap_next_ok = frame +
             (uint64_t)AUTOCAP_COOLDOWN_FRAMES * s_autocap_backoff;
+        s_autocap_next_ok_ms = autocap_now_ms() +
+            AUTOCAP_COOLDOWN_MS * (uint64_t)s_autocap_backoff;
         s_autocap_provider_sig_pending = 0;
         s_autocap_provider_retry_frame = 0;
         s_autocap_provider_attempts = 0;
@@ -1306,8 +1319,12 @@ void overlay_autocapture_tick(void)
 
     if (!s_autocap_enabled || !s_active) return;
     if (SDL_AtomicGet(&s_autocap_write_state) != 0) return;
-    if (s_frame_count - s_autocap_last_check < AUTOCAP_CHECK_FRAMES) return;
+    const uint64_t now_ms = autocap_now_ms();
+    if (s_frame_count - s_autocap_last_check < AUTOCAP_CHECK_FRAMES &&
+        now_ms - s_autocap_last_check_ms < AUTOCAP_CHECK_MS)
+        return;
     s_autocap_last_check = s_frame_count;
+    s_autocap_last_check_ms = now_ms;
 
     uint64_t disp  = g_dirty_window_dispatches;
     uint64_t delta = disp - s_autocap_last_disp;
@@ -1322,13 +1339,15 @@ void overlay_autocapture_tick(void)
         return;
     if (cdrom_load_in_progress()) return;          /* coherent moment only  */
     if (cp->busy && cp->busy()) return;
-    if (s_frame_count < s_autocap_next_ok) return; /* cooldown (x backoff)  */
+    if (s_frame_count < s_autocap_next_ok && now_ms < s_autocap_next_ok_ms)
+        return;                                    /* cooldown (x backoff)  */
 
     /* Snapshot coherent inputs for the player-shareable coverage manifest;
      * a worker writes/hashes it, then a later vblank applies futility/backoff.
      * Unchanged content with no new candidates backs off without a provider run. */
     s_autocap_last_fire = s_frame_count;
     s_autocap_next_ok = s_frame_count + AUTOCAP_COOLDOWN_FRAMES;
+    s_autocap_next_ok_ms = now_ms + AUTOCAP_COOLDOWN_MS;
     if (autocap_write_start()) {
         /* The queued job now owns this coherent evidence epoch. Start the next
          * one immediately so later periodic manifests contain only newly seen

--- a/runtime/src/overlay_capture.c
+++ b/runtime/src/overlay_capture.c
@@ -969,6 +969,24 @@ static uint64_t s_autocap_next_ok_ms    = 0; /* host twin of next_ok         */
 
 static uint64_t autocap_now_ms(void) { return (uint64_t)SDL_GetTicks64(); }
 
+/* Wedge visibility: which pre-sample gate the tick last returned at, and
+ * when the pressure sample last completed. A latched gate is silent from
+ * outside — triggers, futility and pressure counters simply stop moving —
+ * so record it and let autocompile_status report it. */
+static uint64_t s_autocap_last_sample_ms = 0;
+static int      s_autocap_gate_hit       = 0;
+
+/* Gate identifiers, in the order overlay_autocapture_tick() tests them. */
+enum {
+    AUTOCAP_GATE_NONE = 0,      /* reached the pressure sample          */
+    AUTOCAP_GATE_WRITE_JOIN,    /* worker finished, snapshot requeued   */
+    AUTOCAP_GATE_WRITE_RETRY,   /* manifest write failed, retrying      */
+    AUTOCAP_GATE_PROVIDER,      /* compile request pending              */
+    AUTOCAP_GATE_DISABLED,      /* autocapture off / capture inactive   */
+    AUTOCAP_GATE_WRITE_BUSY,    /* worker thread still running          */
+    AUTOCAP_GATE_INTERVAL,      /* check budget not yet elapsed         */
+};
+
 typedef struct {
     uint8_t *ram;
     uint32_t *dispatch_pc_bitmap;
@@ -1013,6 +1031,47 @@ uint64_t overlay_autocapture_last_insns_delta(void) {
 void overlay_autocapture_get_futility(uint32_t *backoff, uint32_t *futile) {
     if (backoff) *backoff = s_autocap_backoff;
     if (futile)  *futile  = s_autocap_futile;
+}
+
+/* Wedge report: the latched gate and time since the last completed pressure
+ * sample. Sampling is host-time paced, so a long dry stretch means a gate
+ * latched — autocapture is wedged and nothing new will ever compile — not
+ * that the game is merely slow. (Seen live: a full disk made the manifest
+ * write retry forever; the only outward symptom was "the game got slow".) */
+const char *overlay_autocapture_gate_name(void) {
+    switch (s_autocap_gate_hit) {
+    case AUTOCAP_GATE_WRITE_JOIN:  return "write-join";
+    case AUTOCAP_GATE_WRITE_RETRY: return "write-retry";
+    case AUTOCAP_GATE_PROVIDER:    return "provider-pending";
+    case AUTOCAP_GATE_DISABLED:    return "disabled";
+    case AUTOCAP_GATE_WRITE_BUSY:  return "write-busy";
+    case AUTOCAP_GATE_INTERVAL:    return "interval";
+    default:                       return "none";
+    }
+}
+
+/* Milliseconds since the last completed pressure sample; 0 before the first
+ * sample (nothing to conclude yet). */
+uint64_t overlay_autocapture_ms_since_sample(void) {
+    if (!s_autocap_last_sample_ms) return 0;
+    uint64_t now = autocap_now_ms();
+    return now > s_autocap_last_sample_ms ? now - s_autocap_last_sample_ms : 0;
+}
+
+void overlay_autocapture_get_gates(int *capture_active, int *write_state,
+                                   int *write_job_pending,
+                                   unsigned *write_job_attempts,
+                                   int *provider_pending,
+                                   unsigned *provider_attempts) {
+    if (capture_active)     *capture_active     = s_active;
+    if (write_state)        *write_state        =
+        SDL_AtomicGet(&s_autocap_write_state);
+    if (write_job_pending)  *write_job_pending  = s_autocap_write_job ? 1 : 0;
+    if (write_job_attempts) *write_job_attempts =
+        s_autocap_write_job ? s_autocap_write_job->attempts : 0u;
+    if (provider_pending)   *provider_pending   =
+        s_autocap_provider_sig_pending != 0;
+    if (provider_attempts)  *provider_attempts  = s_autocap_provider_attempts;
 }
 
 #ifdef PSX_OVERLAY_CAPTURE_TEST
@@ -1272,6 +1331,7 @@ void overlay_autocapture_tick(void)
     const CodeProvider *cp = code_provider_active();
 
     if (SDL_AtomicGet(&s_autocap_write_state) == 2) {
+        s_autocap_gate_hit = AUTOCAP_GATE_WRITE_JOIN;
         AutocapWriteJob *job = s_autocap_write_job;
         SDL_WaitThread(s_autocap_write_thread, NULL);
         s_autocap_write_thread = NULL;
@@ -1301,6 +1361,7 @@ void overlay_autocapture_tick(void)
      * not discard an already-cleared evidence epoch. Retry the same immutable
      * snapshot at bounded cadence before considering another periodic fire. */
     if (s_autocap_write_job) {
+        s_autocap_gate_hit = AUTOCAP_GATE_WRITE_RETRY;
         AutocapWriteJob *job = s_autocap_write_job;
         if (SDL_AtomicGet(&s_autocap_write_state) == 0 &&
             s_frame_count >= job->retry_frame &&
@@ -1313,18 +1374,29 @@ void overlay_autocapture_tick(void)
     }
 
     if (s_autocap_provider_sig_pending) {
+        s_autocap_gate_hit = AUTOCAP_GATE_PROVIDER;
         (void)autocap_provider_request_try(cp, s_frame_count);
         return;
     }
 
-    if (!s_autocap_enabled || !s_active) return;
-    if (SDL_AtomicGet(&s_autocap_write_state) != 0) return;
+    if (!s_autocap_enabled || !s_active) {
+        s_autocap_gate_hit = AUTOCAP_GATE_DISABLED;
+        return;
+    }
+    if (SDL_AtomicGet(&s_autocap_write_state) != 0) {
+        s_autocap_gate_hit = AUTOCAP_GATE_WRITE_BUSY;
+        return;
+    }
     const uint64_t now_ms = autocap_now_ms();
     if (s_frame_count - s_autocap_last_check < AUTOCAP_CHECK_FRAMES &&
-        now_ms - s_autocap_last_check_ms < AUTOCAP_CHECK_MS)
+        now_ms - s_autocap_last_check_ms < AUTOCAP_CHECK_MS) {
+        s_autocap_gate_hit = AUTOCAP_GATE_INTERVAL;
         return;
+    }
     s_autocap_last_check = s_frame_count;
     s_autocap_last_check_ms = now_ms;
+    s_autocap_last_sample_ms = now_ms;
+    s_autocap_gate_hit = AUTOCAP_GATE_NONE;
 
     uint64_t disp  = g_dirty_window_dispatches;
     uint64_t delta = disp - s_autocap_last_disp;


### PR DESCRIPTION
Three fixes from one investigation: an overlay autocompile pipeline that silently stopped promoting code to native, leaving every freshly loaded RAM image running in the interpreter (loads at 0.26–9 fps that recover to 60 with the pipeline healthy). One commit per fix; the first is a hard bug, the other two make the pipeline survive and diagnose the conditions the first one created.

## 1. `recompiler: scope the load-delay temp past the PGXP load wrapper`

The MIPS-I load-delay pair defers a dependent load's register writeback past its successor by assigning into a `psx_ldd_<addr>` temp. `translate_basic_block` declared that temp **inline at the load statement** — but with PGXP enabled the load has already been wrapped in its own `{ uint32_t _pgxa = ...; <load> PGXP_LOAD(...); }` block, so the declaration went out of scope before the writeback, which is emitted after the successor:

```c
{ /* MIPS-I load-delay pair */
{ uint32_t _pgxa = ...; uint32_t psx_ldd_8000362C = psx_cyc_load_word(...); PGXP_LOAD(..., cpu->gpr[26]); }
    ...successor...
    cpu->gpr[26] = psx_ldd_8000362C;  /* load-delay writeback */   // <- undeclared
}
```

gcc rejected the shard (`'psx_ldd_8000362C' undeclared`), the whole compile run exited non-zero, and after enough consecutive failures autocompile latched **degraded**: nothing was promoted to native for the rest of the session.

Fix: declare the temp at the top of the pair block that encloses both statements, and point the PGXP load hook at the temp — with the writeback deferred, the loaded value lives in the temp while the GPR still holds the old value the successor must read, so the hook previously recorded a stale pre-load shadow value (a PGXP correctness bug in its own right). Delay semantics unchanged; the `full_function_emitter` deferred-load path already uses a function-scope temp and is unaffected.

## 2. `runtime: pace autocapture gates on host time as well as vblanks`

`overlay_autocapture_tick()`'s pressure-sample and cooldown gates counted only emulated vblanks (120 / 300 frames — ~2 s / ~5 s at full speed). The situation autocapture exists to fix — a fresh RAM image with no native coverage, running interpreted — is exactly the situation where vblanks stop arriving, so recovery was throttled by the very stall it should end: at a measured 0.26 fps, one pressure sample every **~8 minutes** of wall clock and one capture fire every **~19**.

Fix: host-time twins at the 60 Hz equivalents (`AUTOCAP_CHECK_MS` 2000, `AUTOCAP_COOLDOWN_MS` 5000); each gate opens on whichever budget expires **first**. At full speed the budgets coincide, so healthy-title cadence is unchanged — behavior differs only while the guest runs slower than real time. Futility backoff multiplies the host cooldown exactly as it multiplies the frame cooldown.

## 3. `runtime: report which gate autocapture is parked on`

A latched tick gate is invisible from outside: triggers, futility and pressure counters simply stop moving, which reads as "nothing to do" while in reality no new overlay variant will ever be captured again. Observed live: a full disk made the capture manifest write fail and requeue forever, and the only outward symptom was the game getting slower with every new area.

Fix: record which gate the tick last returned at and when the last pressure sample completed; surface both through `autocompile_status` as an **additive** `"autocapture"` object — `wedged` (enabled yet no sample for 30 s), `gate`, `ms_since_sample`, plus the raw write-job/provider state. Observability only, zero behavior change; existing fields untouched.

## Game-agnostic?

Yes, all three. (1) fires on a structural emission pattern — any dependent load-delay pair compiled with PGXP hooks, any title. (2) and (3) are title-independent pipeline mechanics. All were **found on Ehrgeiz (SLUS-00809)**: a dependent `lw` pair in a kernel-window overlay failed every autocompile run (19/19), so load-screen code ran interpreted at 1.5–9 fps for minutes per load while steady gameplay held 60.

## Verification

- **(1) codegen diff on the exact failing capture**: declaration lands in the pair block, `PGXP_LOAD(..., psx_ldd_...)`, shard compiles; the full Ehrgeiz capture set builds with **0 failures** (was: every run failed) and load windows hold 60 fps (CD-burst ring: 1.5–9 fps before, 57–69 after).
- **(2) live under a stall**: pressure samples continue at ~2 s wall cadence regardless of guest fps (`ms_since_sample` never exceeded ~2 s across a 4-minute monitored session); at 60 fps, trigger cadence identical to before.
- **(3) live**: `autocompile_status` returns the new object alongside all existing fields (`{"wedged":0,"gate":"interval","ms_since_sample":1607,...}`); during the disk-full incident this state was reconstructible only by reading source.
- **Automated tests**: `ctest` in `recompiler/build` — identical results on `master` (9913b14) and this branch after each commit: same set of pre-existing environment/packaging failures, no new failures. Runtime builds clean (MinGW-w64).

## Tested on

Windows 11, recompiler MSVC 19.44 (VS 2022, Ninja, Release), runtime MinGW-w64 gcc (RelWithDebInfo). Game: Ehrgeiz SLUS-00809 (NTSC-U) — arcade and quest gameplay, overlay autocompile active (gcc backend).

## Pin bump / regen

- Usual **submodule pin bump** to consume.
- Commit 1 is an **emitter change**: overlay codegen hash bumps, caches auto-invalidate and rebuild on first run (by design); regenerate game C with the rebuilt recompiler. Commits 2–3 are runtime-only.

## Risks / limitations

- (1) A shard containing the pattern **never compiled before**, so the scoping change cannot regress a working shard. The PGXP hook retarget changes recorded shadow values only for deferred pairs, from the stale pre-load value (wrong) to the loaded value (correct).
- (2) Strictly widens when gates may open (frame budget OR host budget); it never delays a fire that would have happened. A deliberately slow guest (turbo off, pause-like states) samples on host cadence — the sample is a cheap counter read unless pressure is real.
- (3) Additive JSON only; consumers keying on existing fields are unaffected.
