### PR TITLE
pgxp: emitted hooks after muldiv land on #endif lines and get discarded (+ link iphlpapi on Windows)

### DIFF
--- a/recompiler/src/pgxp_hook_emitter.cpp
+++ b/recompiler/src/pgxp_hook_emitter.cpp
@@ -47,38 +47,38 @@ void append_pgxp_hooks(uint32_t instr, std::string& code) {
         case 0x00: case 0x02: case 0x03:       /* SLL / SRL / SRA             */
             if (rd == 0 || instr == 0) return; /* skip plain nop              */
             code = fmt::format(
-                "{{ uint32_t _pgx1 = {}; {} PGXP_ALU(0x{:08X}u, {}, _pgx1, {}u); }}",
+                "{{ uint32_t _pgx1 = {}; {}\n    PGXP_ALU(0x{:08X}u, {}, _pgx1, {}u); }}",
                 reg_name(rt), code, instr, reg_name(rd), (instr >> 6) & 31u);
             return;
         case 0x04: case 0x06: case 0x07:       /* SLLV / SRLV / SRAV          */
             if (rd == 0) return;
             code = fmt::format(
-                "{{ uint32_t _pgx1 = {}; uint32_t _pgx2 = {}; {} "
+                "{{ uint32_t _pgx1 = {}; uint32_t _pgx2 = {}; {}\n    "
                 "PGXP_ALU(0x{:08X}u, {}, _pgx1, _pgx2); }}",
                 reg_name(rt), reg_name(rs), code, instr, reg_name(rd));
             return;
         case 0x10: case 0x12:                  /* MFHI / MFLO                 */
             if (rd == 0) return;
-            code = fmt::format("{} PGXP_ALU(0x{:08X}u, {}, {}, 0u);",
+            code = fmt::format("{}\n    PGXP_ALU(0x{:08X}u, {}, {}, 0u);",
                                code, instr, reg_name(rd),
                                funct == 0x10 ? "cpu->hi" : "cpu->lo");
             return;
         case 0x11: case 0x13:                  /* MTHI / MTLO                 */
-            code = fmt::format("{} PGXP_ALU(0x{:08X}u, {}, {}, 0u);",
+            code = fmt::format("{}\n    PGXP_ALU(0x{:08X}u, {}, {}, 0u);",
                                code, instr,
                                funct == 0x11 ? "cpu->hi" : "cpu->lo",
                                funct == 0x11 ? "cpu->hi" : "cpu->lo");
             return;
         case 0x18: case 0x19: case 0x1A: case 0x1B:  /* MULT(U)/DIV(U)        */
             code = fmt::format(
-                "{} PGXP_MULDIV(0x{:08X}u, cpu->hi, cpu->lo, {}, {});",
+                "{}\n    PGXP_MULDIV(0x{:08X}u, cpu->hi, cpu->lo, {}, {});",
                 code, instr, reg_name(rs), reg_name(rt));
             return;
         case 0x20: case 0x21: case 0x22: case 0x23:  /* ADD(U)/SUB(U)         */
         case 0x25:                                   /* OR                    */
             if (rd == 0) return;
             code = fmt::format(
-                "{{ uint32_t _pgx1 = {}; uint32_t _pgx2 = {}; {} "
+                "{{ uint32_t _pgx1 = {}; uint32_t _pgx2 = {}; {}\n    "
                 "PGXP_ALU(0x{:08X}u, {}, _pgx1, _pgx2); }}",
                 reg_name(rs), reg_name(rt), code, instr, reg_name(rd));
             return;
@@ -89,26 +89,26 @@ void append_pgxp_hooks(uint32_t instr, std::string& code) {
     case 0x08: case 0x09:                      /* ADDI / ADDIU                */
         if (rt == 0) return;
         code = fmt::format(
-            "{{ uint32_t _pgx1 = {}; {} PGXP_ALU(0x{:08X}u, {}, _pgx1, 0x{:08X}u); }}",
+            "{{ uint32_t _pgx1 = {}; {}\n    PGXP_ALU(0x{:08X}u, {}, _pgx1, 0x{:08X}u); }}",
             reg_name(rs), code, instr, reg_name(rt),
             (uint32_t)(int32_t)offset);
         return;
     case 0x0D:                                 /* ORI                         */
         if (rt == 0) return;
         code = fmt::format(
-            "{{ uint32_t _pgx1 = {}; {} PGXP_ALU(0x{:08X}u, {}, _pgx1, 0x{:04X}u); }}",
+            "{{ uint32_t _pgx1 = {}; {}\n    PGXP_ALU(0x{:08X}u, {}, _pgx1, 0x{:04X}u); }}",
             reg_name(rs), code, instr, reg_name(rt),
             (uint32_t)(uint16_t)offset);
         return;
     case 0x0F:                                 /* LUI                         */
         if (rt == 0) return;
-        code = fmt::format("{} PGXP_ALU(0x{:08X}u, {}, 0u, 0u);",
+        code = fmt::format("{}\n    PGXP_ALU(0x{:08X}u, {}, 0u, 0u);",
                            code, instr, reg_name(rt));
         return;
     case 0x12: {                               /* COP2 register transfers     */
         const uint32_t cop_op = (instr >> 21) & 0x1F;
         if ((cop_op == 0x00 && rt != 0) || cop_op == 0x04)  /* MFC2 / MTC2   */
-            code = fmt::format("{} PGXP_COP2(0x{:08X}u, {}, 0u);",
+            code = fmt::format("{}\n    PGXP_COP2(0x{:08X}u, {}, 0u);",
                                code, instr, reg_name(rt));
         return;
     }
@@ -116,13 +116,13 @@ void append_pgxp_hooks(uint32_t instr, std::string& code) {
     case 0x24: case 0x25: case 0x26:           /* loads                       */
         if (rt == 0) return;
         code = fmt::format(
-            "{{ uint32_t _pgxa = {}; {} PGXP_LOAD(0x{:08X}u, _pgxa, {}); }}",
+            "{{ uint32_t _pgxa = {}; {}\n    PGXP_LOAD(0x{:08X}u, _pgxa, {}); }}",
             addr_expr(), code, instr, reg_name(rt));
         return;
     case 0x28: case 0x29: case 0x2A: case 0x2B:
     case 0x2E:                                 /* stores                      */
         code = fmt::format(
-            "{{ uint32_t _pgxa = {}; {} PGXP_STORE(0x{:08X}u, _pgxa, {}); }}",
+            "{{ uint32_t _pgxa = {}; {}\n    PGXP_STORE(0x{:08X}u, _pgxa, {}); }}",
             addr_expr(), code, instr, reg_name(rt));
         return;
     default:

--- a/runtime/runtime.cmake
+++ b/runtime/runtime.cmake
@@ -1422,7 +1422,9 @@ function(psxrecomp_add_runtime_target target)
     if(WIN32 OR MINGW)
         # opengl32: GL backend (gpu_gl_renderer.c). GL 1.x is exported directly
         # by opengl32; Phase 2b will load modern GL via SDL_GL_GetProcAddress.
-        target_link_libraries(${target} PRIVATE ws2_32 dbghelp comdlg32 opengl32)
+        # iphlpapi: GetAdaptersAddresses in the launcher's netplay
+        # local-address discovery (MSVC does not link it implicitly).
+        target_link_libraries(${target} PRIVATE ws2_32 iphlpapi dbghelp comdlg32 opengl32)
         # Newer mingw-w64 maps clock_gettime → clock_gettime64 in libwinpthread.
         # Link it even when netplay code prefers Win32 clocks, so any residual
         # POSIX time refs (third-party / debug tools) resolve under -static.


### PR DESCRIPTION
Two small independent correctness fixes, one commit each. Happy to split into two PRs if preferred.

## 1. `pgxp: join emitted hooks with a newline, never a space` (recompiler)

`append_pgxp_hooks` splices every `PGXP_*` call onto the tail of the instruction's emitted code with a plain space. When that emission ends with a preprocessor directive — the `PSX_ENABLE_BLOCK_CYCLES` muldiv stall/latency block ends with a bare `#endif` — the hook lands **on the directive line**, where the preprocessor discards it as extra tokens (`-Wendif-labels` warns). Net effect: in a PGXP-flavored build with block cycles enabled, every MULT/DIV/MFHI/MFLO hook silently vanishes, so hi/lo results never propagate precision through the value-propagation engine.

Fix: join with `"\n"` at every hook site. A newline is always valid where the space was, so unaffected emissions compile byte-equivalently; directive-terminated emissions now keep their hooks.

## 2. `build: link iphlpapi into Windows runtime targets`

`main.cpp` includes `iphlpapi.h` and calls `GetAdaptersAddresses` (netplay local-address discovery), but no CMake file links the library. MinGW builds link regardless; MSVC does not link iphlpapi implicitly, so MSVC runtime builds fail at link with an unresolved `GetAdaptersAddresses`.

## Verification

- Regenerated + rebuilt Bushido Blade 2 (SLUS-00663, local game repo) on today's master: **before** the fix the regen emitted 1000+ `#endif PGXP_*(...)` lines across the game shards (399 in a single shard); **after**, zero — every hook lands on its own line after the `#endif`.
- recompiler `ctest`: 45/50 pass, including `full_function_emitter_test` and `l2_structural_test`. The 5 failures are pre-existing on master and untouched by this change: `mod_load_acceleration` asserts a `gi.has_turbo_loads` source line that the turbo_loads retirement removed, `launcher_vulkan_option` hits a Windows cp1252 decode error inside the test harness, and `aot_overlay_discovery` / `release_zip` / `vk_present_wait_stage` fail identically without this change (none of the five reads the emitter).
- Booted BB2 end-to-end on the rebuilt runtime (MinGW RelWithDebInfo, GL): boots to gameplay, pixels and audio fine.
- Honest gaps: no before/after A-B of a `_pgxp`-flavored binary (this game doesn't ship the PGXP mod yet) — the claim rests on the generated-code diff. The iphlpapi gap was verified by inspection on today's master (header included, no link entry anywhere in the tree); the MSVC link failure itself was observed on an earlier master, not re-run today (MinGW is my primary toolchain).

## Scope

- Both fixes are fully game-agnostic (an emitter string join; a Windows link line). No config, no per-game behavior.
- Fix 1 is recompiler-side: games pick it up on their next regen (non-PGXP output changes only by whitespace). Fix 2 is build-system-only, no regen. Consuming game repos need the usual submodule pin bump.