### PR TITLE
sio: gate Ape Escape card IRQ unstick behind config

### DIFF
--- a/recompiler/src/config_loader.cpp
+++ b/recompiler/src/config_loader.cpp
@@ -448,6 +448,9 @@ static RuntimeConfig parse_runtime_block(const toml::value& cfg, const fs::path&
     if (runtime.contains("fast_boot")) {
         rt.fast_boot = toml::find<bool>(runtime, "fast_boot");
     }
+    if (runtime.contains("ape_card_unstick")) {
+        rt.ape_card_unstick = toml::find<bool>(runtime, "ape_card_unstick");
+    }
     if (runtime.contains("openbios")) {
         rt.openbios = toml::find<bool>(runtime, "openbios");
     }

--- a/recompiler/src/config_loader.h
+++ b/recompiler/src/config_loader.h
@@ -188,6 +188,14 @@ struct RuntimeConfig {
     // Kept so existing game.toml/settings.toml keep working.
     bool                  fast_boot = false;
 
+    // Ape Escape LOAD card-IRQ unstick pump ([runtime] ape_card_unstick).
+    // A per-game kernel-nest repair that force-re-edges I_MASK.7/IRQ7 after a
+    // LOAD-style probe abort. OPT-IN: on WipEout 3 under the x2 CRTC the
+    // arming detector misfires and the forced IRQ storm wedges the kernel
+    // card driver (completion events never deliver -> memcard screen hangs).
+    // Env PSX_APE_CARD_UNSTICK=0/1 still overrides either way.
+    bool                  ape_card_unstick = false;
+
     // bios_hle: High-Level Emulation tier for BIOS kernel services
     // (CLAUDE.md §0 amendment 2026-07-02, the gbarecomp model). DEFAULT ON as of
     // 2026-07-06 (user-directed player default: instant boot-skip for every

--- a/runtime/include/sio.h
+++ b/runtime/include/sio.h
@@ -75,6 +75,8 @@ uint64_t sio_get_advance_with_work(void);
  * Bulk 0x80 responses follow the real TAP/REQ latch (psx-spx): REQ=1 in the
  * third command byte arms the *next* transfer; empty tap slots are fine. */
 void sio_set_multitap(int enabled);
+/* [runtime] ape_card_unstick config default (env PSX_APE_CARD_UNSTICK overrides). */
+void sio_set_ape_card_unstick(int on);
 int  sio_get_multitap(void);
 /* phys_port: 0 = console Port 1, 1 = console Port 2. Default 0. */
 void sio_set_multitap_port(int phys_port);

--- a/runtime/src/main.cpp
+++ b/runtime/src/main.cpp
@@ -10872,6 +10872,7 @@ int main(int argc, char** argv) {
               if (e && e[0] && e[0] != '0') g_gl_fbo_present = 0; }
             game_entry_pc = gc.entry_pc;
             fast_boot     = gc.runtime.fast_boot;
+            sio_set_ape_card_unstick(gc.runtime.ape_card_unstick ? 1 : 0);
             bios_hle      = gc.runtime.bios_hle;
             bios_hle_keep_intro = gc.runtime.bios_hle_keep_intro;
             /* Developer compatibility finding, applied before BIOS selection.

--- a/runtime/src/sio.c
+++ b/runtime/src/sio.c
@@ -494,15 +494,24 @@ static int s_ape_unstick_pending = 0;
 static uint64_t s_ape_unstick_cool_cyc = 0;
 static int s_ape_torn_pulses = 0;
 
+/* Config default ([runtime] ape_card_unstick), set at boot. OFF unless the
+ * game opts in: this pump force-re-edges I_MASK.7/IRQ7, and a misfired arm
+ * (WipEout 3 under the x2 CRTC) storms the kernel card ISR so completion
+ * events never deliver and the memcard screen hangs forever. */
+static int s_ape_unstick_cfg = 0;
+void sio_set_ape_card_unstick(int on) { s_ape_unstick_cfg = on ? 1 : 0; }
+
 static int ape_unstick_enabled(void) {
     if (s_ape_unstick_env < 0) {
         const char *e = getenv("PSX_APE_CARD_UNSTICK");
-        if (e && e[0] == '0')
-            s_ape_unstick_env = 0;
+        if (e && e[0])
+            s_ape_unstick_env = (e[0] == '0') ? 0 : 1;
         else
-            s_ape_unstick_env = 1;
+            s_ape_unstick_env = -2;   /* no env: fall through to config */
     }
-    return s_ape_unstick_env;
+    if (s_ape_unstick_env >= 0)
+        return s_ape_unstick_env;
+    return s_ape_unstick_cfg;
 }
 
 /* Defined later; sio_tick calls the pump. */


### PR DESCRIPTION
Split from original PR #169 by tetrisgm; original PR intentionally left open.\n\nThis PR extracts only the Ape Escape memory-card IRQ unstick gating change. The pump is now controlled by [runtime] ape_card_unstick instead of being implicitly active for all titles.\n\nValidation run locally:\n- Built psxrecomp-toml\n- Configured runtime with Retcomm Clang/Ninja using PSXRECOMP_ALLOW_NO_BIOS=ON and PSX_RECOMP_UI=OFF\n- Built sio_dualshock_rumble_test\n\nNotes:\n- sio_dualshock_rumble_test is disabled in the upstream CTest registration, so this PR validates compile coverage only for the SIO test target.\n- Runtime configure emitted the existing stale generated BIOS warning; not caused by this branch.