### PR TITLE
cdrom: CD-DA position report interrupts (Setmode bit2) during Play

### DIFF
--- a/runtime/src/cdrom.c
+++ b/runtime/src/cdrom.c
@@ -1520,6 +1520,54 @@ static void deliver_cdda_data_end(void) {
     fire_cdrom_irq();
 }
 
+/* CD-DA position reports (Setmode bit2), psx-spx "Command 03h - Play":
+ * INT1(stat, track, index, mm/amm, ss+80h/ass, sect/asect, peaklo, peakhi)
+ * on every 10th frame of absolute time — asect BCD 00/20/40/60h absolute,
+ * 10/30/50/70h track-relative with bit7 set on the seconds byte. Peak is
+ * the sector's per-channel peak (the L/R toggle is effectively stuck on
+ * PSX, kept 0), measured pre-mute — the controller keeps processing audio
+ * while muted. A report colliding with an unacknowledged IRQ is dropped;
+ * the controller does not queue reports. */
+static void deliver_cdda_report(const int16_t* pcm) {
+    int am, as, af;
+    lba_to_msf((int)cdda_lba, 150, &am, &as, &af);
+    if (af % 10) return;
+    if (irq_flag != 0) return;
+
+    int track_lba = (int)iso_track_start_lba(iso_handle, cdda_track);
+    int index = ((int)cdda_lba >= track_lba) ? 1 : 0;
+
+    int32_t peak = 0;
+    for (int i = 0; i < CDDA_SECTOR_FRAMES; ++i) {
+        int32_t v = pcm[i * 2];
+        if (v < 0) v = -v;
+        if (v > peak) peak = v;
+    }
+    if (peak > 0x7FFF) peak = 0x7FFF;
+
+    response_clear();
+    response_push(stat_reg);
+    response_push(bin_to_bcd(cdda_track));
+    response_push(bin_to_bcd(index));
+    if ((af / 10) % 2 == 0) {
+        response_push(bin_to_bcd(am));
+        response_push(bin_to_bcd(as));
+        response_push(bin_to_bcd(af));
+    } else {
+        int rm, rs, rf;
+        int rel = (int)cdda_lba - track_lba;
+        if (rel < 0) rel = -rel;
+        lba_to_msf(rel, 0, &rm, &rs, &rf);
+        response_push(bin_to_bcd(rm));
+        response_push((uint8_t)(bin_to_bcd(rs) | 0x80u));
+        response_push(bin_to_bcd(rf));
+    }
+    response_push((uint8_t)(peak & 0xFF));
+    response_push((uint8_t)((peak >> 8) & 0x7F));
+    set_irq(CDIRQ_DATA_READY);
+    fire_cdrom_irq();
+}
+
 static int cdda_track_for_lba(uint32_t lba) {
     int count = iso_handle ? iso_track_count(iso_handle) : 0;
     int found = 0;
@@ -1590,6 +1638,8 @@ static void process_cdda_stream(uint32_t cycles) {
                 pcm[i] = (int16_t)u;
             }
         }
+
+        if (mode_reg & 0x04u) deliver_cdda_report(pcm);
 
         if (cd_muted) memset(pcm, 0, sizeof(pcm));
         cd_apply_decode_volume(pcm, CDDA_SECTOR_FRAMES);


### PR DESCRIPTION
## What / why

The CD controller had a complete CD-DA engine (decode, track advance, autopause, data-end INT) but never generated the position report interrupts hardware sends during Play when Setmode bit2 is set. A driver that mutes, starts Play in report mode, and demutes only after the first report confirms playback waits forever with music muted.

## Hardware behavior matched

psx-spx "Command 03h - Play": `INT1(stat, track, index, mm/amm, ss+80h/ass, sect/asect, peaklo, peakhi)` on every 10th frame of absolute time — asect BCD 00/20/40/60h carry absolute MSF, 10/30/50/70h carry track-relative MSF with bit7 set on the seconds byte. Peak bytes hold the sector's per-channel peak, measured pre-mute (the controller keeps processing audio while muted); the L/R toggle bit15 is effectively stuck on PSX and stays 0. Reports are never queued — one colliding with an unacknowledged IRQ is dropped.

## Verification

- Twisted Metal III (SCUS-94249, USA v1.1) — its music driver does `Stop → Mute → Setmode(0x05) → Setloc → Play` and demutes from its report handler. Traced via `cdrom_command_history`: with this change the Demute lands on the same frame as Play, and all 36 CD-DA soundtrack tracks are audible in menu/attract/gameplay. Boots, attract plays, gameplay reachable.
- `ctest` in `recompiler/build`: 33 pass; 5 failures pre-existing on this environment and unrelated (aot_overlay_discovery, launcher_vulkan_option, mod_load_acceleration, release_zip, vk_present_wait_stage) — same set fails on clean master binaries.
- Not run against Tomba/MMX6/Ape Escape locally; the change is inert unless a game enables report mode during Play (no reports were generated before, none are without bit2 now).

## Notes

- Game-agnostic: models the documented controller behavior, no title checks.
- Runtime-only (`runtime/src/cdrom.c`): no regen required; games consume via a submodule pin bump.
- Found bringing up Twisted Metal III; the game repo is not yet published — traces/notes available on request.