### PR TITLE
mods: enable Fast Loading by default

### DIFF
--- a/mods/builtin/packages/psx.enhancement.fast-loading/1.0.0/manifest.toml
+++ b/mods/builtin/packages/psx.enhancement.fast-loading/1.0.0/manifest.toml
@@ -15,9 +15,9 @@ game_id = "*"
 [[feature]]
 id = "fast-loading"
 name = "Fast Loading (host pacing)"
-description = "Disabled by default. Host pacing is the safe accelerator: it only changes how fast real time is fed to a load, so the guest cannot desync. It does speed the game up while a load is detected, which some speedrun routes rely on NOT happening -- if that is you, leave this off and use CD Speed instead."
+description = "Enabled by default. Host pacing changes only how quickly real time is fed to a load; guest frames, CD interrupts, and callbacks retain their normal schedule. Disable it for strictly authentic wall-clock loading."
 group = "Quality of Life"
-default_enabled = false
+default_enabled = true
 
 [[option]]
 feature = "fast-loading"


### PR DESCRIPTION
Split from original PR #169 by tetrisgm; original PR intentionally left open.

This is intentionally isolated as a policy-only PR. It globally changes the built-in Fast Loading feature from default-off to default-on for game_id='*'.

Validation:
- git diff --check

Risk / review note:
- This affects every title using the built-in mod catalog, so it should be accepted or rejected independently from the correctness and infrastructure splits.
- Requires heavier title regression if accepted: Mega Man X6, Tomba 1, Tomba 2, Ape Escape, and WipEout scenarios with Fast Loading default-on and explicitly disabled.