### PR TITLE
mods: add default-off Skip FMVs package

### DIFF
--- a/mods/builtin/packages/psx.enhancement.skip-fmv/1.0.0/manifest.toml
+++ b/mods/builtin/packages/psx.enhancement.skip-fmv/1.0.0/manifest.toml
@@ -1,0 +1,24 @@
+format_version = 5
+id = "psx.enhancement.skip-fmv"
+version = "1.0.0"
+name = "Skip FMVs"
+author = "psxrecomp"
+description = "Skip full-motion video the moment it starts, so a launch goes straight to the game instead of sitting through logos and the attract intro. Detection is the documented signature of a streaming FMV (XA audio feeding the SPU while the MDEC produces frames), not a per-title frame count or address, so it applies to any disc without knowing anything about it. Presentation-only: the game still runs the sequence, it is simply not waited on."
+resolver = "declarative"
+save_compatibility = "shared"
+
+# FMV playback is a property of the emulated CD/MDEC/SPU path rather than of any
+# particular disc, so this ships with the framework and targets every game.
+[[target]]
+game_id = "*"
+
+[[feature]]
+id = "skip_fmv"
+name = "Skip FMVs"
+description = "Off by default. This is presentation, not simulation: skipping a video changes no game state and no timing the game can observe, and save compatibility is unchanged. Turn it on to skip intros and attract sequences."
+group = "Quality of life"
+default_enabled = false
+
+[[plugin]]
+feature = "skip_fmv"
+id = "psx.skip_fmv"

--- a/runtime/runtime.cmake
+++ b/runtime/runtime.cmake
@@ -333,6 +333,7 @@ set(PSXRECOMP_RUNTIME_SOURCES
     ${PSXRECOMP_ROOT}/runtime/src/game_options.c
     ${PSXRECOMP_ROOT}/runtime/src/mod_builtin_speed.c
     ${PSXRECOMP_ROOT}/runtime/src/mod_builtin_pgxp.c
+    ${PSXRECOMP_ROOT}/runtime/src/mod_builtin_skip_fmv.c
     ${PSXRECOMP_ROOT}/runtime/src/mod_packages.cpp
     ${PSXRECOMP_ROOT}/runtime/src/mod_runtime.cpp
     ${PSXRECOMP_ROOT}/runtime/src/psx_keybinds.c
@@ -1257,7 +1258,7 @@ function(psxrecomp_add_runtime_target target)
                 "${PSXRECOMP_BUNDLED_BIOS_LICENSE}")
         endif()
 
-    # Framework-owned mod catalog (loading speed). These target game_id "*" and
+    # Framework-owned mod catalog. These target game_id "*" and
     # are emulator features rather than per-disc content, so every game gets
     # them without carrying a copy of the manifests. Staged BEFORE the game's
     # own POST_BUILD copy so a title may still override an id if it ever needs

--- a/runtime/src/mod_builtin_skip_fmv.c
+++ b/runtime/src/mod_builtin_skip_fmv.c
@@ -1,0 +1,33 @@
+/*
+ * Framework-owned "skip FMVs" mod, available to every game.
+ *
+ * The runtime has been able to do this since auto_skip_fmv existed, but the
+ * setting is deliberately inert on PSX: main.cpp holds skip_fmv_offered at
+ * constexpr false and clears g_auto_skip_fmv right after config resolution,
+ * with "Skip FMVs is mod-owned on PSX; ignoring the legacy Settings value".
+ * That is the correct design -- the feature is a per-user choice with a real
+ * behavioural effect, so it belongs in the mod plan where it can be toggled and
+ * recorded, not in a config file a game ships. What was missing was the mod
+ * itself, so the capability existed with no way to reach it.
+ *
+ * Activation runs after the final mod-plan commit, which is what makes this
+ * work where the config key cannot: the guard that clears the legacy value has
+ * already run by then.
+ *
+ * Detection is the framework's, not ours: a streaming FMV is XA audio plus MDEC
+ * output, a documented signature, so nothing here is keyed to a frame count or
+ * a per-title address.
+ */
+#include "mod_plugins.h"
+
+/* main.cpp -- validates and applies; refuses anything but 0/1. */
+extern int psx_mod_set_auto_skip_fmv(int enabled);
+
+static void builtin_skip_fmv_activate(void) {
+    (void)psx_mod_set_auto_skip_fmv(1);
+}
+
+PSX_MOD_CONSTRUCTOR(psx_register_builtin_skip_fmv_plugin) {
+    (void)psx_mod_register_activation_plugin("psx.skip_fmv",
+                                             builtin_skip_fmv_activate);
+}


### PR DESCRIPTION
Split from original PR #169 by tetrisgm; original PR intentionally left open.\n\nThis PR extracts only the built-in Skip FMVs mod package and runtime plugin. It deliberately keeps the feature default-off and does not include the broader global launcher exposure/default policy from #169.\n\nIncluded:\n- mods/builtin/packages/psx.enhancement.skip-fmv/1.0.0/manifest.toml\n- untime/src/mod_builtin_skip_fmv.c\n- runtime source-list registration\n\nValidation run locally:\n- python runtime/tests/test_mod_owned_display_controls.py\n- Configured runtime with Retcomm Clang/Ninja using PSXRECOMP_ALLOW_NO_BIOS=ON and PSX_RECOMP_UI=OFF\n- Built psx-runtime\n\nNotes:\n- I corrected the extracted manifest description to match default_enabled = false; PR #169 had intermediate default-on wording that did not match its final extracted policy.\n- untime/tests/test_mod_load_acceleration.py currently fails against this master text for an unrelated fast-loading ownership assertion, so it was not used as validation for this Skip FMV-only branch.