### PR TITLE
runtime: swallow the overlay-closing press so it doesn't bleed into the game

### DIFF
--- a/runtime/src/main.cpp
+++ b/runtime/src/main.cpp
@@ -5811,6 +5811,8 @@ static void rewind_host_pause_loop(void) {
         rewind_pause_present();
         SDL_Delay(8);
     }
+    /* Swallow the still-held close press so it doesn't bleed into the game. */
+    savestate_input_guard_arm();
 }
 
 /* Freeze guest in vblank present while the save-state slot menu is open. */
@@ -5852,6 +5854,8 @@ static void savestate_menu_host_pause_loop(void) {
         rewind_pause_present();
         SDL_Delay(8);
     }
+    /* Swallow the close press; a just-queued save must not snapshot it. */
+    savestate_input_guard_arm();
 }
 
 /* Epilogue for netplay admit/pace AFTER all C++ RAII in the present body


### PR DESCRIPTION
## What

Four-line fix: arm the existing `savestate_input_guard_arm()` when either host pause loop (`savestate_menu_host_pause_loop`, `rewind_host_pause_loop`) hands control back to the guest — the single chokepoint every overlay close path funnels through (save, load, cancel/back, Esc, the toggle hotkey, rewind accept/cancel).

```c
    /* Swallow the close press; a just-queued save must not snapshot it. */
    savestate_input_guard_arm();
```

## Why it matters / how it showed up

The save-state slot menu and the rewind filmstrip freeze the guest in a host pause loop. The press that closes them (pad Square/Circle, or a keyboard key that is also pad-bound — the menu's save key S is bound to Circle in the default keybinds) is still physically held when the loop exits, so the game's first SIO sample after resume reads it as gameplay input. In a fighter, saving a state always throws a punch — and because the queued save executes *after* the guest resumes, the punch gets baked into the snapshot, ruining states meant to capture menus or precise situations.

## Behavior preserved (why this should be regression-safe)

- **No new mechanism.** Loads have shipped this exact guard for a while; `capture_pad_slot`'s guarded path is untouched. This only adds two more arm sites, so a menu/rewind close now behaves identically to a post-load resume.
- **Inputs cannot stick.** The guard self-limits: it drops on release after a 90 ms minimum and hard-caps at 700 ms even if the button stays held.
- **Netplay is untouched.** The netplay capture path (`capture_pad_slot_exclusive`) does not consult the guard — same as before (loads already armed it during netplay with no effect there).
- The one intentional behavior change: every overlay close now has the same ≤90 ms neutral-pad window that savestate loads have always had.

## How I verified it

All via the TCP debug server (no printf), on the game below:

- Injected real host keystrokes (SendInput scancodes, foreground window asserted) and sampled `pad_status`:
  - Control — X (bound to Cross) held during gameplay → game samples `0xBFFF`. Injection path live.
  - Bleed test — F7 opens the menu, X held, Esc closes with X still down → game samples `0xFFFF` (neutral) from the first post-close frame for ~660 ms, then the still-held key surfaces at the designed 700 ms cap (`0xBFFF`). Before this change the first post-close sample already read `0xBFFF`.
- Played it: saving a state mid-fight no longer punches, and the saved state no longer records the closing press.
- `ctest`: 46/51 pass. The 5 failures are pre-existing local-environment issues, not this change: 4 (`launcher_vulkan_option`, `mod_load_acceleration`, `release_zip`, `vk_present_wait_stage`) reproduce identically with `runtime/src/main.cpp` reverted to `origin/master` (CRLF checkout via `core.autocrlf=true` + cp1252 default-encoding `read_text`), and `aot_overlay_discovery` fails on a fresh-worktree recompiler/runtime stamp mismatch ("STALE RECOMPILER BINARY … cache tag hash 00000000") that never reads this file.
- `runtime/tests/test_rewind_toggle_combo.py` passes; builds clean (mingw64 GCC, Ninja, SDL3 runtime).

## ⚠️ Tested on Ehrgeiz ONLY

SLUS-00809 (USA), my own WIP port — no other titles were run against this branch. Safety argument for the rest: the change is host-side only, sits on the shared overlay path, and reuses the guard every game already exercises on savestate load.

## Scope notes

- **Game-agnostic**: no title check, no magic address, no per-game config.
- **Runtime-only — no regen required.** Games consume it by bumping their `psxrecomp/` submodule pointer.
- Host: Windows 11, MSYS2 mingw64 GCC, Ninja.
