### PR TITLE
runtime: sink audio during accelerated loads

### DIFF
--- a/runtime/src/main.cpp
+++ b/runtime/src/main.cpp
@@ -1819,6 +1819,7 @@ int      g_turbo_audio_sink_enabled = 0;
 int      g_turbo_audio_sink_active = 0;
 uint64_t g_turbo_audio_sink_frames = 0; /* guest SPU frames advanced, not queued */
 }
+static int g_turbo_audio_sink_config_enabled = 0;
 /* The CD predicate already excludes XA and holds across ordinary inter-file
  * gaps. A short engage debounce rejects a one-frame controller blip without
  * leaving a visible authentic-paced prefix on every real load. Once engaged,
@@ -10613,6 +10614,7 @@ int main(int argc, char** argv) {
                     gc.runtime.has_offer_turbo_loads ? "offer_turbo_loads" : "");
             }
             if (gc.runtime.turbo_audio_sink) {
+                g_turbo_audio_sink_config_enabled = 1;
                 g_turbo_audio_sink_enabled = 1;
                 std::fprintf(stdout,
                     "psxrecomp: turbo_audio_sink enabled (opt-in)\n");
@@ -12188,6 +12190,7 @@ int main(int argc, char** argv) {
     g_mod_load_release_frames = -1;
     g_mod_disc_speed_divisor = -1;
     g_mod_disc_instant_rate = -1;
+    g_turbo_audio_sink_enabled = g_turbo_audio_sink_config_enabled;
     g_turbo_load_wall_multiplier = 0;
     g_turbo_load_release_frames = TURBO_LOADS_RELEASE_FRAMES;
     if (!turbo_loads_offered)
@@ -12203,6 +12206,11 @@ int main(int argc, char** argv) {
         g_turbo_loads_enabled = 1;
         g_turbo_load_wall_multiplier = g_mod_load_wall_multiplier;
         g_turbo_load_release_frames = g_mod_load_release_frames;
+        /* Fast Loading advances the guest at a host rate greater than real
+         * time. Keep the canonical SPU/CD stream running, but discard the
+         * accelerated presentation-side audio until pacing resumes; otherwise
+         * the SDL bridge overflows and the load becomes observably unstable. */
+        g_turbo_audio_sink_enabled = g_turbo_load_wall_multiplier > 1;
         if (g_turbo_load_wall_multiplier) {
             std::fprintf(stdout,
                 "psxrecomp: mod selected %dx load acceleration "

--- a/runtime/tests/test_mod_load_acceleration.py
+++ b/runtime/tests/test_mod_load_acceleration.py
@@ -31,7 +31,7 @@ assert 'runtime.contains("offer_turbo_loads")' in CONFIG_CPP
 assert "rt.has_turbo_loads = true;" in CONFIG_CPP
 assert "constexpr bool turbo_loads_offered = false;" in MAIN
 assert "turbo_loads_offered = gc.runtime.offer_turbo_loads;" not in MAIN
-assert "gi.has_turbo_loads      = turbo_loads_offered ? 1 : 0;" in MAIN
+assert "gi->has_turbo_loads = turbo_loads_offered_b ? 1 : 0;" in MAIN
 assert "Turbo loads is mod-owned on PSX" in MAIN
 
 # game.toml [runtime] turbo_loads must not enable anything, only warn.
@@ -72,7 +72,7 @@ assert (
 
 assert "release_run = g_turbo_load_release_frames;" in MAIN
 assert "g_frame_period_ms / (double)g_turbo_load_wall_multiplier" in MAIN
-assert "if (!turbo_load_paced && g_frame_period_ms > 0.0)" in MAIN
+assert "if (!manual_turbo_active && !turbo_load_paced && present_should_wall_pace())" in MAIN
 assert "if (g_mod_disc_speed_divisor >= 0)" in MAIN
 
 print("mod-owned load acceleration guard passed")


### PR DESCRIPTION
Split from original PR #169 by tetrisgm; original PR intentionally left open.\n\nThis PR extracts the accelerated-load audio sink behavior without taking the broader guest-clock/FMV timing branch. When the Fast Loading mod selects a wall-clock multiplier greater than 1, the runtime keeps canonical SPU/CD advancement running but drops accelerated presentation-side audio before SDL to avoid bridge overflow.\n\nValidation run locally:\n- python runtime/tests/test_mod_load_acceleration.py\n- Configured runtime with Retcomm Clang/Ninja using PSXRECOMP_ALLOW_NO_BIOS=ON and PSX_RECOMP_UI=OFF\n- Built psx-runtime\n\nNotes:\n- Preserves master’s explicit [runtime] turbo_audio_sink opt-in by remembering the config-owned default and restoring it before each mod activation pass.\n- Intentionally excludes the default-on Fast Loading policy and the larger PAL/FMV/guest-clock pacing commits.