### PR TITLE
debug: expose savestate completion status

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -403,6 +403,9 @@ if(BUILD_TESTING)
         add_test(NAME rewind_toggle_combo_test
                  COMMAND ${Python3_EXECUTABLE}
                          ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_rewind_toggle_combo.py)
+        add_test(NAME savestate_status_protocol_test
+                 COMMAND ${Python3_EXECUTABLE}
+                         ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_savestate_status_protocol.py)
     endif()
 
     # DISABLED, not de-registered. It links and runs, but 147 of its 309 checks

--- a/runtime/include/savestate.h
+++ b/runtime/include/savestate.h
@@ -97,6 +97,9 @@ int savestate_request_load_blob_protocol(const void* data, size_t size);
 /* 1 while a staged save/load has not yet been consumed by savestate_poll. */
 int savestate_pending(void);
 
+/* Machine-readable lifecycle receipt for deterministic debug harnesses. */
+void savestate_status_json(char* buf, size_t cap);
+
 /* 1 once after a successful load restore (before scheduler longjmp). Clears. */
 int savestate_take_load_completed(void);
 

--- a/runtime/src/debug_server.c
+++ b/runtime/src/debug_server.c
@@ -8044,6 +8044,18 @@ static void handle_savestate(int id, const char *json)
     send_fmt("{\"id\":%d,\"ok\":true,\"op\":\"%s\",\"slot\":%d}", id, op, slot);
 }
 
+/* Deterministic harness receipt: unlike the savestate acknowledgement above,
+ * this reports the safe-boundary completion generation after savestate_poll
+ * has actually applied or rejected the request. */
+static void handle_savestate_status(int id, const char *json)
+{
+    (void)json;
+    extern void savestate_status_json(char *buf, size_t cap);
+    char status[256];
+    savestate_status_json(status, sizeof status);
+    send_fmt("{\"id\":%d,\"ok\":true,%s}", id, status);
+}
+
 static void handle_turbo(int id, const char *json)
 {
     int enabled = json_get_int(json, "enabled", -1);
@@ -13514,6 +13526,7 @@ static const CmdEntry s_commands[] = {
     { "input_route_stop",  handle_input_route_stop },
     { "input_route_status",handle_input_route_status },
     { "savestate",         handle_savestate },
+    { "savestate_status",  handle_savestate_status },
     { "turbo",             handle_turbo },
     { "turbo_state",       handle_turbo_state },
     { "pause",             handle_pause },

--- a/runtime/src/savestate.c
+++ b/runtime/src/savestate.c
@@ -55,6 +55,11 @@ static int      s_save_pending = -1;   /* slot, or -1 */
 static int      s_load_pending = -1;
 static int      s_load_completed = 0;
 static int      s_load_failed = 0;
+static uint32_t s_status_generation = 0;
+static int      s_status_pending = 0;
+static int      s_status_last_ok = 0;
+static int      s_status_last_load = 0;
+static int      s_status_last_slot = -1;
 static int      s_save_failed = 0;
 static uint32_t s_last_save_pc = 0;
 static int      s_save_defer_slot = -1;
@@ -587,6 +592,9 @@ static int request_save_inner(int slot) {
     s_last_save_pc = 0; /* block netplay transfer until this write stamps a PC */
     s_save_defer_slot = -1;
     s_save_pending = slot;
+    s_status_pending = 1;
+    s_status_last_load = 0;
+    s_status_last_slot = slot;
     return 1;
 }
 
@@ -603,6 +611,9 @@ static int request_load_inner(int slot) {
     s_load_failed = 0;
     s_load_completed = 0;
     s_load_pending = slot;
+    s_status_pending = 1;
+    s_status_last_load = 1;
+    s_status_last_slot = slot;
     return 1;
 }
 
@@ -658,6 +669,16 @@ int savestate_pending(void) {
     return (s_save_pending >= 0 || s_load_pending >= 0) ? 1 : 0;
 }
 
+void savestate_status_json(char* buf, size_t cap) {
+    if (!buf || cap == 0) return;
+    snprintf(buf, cap,
+             "\"generation\":%u,\"pending\":%d,\"last_ok\":%d,"
+             "\"last_op\":\"%s\",\"last_slot\":%d",
+             (unsigned)s_status_generation, s_status_pending,
+             s_status_last_ok, s_status_last_load ? "load" : "save",
+             s_status_last_slot);
+}
+
 int savestate_take_load_completed(void) {
     int v = s_load_completed;
     s_load_completed = 0;
@@ -705,6 +726,9 @@ void savestate_poll(CPUState* cpu, uint32_t resume_pc) {
             s_save_defer_slot = -1;
             s_last_save_pc = 0;
             s_save_failed = 1;
+            s_status_pending = 0;
+            s_status_last_ok = 0;
+            s_status_generation++;
             fprintf(stderr,
                     "savestate: SAVE FAILED slot %d — no safe resume PC "
                     "(hint=0x%08X)\n",
@@ -733,12 +757,18 @@ void savestate_poll(CPUState* cpu, uint32_t resume_pc) {
                     s_last_save_pc = 0;
                     s_save_failed = 1;
                 }
+                s_status_pending = 0;
+                s_status_last_ok = ok ? 1 : 0;
+                s_status_generation++;
                 fprintf(stderr, "savestate: %s slot %d @ pc=0x%08X -> %s\n",
                         ok ? "SAVED" : "SAVE FAILED", slot, (unsigned)pc, path);
                 psx_frontend_on_savestate_notify(0, slot, ok);
             } else {
                 s_last_save_pc = 0;
                 s_save_failed = 1;
+                s_status_pending = 0;
+                s_status_last_ok = 0;
+                s_status_generation++;
                 psx_frontend_on_savestate_notify(0, slot, 0);
             }
         }
@@ -788,6 +818,11 @@ void savestate_poll(CPUState* cpu, uint32_t resume_pc) {
             s_load_failed = 1;
             psx_frontend_on_savestate_notify(1, slot, 0);
         }
+        if (!loaded) {
+            s_status_pending = 0;
+            s_status_last_ok = 0;
+            s_status_generation++;
+        }
         if (loaded) {
             t_after_boot = savestate_mono_ms();
             psx_cycles_resync_after_restore(cpu);
@@ -801,6 +836,9 @@ void savestate_poll(CPUState* cpu, uint32_t resume_pc) {
             cdrom_accelerate_after_savestate();
             /* Netplay post-load barrier observes this before the longjmp. */
             s_load_completed = 1;
+            s_status_pending = 0;
+            s_status_last_ok = 1;
+            s_status_generation++;
             /* Restage FBO/present latch so the restored frame is visible
              * immediately (avoids disabled-display blank latch + stale smooth). */
             psx_frontend_on_savestate_loaded();

--- a/runtime/tests/test_savestate_status_protocol.py
+++ b/runtime/tests/test_savestate_status_protocol.py
@@ -1,0 +1,14 @@
+"""Guard the deterministic savestate completion receipt used by load gates."""
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+HEADER = (ROOT / "include/savestate.h").read_text(encoding="utf-8")
+STATE = (ROOT / "src/savestate.c").read_text(encoding="utf-8")
+SERVER = (ROOT / "src/debug_server.c").read_text(encoding="utf-8")
+
+assert "void savestate_status_json(char* buf, size_t cap);" in HEADER
+assert '\\"generation\\"' in STATE and '\\"pending\\"' in STATE
+assert "s_status_generation++" in STATE
+assert '"savestate_status"' in SERVER
+assert "savestate_status_json(status, sizeof status)" in SERVER
+print("savestate status protocol guard passed")


### PR DESCRIPTION
Split from original PR #169 by tetrisgm; original PR intentionally left open.\n\nThis PR extracts only the deterministic savestate completion receipt endpoint. savestate_status reports the lifecycle generation and last pending/apply result after savestate_poll has actually consumed a staged save/load request.\n\nValidation run locally:\n- python runtime/tests/test_savestate_status_protocol.py\n- Configured runtime with Retcomm Clang/Ninja using PSXRECOMP_ALLOW_NO_BIOS=ON and PSX_RECOMP_UI=OFF\n- ctest --test-dir build/split-runtime -R savestate_status_protocol_test --output-on-failure\n- Built psx-runtime\n\nNotes:\n- The original commit conflicted near unrelated PGXP/overclock debug handlers in #169; this split intentionally keeps only the savestate status endpoint and its test registration.\n- Runtime configure emitted the existing stale generated BIOS warning; not caused by this branch.