### PR TITLE
recompiler: guard every same-line appender off preprocessor-directive lines

### DIFF
--- a/recompiler/CMakeLists.txt
+++ b/recompiler/CMakeLists.txt
@@ -274,7 +274,24 @@ target_include_directories(l2_structural_test PRIVATE
 )
 target_link_libraries(l2_structural_test PRIVATE fmt rabbitizer)
 
+# Emitter directive-line guard — pins the predicate that keeps same-line
+# appenders off preprocessor-directive lines (the PR #171 hazard class).
+add_executable(emitter_directive_line_test
+    tests/emitter_directive_line_test.cpp
+    src/pgxp_hook_emitter.cpp
+)
+target_include_directories(emitter_directive_line_test PRIVATE
+    include
+    src
+    lib/rabbitizer/include
+    lib/rabbitizer/cplusplus/include
+    lib/fmt/include
+)
+target_link_libraries(emitter_directive_line_test PRIVATE fmt rabbitizer)
+
 if(BUILD_TESTING)
+    add_test(NAME emitter_directive_line_test
+             COMMAND emitter_directive_line_test)
     add_executable(debug_trace_ranges_test
         ../runtime/tests/test_debug_trace_ranges.c
         ../runtime/src/debug_trace_ranges.c

--- a/recompiler/src/code_generator.cpp
+++ b/recompiler/src/code_generator.cpp
@@ -1633,6 +1633,16 @@ std::string CodeGenerator::translate_instruction(uint32_t addr, uint32_t instr) 
     }
 
     PSXRecomp::append_pgxp_hooks(instr, code);
+    /* The trailing disassembly comment must not land ON a preprocessor
+     * directive line -- it would be swallowed as extra tokens and dropped,
+     * costing the annotation and emitting -Wendif-labels noise. Reachable
+     * whenever the PGXP hook did NOT get appended after a block-cycles stall
+     * block, e.g. `mfhi $zero` / `mflo $zero` (append_pgxp_hooks returns early
+     * for rd==0, leaving the emission ending on a bare #endif). Same hazard
+     * class as PR #171. */
+    if (!comment.empty() &&
+        PSXRecomp::emission_ends_on_preprocessor_directive(code))
+        return config_.indent + code + "\n" + config_.indent + comment;
     return config_.indent + code + comment;
 }
 

--- a/recompiler/src/pgxp_hook_emitter.cpp
+++ b/recompiler/src/pgxp_hook_emitter.cpp
@@ -29,6 +29,20 @@ inline int16_t get_imm16(uint32_t i) { return (int16_t)(i & 0xFFFF); }
  * their stale shadows without help. The configured widescreen special sites
  * return early above translate_instruction's main dispatch and are likewise
  * unhooked (they are cull compares, not vertex moves; validation covers). */
+bool emission_ends_on_preprocessor_directive(const std::string& code) {
+    /* Scan back to the start of the final line, then find its first
+     * non-blank character. A directive is legal with leading whitespace, so
+     * "    #endif" counts just as much as "#endif". */
+    const std::size_t nl = code.find_last_of('\n');
+    const std::size_t line_begin = (nl == std::string::npos) ? 0u : nl + 1u;
+    for (std::size_t i = line_begin; i < code.size(); ++i) {
+        const char c = code[i];
+        if (c == ' ' || c == '\t' || c == '\r') continue;
+        return c == '#';
+    }
+    return false;  /* blank final line -- appending is already safe */
+}
+
 void append_pgxp_hooks(uint32_t instr, std::string& code) {
     const uint32_t opcode = (instr >> 26) & 0x3F;
     const uint32_t rs = get_rs(instr);

--- a/recompiler/src/pgxp_hook_emitter.h
+++ b/recompiler/src/pgxp_hook_emitter.h
@@ -24,6 +24,24 @@ namespace PSXRecomp {
  * Deliberately unhooked: AND/XOR/NOR/SLT-family and the exotic immediates —
  * they only ever DESTROY precision, and the engine's validate-on-read drops
  * their stale shadows without help. */
+/* True when `code`'s LAST line is a preprocessor directive.
+ *
+ * A directive owns its whole line: the preprocessor swallows anything after it
+ * as "extra tokens" and silently DISCARDS it (gcc -Wendif-labels). Several
+ * emissions end on a bare `#endif` -- the PSX_ENABLE_BLOCK_CYCLES muldiv
+ * stall/latency blocks in both emitters (code_generator.cpp translate_mult/
+ * multu/div/divu and translate_mfhi/mflo; strict_translator.cpp the same
+ * shapes) -- so ANY text appended to such an emission on the same line is
+ * dropped without a build failure.
+ *
+ * That is exactly the defect PR #171 fixed for the PGXP hooks, where 3,187
+ * hooks per title were being discarded. This predicate exists so the remaining
+ * same-line appenders can be guarded by construction instead of one at a time.
+ *
+ * Callers append "
+" + indent instead of a space when this returns true. */
+bool emission_ends_on_preprocessor_directive(const std::string& code);
+
 void append_pgxp_hooks(uint32_t instr, std::string& code);
 
 } // namespace PSXRecomp

--- a/recompiler/src/strict_translator.cpp
+++ b/recompiler/src/strict_translator.cpp
@@ -78,8 +78,14 @@ TranslateResult StrictTranslator::translate(const PSXRecomp::DecodedInstruction&
     if (r.load_dest >= 0 && !r.c_code_deferred.empty()) {
         const uint32_t rs = (d.raw >> 21) & 0x1F;
         const int16_t offset = static_cast<int16_t>(d.raw & 0xFFFF);
+        /* Newline, never a space: if the deferred emission ever ends on a
+         * preprocessor directive (the block-cycles annotations already do
+         * elsewhere in this file), a space-joined hook lands on the directive
+         * line and is silently discarded -- the PR #171 defect. Unconditional
+         * "\n" is always valid where the space was, so non-directive
+         * emissions are unaffected apart from whitespace. */
         r.c_code_deferred = fmt::format(
-            "{{ uint32_t _pgxa = cpu->gpr[{}] + {}; {} "
+            "{{ uint32_t _pgxa = cpu->gpr[{}] + {}; {}\n    "
             "PGXP_LOAD(0x{:08X}u, _pgxa, psx_ldd_{:08X}); }}",
             static_cast<int>(rs), static_cast<int>(offset),
             r.c_code_deferred, d.raw, d.address);

--- a/recompiler/tests/emitter_directive_line_test.cpp
+++ b/recompiler/tests/emitter_directive_line_test.cpp
@@ -1,0 +1,71 @@
+/*
+ * A preprocessor directive owns its whole line. Anything appended after it on
+ * that line is swallowed as "extra tokens" and silently DISCARDED -- no build
+ * failure, just a -Wendif-labels warning nobody reads. PR #171 was exactly
+ * this: `append_pgxp_hooks` space-joined its PGXP_*() call onto emissions that
+ * end on a bare `#endif` (the PSX_ENABLE_BLOCK_CYCLES muldiv stall/latency
+ * blocks), so 3,187 hooks per title were thrown away.
+ *
+ * This pins the predicate that now guards the remaining same-line appenders,
+ * so the hazard cannot come back by construction.
+ *
+ * Build/run: ctest -R emitter_directive_line_test
+ */
+
+#include "pgxp_hook_emitter.h"
+
+#include <cstdio>
+#include <string>
+
+static int failures;
+
+#define CHECK(cond, msg)                                                       \
+    do {                                                                       \
+        if (!(cond)) { std::fprintf(stderr, "FAIL: %s\n", (msg)); failures++; } \
+        else         { std::printf("ok:   %s\n", (msg)); }                      \
+    } while (0)
+
+using PSXRecomp::emission_ends_on_preprocessor_directive;
+
+int main() {
+    /* The shape that caused PR #171: translate_mult's real emission. */
+    const std::string muldiv =
+        "{ int64_t result = (int64_t)(int32_t)cpu->gpr[4] * (int64_t)(int32_t)cpu->gpr[5];"
+        " cpu->lo = (uint32_t)result; cpu->hi = (uint32_t)(result >> 32); }"
+        "\n#ifdef PSX_ENABLE_BLOCK_CYCLES\n    psx_muldiv_set(cpu, 13u);\n#endif";
+    CHECK(emission_ends_on_preprocessor_directive(muldiv),
+          "a muldiv emission ending on a bare #endif is detected");
+
+    /* translate_mfhi with rd==$zero: the stall block with no statement. */
+    CHECK(emission_ends_on_preprocessor_directive(
+              "/* nop: write to $zero */"
+              "\n#ifdef PSX_ENABLE_BLOCK_CYCLES\n    psx_muldiv_stall(cpu);\n#endif"),
+          "a zero-reg mfhi/mflo emission ending on #endif is detected");
+
+    /* Leading whitespace is legal before a directive. */
+    CHECK(emission_ends_on_preprocessor_directive("foo();\n    #endif"),
+          "an indented directive still owns its line");
+    CHECK(emission_ends_on_preprocessor_directive("foo();\n\t#else"),
+          "a tab-indented directive still owns its line");
+    CHECK(emission_ends_on_preprocessor_directive("#endif"),
+          "a single-line emission that is only a directive is detected");
+
+    /* Ordinary statements must NOT be flagged -- a false positive here would
+     * inject stray newlines into every instruction's output. */
+    CHECK(!emission_ends_on_preprocessor_directive("cpu->gpr[4] = cpu->hi;"),
+          "a plain statement is not a directive line");
+    CHECK(!emission_ends_on_preprocessor_directive(
+              "\n#ifdef PSX_ENABLE_BLOCK_CYCLES\n    psx_gte_stall(cpu);\n#endif\n    "),
+          "an emission whose directive block is followed by a fresh indented "
+          "line is safe to append to");
+    CHECK(!emission_ends_on_preprocessor_directive(
+              "{ uint32_t _pgxa = cpu->gpr[4]; foo();\n    PGXP_LOAD(0u, _pgxa, x); }"),
+          "an already-fixed hook emission is not flagged");
+    CHECK(!emission_ends_on_preprocessor_directive(""),
+          "an empty emission is not flagged");
+    CHECK(!emission_ends_on_preprocessor_directive("x = 1; /* #endif in a comment */"),
+          "a '#' that is not the line's first token is not a directive");
+
+    std::printf(failures ? "FAILED (%d)\n" : "ALL PASS\n", failures);
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
Follow-up to #171. That PR fixed the PGXP hook site; this closes the rest of the class.

## The hazard

A preprocessor directive owns its whole line. Anything appended after it is swallowed as "extra tokens" and silently discarded — no build failure, just a `-Wendif-labels` warning nobody reads. #171 was exactly this: `append_pgxp_hooks` space-joined its `PGXP_*()` call onto emissions ending on a bare `#endif` (the `PSX_ENABLE_BLOCK_CYCLES` muldiv stall/latency blocks), so **3,187 hooks in Ape Escape, 1,356 in Tomba 1, 781 in MMX6, 52 in Tomba 2 and 1,024 in the BIOS** were thrown away.

Two same-line appenders of the same class were left behind:

1. **`strict_translator.cpp`** — the deferred-load `PGXP_LOAD` hook is still space-joined onto `c_code_deferred`. All five `c_code_deferred` producers currently end in plain statements, so it is benign *today* — but the moment a block-cycles annotation lands on deferred loads it breaks exactly the way #171 did, and just as silently.
2. **`code_generator.cpp`** — the trailing disassembly comment is appended unconditionally. Reachable whenever `append_pgxp_hooks` returned early and left the emission ending on a directive, e.g. `mfhi $zero` / `mflo $zero` (`rd == 0` takes an early return). The comment is dropped and `-Wendif-labels` fires.

## The fix

Both route through one predicate, `emission_ends_on_preprocessor_directive()`, so the hazard is closed by construction rather than one site at a time. Site 1 takes an unconditional newline (always valid where the space was); site 2 only breaks the line when the emission actually ends on a directive, so ordinary instructions keep their inline comment and the generated diff stays minimal.

## Measured effect on emitted code (vs merged master)

- **SCPH1001 BIOS:** byte-identical
- **OpenBIOS:** 2 sites, both the deferred `PGXP_LOAD` moving to its own line — identical token sequence
- **Ape / Tomba 1 / Tomba 2 / MMX6:** every function token-identical (3095 / 6891 / 2726 / 4023 functions each; none added, none removed, zero body changes)

## Validation

All four reference titles regenerated against merged master + this change, built, and boot-tested:

| Title | stranded hooks | build | `-Wendif-labels` | boot |
|---|---|---|---|---|
| Ape Escape | 3187 → **0** | clean | **0** | title menu, 18,823 key-ons |
| Tomba 1 | 1356 → **0** | clean | **0** | title screen, 2,053 key-ons |
| MMX6 | 781 → **0** | clean | **0** | logo/attract, 1,051 key-ons |
| Tomba 2 | 52 → **0** | clean | **0** | in-game, 375 key-ons |

BIOS regenerated: SCPH1001 687 → 0, OpenBIOS 337 → 0. Tomba 2 additionally validated windowed by the maintainer.

Adds `emitter_directive_line_test` (10 checks, registered with `add_test`) pinning both real `#endif`-terminated emission shapes **and** the negative cases — a false positive would inject stray newlines into every instruction.

`ctest` fails the identical 6 pre-existing tests before and after (`aot_overlay_discovery`, `launcher_vulkan_option`, `mod_load_acceleration`, `release_zip`, `sdl3_main_single_include`, `vk_present_wait_stage`); no new failures. `full_function_emitter_test` and `l2_structural_test` pass.

## Note for consumers

#171 already bumped the cg tag, and this rides along with it. Titles pick both up on their next regen. Because #171 adds a line per PGXP hook, shard counts rise slightly (Ape 51→54, Tomba 1 38→41, MMX6 30→32, Tomba 2 unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)