### PR TITLE
recompiler: tail-transfer image-edge fallthroughs

### DIFF
--- a/recompiler/src/code_generator.cpp
+++ b/recompiler/src/code_generator.cpp
@@ -2788,6 +2788,24 @@ GeneratedFunction CodeGenerator::generate_function(
                                        fallthrough_name);
             }
         }
+    } else if (!cfg.block_order.empty()) {
+        // No in-image fallthrough function exists (region/image boundary): a
+        // reachable final block that runs off the end must publish its
+        // continuation PC. Falling off the C body would return with the
+        // entry-switch's consumed cpu->pc == 0, which the top-level trampoline
+        // reads as "program ended".
+        const BasicBlock& last_block = cfg.blocks.at(cfg.block_order.back());
+        bool runs_off_end =
+            last_block.exit_instr.type == ControlFlowType::None ||
+            ((last_block.exit_instr.type == ControlFlowType::Branch ||
+              last_block.exit_instr.type == ControlFlowType::Jump) &&
+             last_block.successors.empty());
+        bool is_reachable = last_block.is_entry || !last_block.predecessors.empty();
+        if (runs_off_end && is_reachable) {
+            body_ss << fmt::format(
+                "    cpu->pc = 0x{:08X}u; return;  /* image-edge fallthrough: tail-transfer */\n",
+                last_block.end_addr + 4u);
+        }
     }
     body_ss << "    ;  /* label compatibility: C requires a statement after the last label */\n";
     body_ss << "}\n";
@@ -3016,6 +3034,23 @@ std::vector<GeneratedFunction> CodeGenerator::generate_alias_group(
         if (needs_fallthrough) {
             body << fmt::format("    {}(cpu);  /* fallthrough to next function */\n",
                                 fallthrough_name);
+        }
+    } else if (!cfg.block_order.empty() &&
+               live_blocks.count(cfg.block_order.back())) {
+        // Image-edge fallthrough (mirrors generate_function): no in-image next
+        // function exists, so a live final block that runs off the end must
+        // tail-transfer to its continuation PC instead of falling off the C
+        // body with cpu->pc still consumed to 0.
+        const BasicBlock& last_block = cfg.blocks.at(cfg.block_order.back());
+        bool runs_off_end =
+            (last_block.exit_instr.type == ControlFlowType::None) ||
+            ((last_block.exit_instr.type == ControlFlowType::Branch ||
+              last_block.exit_instr.type == ControlFlowType::Jump) &&
+             last_block.successors.empty());
+        if (runs_off_end) {
+            body << fmt::format(
+                "    cpu->pc = 0x{:08X}u; return;  /* image-edge fallthrough: tail-transfer */\n",
+                last_block.end_addr + 4u);
         }
     }
     body << "    ;  /* label compatibility */\n";


### PR DESCRIPTION
Split from original PR #169 by tetrisgm; original PR intentionally left open.\n\nThis PR extracts only the recompiler image-edge fallthrough fix. If a reachable final block runs off the end of a region/image and there is no in-image fallthrough function, generated code now publishes the continuation PC and returns instead of falling off the C body with cpu->pc == 0.\n\nIncluded:\n- Normal function tail-transfer fallback in CodeGenerator::generate_function\n- Alias-host tail-transfer fallback in CodeGenerator::generate_alias_group\n\nValidation run locally:\n- Configured recompiler with Retcomm Clang/Ninja\n- Built psxrecomp-game\n- ctest --test-dir build/split-recompiler -R kuseg_dispatch_lookup --output-on-failure passed as part of the focused run\n- ctest --test-dir build/split-recompiler -R lwlr_load_delay_forward --output-on-failure passed as part of the focused run\n- Built and passed emitter_directive_line_test\n\nNotes:\n- I intentionally excluded the PC0 journal/trap diagnostics and runtime logging hunks from the original #169 commits.\n- This was hunk-extracted from the reconciled understanding of #169 so master fixes for KUSEG dispatch, LWL/LWR forwarding, and PGXP directive handling remain intact.