### PR TITLE
release: allowlist staged built-in mod packages

### DIFF
--- a/runtime/runtime.cmake
+++ b/runtime/runtime.cmake
@@ -1263,19 +1263,37 @@ function(psxrecomp_add_runtime_target target)
     # own POST_BUILD copy so a title may still override an id if it ever needs
     # to; copy_directory merges rather than replacing the tree.
     if(EXISTS "${PSXRECOMP_ROOT}/mods/builtin/packages")
+        # Clear first: copy_directory MERGES, so a mod deleted from source
+        # would otherwise survive in the build output forever and keep
+        # appearing on the Mods page (and inflate release catalog assertions).
+        # Scoped to mods/packages, not mods/: state.toml is launcher-owned user
+        # state and must survive a rebuild.
+        set(_psx_builtin_mod_copy_commands "")
+        if(DEFINED PSX_BUILTIN_MOD_ALLOWLIST AND NOT
+           "${PSX_BUILTIN_MOD_ALLOWLIST}" STREQUAL "")
+            foreach(_psx_builtin_mod IN LISTS PSX_BUILTIN_MOD_ALLOWLIST)
+                if(NOT EXISTS "${PSXRECOMP_ROOT}/mods/builtin/packages/${_psx_builtin_mod}")
+                    message(FATAL_ERROR
+                        "PSX_BUILTIN_MOD_ALLOWLIST names missing package: ${_psx_builtin_mod}")
+                endif()
+                list(APPEND _psx_builtin_mod_copy_commands
+                    COMMAND ${CMAKE_COMMAND} -E copy_directory
+                        "${PSXRECOMP_ROOT}/mods/builtin/packages/${_psx_builtin_mod}"
+                        "$<TARGET_FILE_DIR:${target}>/mods/packages/${_psx_builtin_mod}")
+            endforeach()
+        else()
+            list(APPEND _psx_builtin_mod_copy_commands
+                COMMAND ${CMAKE_COMMAND} -E copy_directory
+                    "${PSXRECOMP_ROOT}/mods/builtin"
+                    "$<TARGET_FILE_DIR:${target}>/mods")
+        endif()
         add_custom_command(TARGET ${target} POST_BUILD
-            # Clear first: copy_directory MERGES, so a mod deleted from source
-            # would otherwise survive in the build output forever and keep
-            # appearing on the Mods page (and inflate the release packagers'
-            # catalog assertions). This runs before the game's own staging, so
-            # both catalogs land on a clean slate.
             COMMAND ${CMAKE_COMMAND} -E rm -rf
-                "$<TARGET_FILE_DIR:${target}>/mods"
-            COMMAND ${CMAKE_COMMAND} -E copy_directory
-                "${PSXRECOMP_ROOT}/mods/builtin"
-                "$<TARGET_FILE_DIR:${target}>/mods"
-            COMMENT "Staging framework-owned mod catalog (loading speed)"
+                "$<TARGET_FILE_DIR:${target}>/mods/packages"
+            ${_psx_builtin_mod_copy_commands}
+            COMMENT "Staging framework-owned mod catalog"
             VERBATIM)
+        unset(_psx_builtin_mod_copy_commands)
     endif()
     endif()
 


### PR DESCRIPTION
Split from original PR #169 by tetrisgm; original PR intentionally left open.\n\nThis PR extracts only the framework-owned mod staging control:\n- Adds PSX_BUILTIN_MOD_ALLOWLIST so a title/release can stage only selected built-in packages.\n- Clears mods/packages rather than the whole mods tree, preserving launcher-owned mods/state.toml across rebuilds.\n\nValidation run locally:\n- Configured runtime with Retcomm Clang/Ninja using PSXRECOMP_ALLOW_NO_BIOS=ON and PSX_RECOMP_UI=OFF\n- Configured a second runtime build with PSX_BUILTIN_MOD_ALLOWLIST=psx.enhancement.fast-loading\n\nNotes:\n- This intentionally excludes package-default policy changes and new built-in packages; those are separate PRs.