### PR TITLE
spu: voice start/repeat addresses ignore bit0 (16-byte-aligned fetch)

### DIFF
--- a/runtime/src/spu.c
+++ b/runtime/src/spu.c
@@ -907,8 +907,11 @@ static void key_on(uint32_t mask) {
         SpuVoice *v = &voices[i];
         memset(v, 0, sizeof(*v));
         v->active = 1;
-        v->cur_addr = ((uint32_t)voice_reg(i, 3) << 3) & (SPU_RAM_SIZE - 1u);
-        v->repeat_addr = ((uint32_t)voice_reg(i, 7) << 3) & (SPU_RAM_SIZE - 1u);
+        /* Address registers count 8-byte units but hardware ignores bit0
+         * — block fetches are 16-byte aligned (DuckStation Voice::KeyOn
+         * `adpcm_start_address & ~1u`; Beetle aligns identically). */
+        v->cur_addr = ((uint32_t)(voice_reg(i, 3) & ~1u) << 3) & (SPU_RAM_SIZE - 1u);
+        v->repeat_addr = ((uint32_t)(voice_reg(i, 7) & ~1u) << 3) & (SPU_RAM_SIZE - 1u);
         v->sample_idx = SPU_BLOCK_SAMPLES;
         /* Reset ADSR — KEYON starts envelope at 0 in Attack phase
          * (matches Beetle's PS_SPU::ResetEnvelope). */
@@ -1438,8 +1441,9 @@ void spu_write(uint32_t addr, uint32_t value) {
              * re-looping ~1400x/s, +11 dB over the oracle, clipping). */
             if (idx < (uint32_t)SPU_VOICE_COUNT * 8u && (idx & 7u) == 7u) {
                 int v = (int)(idx >> 3);
+                /* bit0 ignored (16-byte alignment) — same masking as KEYON. */
                 voices[v].repeat_addr =
-                    ((uint32_t)(uint16_t)value << 3) & (SPU_RAM_SIZE - 1u);
+                    ((uint32_t)((uint16_t)value & ~1u) << 3) & (SPU_RAM_SIZE - 1u);
             }
 
             /* Volume registers feed the sweep envelopes: a direct write


### PR DESCRIPTION
## What / why

The SPU honored bit0 of the voice start/repeat address registers (8-byte units), letting a voice begin decoding mid-block: sample bytes get parsed as ADPCM headers, which typically fabricates an END+REPEAT terminator within a few blocks and truncates or loops the sound as garbage.

## Hardware behavior matched

The registers count 8-byte units but hardware ignores the low bit — block fetches are 16-byte aligned. DuckStation implements exactly this (`Voice::KeyOn`, `adpcm_start_address & ~1u`, same masking on the repeat-address jump); Beetle aligns identically. psx-spx documents only the 8-byte units and is silent on the bit. Masked at the two intake points: KEYON latch of current/repeat, and the live repeat-register write.

## Verification

- Twisted Metal III (SCUS-94249, USA v1.1) — its sound banks pack samples at 8-byte granularity, so its tables legitimately produce odd start addresses (e.g. reg 0x2D5D → byte 0x16AE8, real stream at 0x16AE0). Unaligned, its explosion one-shots collapsed into ~10 ms looping blips heard as constant horn-like noise; every broken sample started at a `...8` address, every healthy one at `...0`. Offline ADPCM decode of the aligned twin recovers the full 1.3 s sample, and after the fix in-game audio matches a reference emulator by ear (boots, attract, gameplay, save-state load all checked).
- `ctest` in `recompiler/build`: 33 pass; 5 failures pre-existing on this environment and unrelated (aot_overlay_discovery, launcher_vulkan_option, mod_load_acceleration, release_zip, vk_present_wait_stage).
- Not run against Tomba/MMX6/Ape Escape locally. Risk profile: even addresses (the common case) are untouched; odd addresses previously decoded mid-block garbage, so behavior there can only move toward hardware.

## Notes

- Game-agnostic: models the register semantics, no title checks.
- Runtime-only (`runtime/src/spu.c`): no regen required; games consume via a submodule pin bump.
- Found bringing up Twisted Metal III; game repo not yet published — decoded-sample WAV evidence available on request.