### PR TITLE
autocompile: pass overlay flavor to spawned compiler

### DIFF
--- a/runtime/src/autocompile.c
+++ b/runtime/src/autocompile.c
@@ -15,6 +15,10 @@
 #  include <windows.h>
 #endif
 
+#ifndef PSX_OVERLAY_FLAVOR
+#define PSX_OVERLAY_FLAVOR 0
+#endif
+
 static char s_cmd[4096];   /* large: the runtime-constructed bundled tcc cmd has
                             * many absolute paths (python+script+recompiler+tcc+...) */
 static char s_cwd[512];
@@ -855,6 +859,16 @@ int autocompile_request(void) {
     if (s_cache_dir[0]) SetEnvironmentVariableA("PSX_OVERLAY_CACHE_DIR", s_cache_dir);
     if (s_captures[0])  SetEnvironmentVariableA("PSX_OVERLAY_CAPTURES",  s_captures);
     SetEnvironmentVariableA("PSX_OVERLAY_LIVE_AUTOCOMPILE", "1");
+    /* Pin the FLAVOR the same way: the tool's --flavor defaults to 0 (play),
+     * so an instrumented (flavor 2) runtime spawned a compile whose shards it
+     * could never load — the loader's flavor guard rejected them and EVERY
+     * overlay ran interpreted, forever, on debug builds. The child must
+     * always write the flavor this runtime reads. */
+    {
+        char flavor_buf[16];
+        snprintf(flavor_buf, sizeof flavor_buf, "%d", (int)PSX_OVERLAY_FLAVOR);
+        SetEnvironmentVariableA("PSX_OVERLAY_FLAVOR", flavor_buf);
+    }
 
     /* cmd.exe /C resolves the command via PATH and supports the relative
      * paths in the configured line (cwd = project root). The WHOLE command is

--- a/tools/compile_overlays.py
+++ b/tools/compile_overlays.py
@@ -5259,6 +5259,19 @@ def main():
         if _env_cap != args.captures:
             print(f'[cache] PSX_OVERLAY_CAPTURES overrides --captures: {_env_cap}')
         args.captures = _env_cap
+    # Flavor is pinned by the spawning runtime the same way as the cache
+    # locations: --flavor defaults to 0 (play), so an instrumented (flavor 2)
+    # runtime used to spawn compiles whose shards its loader then rejected —
+    # every overlay ran interpreted on debug builds, silently.
+    _env_flavor = os.environ.get('PSX_OVERLAY_FLAVOR')
+    if _env_flavor:
+        try:
+            _fl = int(_env_flavor, 0)
+        except ValueError:
+            _fl = None
+        if _fl is not None and _fl != args.flavor:
+            print(f'[cache] PSX_OVERLAY_FLAVOR overrides --flavor: {_fl}')
+            args.flavor = _fl
     if not args.captures:
         ap.error('no captures file: set PSX_OVERLAY_CAPTURES (runtime injects it) '
                  'or pass --captures for manual/offline use')


### PR DESCRIPTION
Split from original PR #169 by tetrisgm; original PR intentionally left open.\n\nThis PR extracts only the autocompile flavor pinning fix. Runtime-spawned overlay compiles now pass PSX_OVERLAY_FLAVOR through the environment, and 	ools/compile_overlays.py honors it over the default --flavor value.\n\nValidation run locally:\n- python -m py_compile tools/compile_overlays.py\n- Configured runtime with Retcomm Clang/Ninja using PSXRECOMP_ALLOW_NO_BIOS=ON and PSX_RECOMP_UI=OFF\n- Built psx-runtime\n\nNotes:\n- I added a local default PSX_OVERLAY_FLAVOR=0 in utocompile.c so this small split compiles without the larger overlay ABI flavor branch.\n- python tools/test_compile_overlays_additive.py is not a valid validation target for this narrow split on current master; it expects later additive-capture APIs that are intentionally not included here.