### PR TITLE
presentation: reconstruct and filter FMV presents

### DIFF
--- a/recompiler/src/config_loader.cpp
+++ b/recompiler/src/config_loader.cpp
@@ -555,6 +555,13 @@ static RuntimeConfig parse_runtime_block(const toml::value& cfg, const fs::path&
             else throw std::runtime_error(fmt::format(
                 "[video] texture_filtering must be \"nearest\" or \"bilinear\": {}", mode));
         }
+        if (video.contains("fmv_filter")) {
+            const auto mode = toml::find<std::string>(video, "fmv_filter");
+            if (!video_fmv_filter_parse(mode, &rt.video_fmv_filter))
+                throw std::runtime_error(fmt::format(
+                    "[video] fmv_filter must be \"nearest\", \"bilinear\", "
+                    "\"sharp\" or \"bicubic\": {}", mode));
+        }
         if (video.contains("renderer")) {
             const auto mode = toml::find<std::string>(video, "renderer");
             if (mode == "software")     rt.video_renderer = 0;
@@ -2215,6 +2222,10 @@ UserSettings load_user_settings(const fs::path& path) {
             if (m == "nearest") { s.texture_filter = 0; s.has_texture_filter = true; }
             else if (m == "bilinear") { s.texture_filter = 1; s.has_texture_filter = true; }
         });
+        if (v.contains("fmv_filter")) try_get([&]{
+            const auto m = toml::find<std::string>(v, "fmv_filter");
+            if (video_fmv_filter_parse(m, &s.fmv_filter)) s.has_fmv_filter = true;
+        });
         if (v.contains("geometry_correction")) try_get([&]{
             s.geometry_correction = toml::find<bool>(v, "geometry_correction");
             s.has_geometry_correction = true;
@@ -2522,6 +2533,8 @@ bool save_user_settings(const fs::path& path, const UserSettings& s) {
         f << "antialiasing      = " << (s.antialiasing ? "true" : "false") << "\n";
     if (s.has_texture_filter)
         f << "texture_filtering = \"" << (s.texture_filter ? "bilinear" : "nearest") << "\"\n";
+    if (s.has_fmv_filter)
+        f << "fmv_filter        = \"" << video_fmv_filter_name(s.fmv_filter) << "\"\n";
     if (s.has_geometry_correction)
         f << "geometry_correction   = "
           << (s.geometry_correction ? "true" : "false") << "\n";

--- a/recompiler/src/config_loader.h
+++ b/recompiler/src/config_loader.h
@@ -55,6 +55,33 @@ inline constexpr int VIDEO_RENDERER_OPENGL = 1;
 inline constexpr int VIDEO_RENDERER_VULKAN = 2;
 inline constexpr int DEFAULT_VIDEO_RENDERER = VIDEO_RENDERER_OPENGL;
 
+// FMV present reconstruction, ordered least → most smoothing. See
+// RuntimeConfig::video_fmv_filter for what each one does and why bicubic is
+// the default. Shared by game.toml/settings parsing and runtime startup.
+inline constexpr int VIDEO_FMV_FILTER_NEAREST  = 0;
+inline constexpr int VIDEO_FMV_FILTER_BILINEAR = 1;
+inline constexpr int VIDEO_FMV_FILTER_SHARP    = 2;
+inline constexpr int VIDEO_FMV_FILTER_BICUBIC  = 3;
+inline constexpr int VIDEO_FMV_FILTER_COUNT    = 4;
+inline constexpr int VIDEO_FMV_FILTER_DEFAULT  = VIDEO_FMV_FILTER_BICUBIC;
+
+// Canonical settings.toml / game.toml spelling for each value, and its parse.
+inline const char* video_fmv_filter_name(int v) {
+    switch (v) {
+        case VIDEO_FMV_FILTER_NEAREST:  return "nearest";
+        case VIDEO_FMV_FILTER_BILINEAR: return "bilinear";
+        case VIDEO_FMV_FILTER_SHARP:    return "sharp";
+        default:                        return "bicubic";
+    }
+}
+inline bool video_fmv_filter_parse(const std::string& s, int* out) {
+    if (s == "nearest")       { *out = VIDEO_FMV_FILTER_NEAREST;  return true; }
+    else if (s == "bilinear") { *out = VIDEO_FMV_FILTER_BILINEAR; return true; }
+    else if (s == "sharp")    { *out = VIDEO_FMV_FILTER_SHARP;    return true; }
+    else if (s == "bicubic")  { *out = VIDEO_FMV_FILTER_BICUBIC;  return true; }
+    return false;
+}
+
 struct WidescreenSignedBoundSite {
     uint32_t address = 0;
     uint32_t expected = 0; // guarded LUI instruction
@@ -344,6 +371,18 @@ struct RuntimeConfig {
     // texture_filtering: "nearest" (default, native PSX look) | "bilinear"
     // (smooths textures and 2D backgrounds). Stored as 0/1.
     int                   video_texture_filter = 0;
+
+    // fmv_filter: how the 24-bit FMV present reconstructs its low-res source
+    // (a 320x192-class movie blown up to the window). Only consulted when
+    // antialiasing is on — AA off means nearest, as it does everywhere else.
+    //   0 nearest   point-sampled; hard pixels, uneven pixel widths at a
+    //               non-integer scale
+    //   1 bilinear  plain GL_LINEAR; smoothest, but blurs the whole texel
+    //   2 sharp     sharp-bilinear; flat texel interiors, ramp confined to a
+    //               one-output-pixel band at the boundary
+    //   3 bicubic   Catmull-Rom (default) — removes most of the staircase
+    //               while holding overall sharpness at the nearest level
+    int                   video_fmv_filter = VIDEO_FMV_FILTER_DEFAULT;
 
     // renderer: "software" | "opengl" (default) | "vulkan". Selects the
     // rasterizer/present backend. The software rasterizer remains the explicit
@@ -1110,6 +1149,9 @@ struct UserSettings {
     bool has_window_width   = false; int  window_width   = 1280; // -> 1280x960
     bool has_antialiasing   = false; bool antialiasing   = true;
     bool has_texture_filter = false; int  texture_filter = 0; // 0=nearest,1=bilinear
+    // FMV present reconstruction (VIDEO_FMV_FILTER_*). Only consulted when
+    // antialiasing is on. See RuntimeConfig::video_fmv_filter.
+    bool has_fmv_filter     = false; int  fmv_filter     = VIDEO_FMV_FILTER_DEFAULT;
     // Sub-pixel vertex precision / perspective-correct UVs (see RuntimeConfig).
     // Both default off — the faithful floor — and are player-selectable.
     bool has_geometry_correction   = false; bool geometry_correction   = false;

--- a/runtime/include/gpu_gl_renderer.h
+++ b/runtime/include/gpu_gl_renderer.h
@@ -81,6 +81,12 @@ void gl_renderer_restage_vram_after_savestate(void);
  * digests / GPUREAD authority) while the OpenGL hr FBO keeps settings-scale
  * SSAA for present-only. Never enables glReadPixels; CPU stays current. */
 void gl_renderer_set_cpu_auth_dual(int on);
+
+/* FMV present reconstruction, settings.toml [video] fmv_filter. Takes the
+ * config enum VIDEO_FMV_FILTER_* (0 nearest, 1 bilinear, 2 sharp, 3 bicubic).
+ * Only consulted while video antialiasing is on; AA off is always nearest.
+ * PSX_FMV_FILTER overrides this for one run. */
+void gl_renderer_set_fmv_filter(int cfg_value);
 int  gl_renderer_cpu_auth_dual(void);
 
 /* Post-savestate freeze probe: skip/swap/dirty-mark counters (GL present path).

--- a/runtime/src/gpu_gl_renderer.c
+++ b/runtime/src/gpu_gl_renderer.c
@@ -2668,6 +2668,33 @@ static void present_dump_drawable(int lx, int ly, int lw, int lh) {
     free(px);
 }
 
+/* FMV present reconstruction. Config-owned (settings.toml [video] fmv_filter,
+ * via gl_renderer_set_fmv_filter); PSX_FMV_FILTER overrides for a single run
+ * without touching the user's settings. Values are the config enum
+ * VIDEO_FMV_FILTER_* (0 nearest, 1 bilinear, 2 sharp, 3 bicubic); the shader
+ * mode is -1/0/1/2, so the two differ by one. */
+static int s_fmv_filter_cfg = 3;          /* bicubic */
+
+void gl_renderer_set_fmv_filter(int cfg_value) {
+    if (cfg_value >= 0 && cfg_value <= 3) s_fmv_filter_cfg = cfg_value;
+}
+
+static int fmv_filter_mode(void) {
+    static int env_mode = -2;             /* -2 = not yet looked up */
+    if (env_mode == -2) {
+        const char *e = getenv("PSX_FMV_FILTER");
+        env_mode = -3;                    /* -3 = no override */
+        if (e && e[0]) {
+            if (!strcmp(e, "nearest"))       env_mode = -1;
+            else if (!strcmp(e, "bilinear")) env_mode = 0;
+            else if (!strcmp(e, "sharp"))    env_mode = 1;
+            else if (!strcmp(e, "bicubic"))  env_mode = 2;
+        }
+    }
+    if (env_mode != -3) return env_mode;
+    return s_fmv_filter_cfg - 1;
+}
+
 /* Select the present-program sampling mode. s_present_prog is shared by the CPU
  * present and both VRAM/FBO quad paths, and program uniforms persist, so every
  * user states its choice rather than inheriting the last one's. sharp=0 keeps
@@ -3118,23 +3145,8 @@ void gl_renderer_present(const uint32_t *pixels, int src_w, int src_h, int linea
      * bilinear 0.14%/0.930. Bicubic removes two thirds of the staircase while
      * holding gradient at the nearest level; bilinear removes the most but
      * costs 10% of it, which reads as blur. Still a taste call, hence the knob. */
-    int filt_mode;
-    if (linear) {
-        static int mode_cached = -2;
-        if (mode_cached == -2) {
-            const char *e = getenv("PSX_FMV_FILTER");
-            mode_cached = 2;
-            if (e && e[0]) {
-                if (!strcmp(e, "nearest"))       mode_cached = -1;
-                else if (!strcmp(e, "bilinear")) mode_cached = 0;
-                else if (!strcmp(e, "sharp"))    mode_cached = 1;
-                else                             mode_cached = 2;
-            }
-        }
-        filt_mode = mode_cached;
-    } else {
-        filt_mode = -1;                   /* AA off: nearest, no shader work */
-    }
+    int filt_mode = linear ? fmv_filter_mode()
+                           : -1;          /* AA off: nearest, no shader work */
     glViewport(lx, ly, lw, lh);
     p_glActiveTexture(PSXGL_TEXTURE0);
     upload_present_tex(pixels, src_w, src_h, filt_mode >= 0 ? 1 : 0);

--- a/runtime/src/gpu_gl_renderer.c
+++ b/runtime/src/gpu_gl_renderer.c
@@ -806,6 +806,32 @@ static void pres_record(int path, int dx, int dy, int w, int h,
         const char *cfg = getenv("PSX_GL_PRESENT_PROBE");
         probe_pixels = (cfg && cfg[0] == '1') ? 1 : 0;
     }
+    /* PSX_PRESENT_DIAG=1: log every change of present path / display mode
+     * (path, 24-bit flag, scanout band, letterbox rect). FMV display bugs are
+     * hard to reason about from source because the band, the buffer the game
+     * is writing, and the band it is scanning out all move independently —
+     * this prints the transitions so they can be read off directly. Pairs with
+     * PSX_PRESENT_DUMP below, which writes the actual presented pixels. */
+    {
+        static int diag = -1;
+        if (diag < 0) {
+            const char *e2 = getenv("PSX_PRESENT_DIAG");
+            diag = (e2 && e2[0] && e2[0] != '0') ? 1 : 0;
+        }
+        if (diag) {
+            static int last_path = -1, last_d24 = -1, last_h = -1, last_dy = -1;
+            int d24 = gpu_display_is_depth24();
+            if (path != last_path || d24 != last_d24 || h != last_h ||
+                dy != last_dy) {
+                fprintf(stderr,
+                        "[PRES] f=%llu path=%d depth24=%d disp=(%d,%d %dx%d) "
+                        "letterbox=(%d,%d %dx%d)\n",
+                        (unsigned long long)s_frame_count, path, d24,
+                        dx, dy, w, h, lx, ly, lw, lh);
+                last_path = path; last_d24 = d24; last_h = h; last_dy = dy;
+            }
+        }
+    }
     GlPresEvent *e = &s_pres_ring[s_pres_seq % GL_PRES_RING_CAP];
     e->frame = (uint32_t)s_frame_count;
     e->t_ms  = (uint32_t)SDL_GetTicks();
@@ -1409,6 +1435,10 @@ static void flush_pack_if_sampling(int tpage_x, int tpage_y, int depth,
 }
 
 /* ---- coherency: GPU -> CPU readback -------------------------------------- */
+/* Defined with the depth24 policy below; needed here for the readback guard. */
+static int s_depth24_skip_up;
+static DirtyRect s_d24_skip_fb;
+
 static void ensure_cpu(void) {
     extern int psx_netplay_active(void);
     if (!s_raster_ok || !s_gpu_dirty) return;
@@ -1887,6 +1917,7 @@ static void gpu_line(int x0,int y0,uint16_t c0,int x1,int y1,uint16_t c1,int sem
 /* Shared PS1 uv-sampling model (limits + mirrored-2D compensation) — one
  * implementation for GL/VK/SW, see gpu_uv.h. */
 #include "gpu_uv.h"
+#include "png_write.h"
 
 /* Textured triangle. Always two passes split by the per-texel STP bit so the
  * stencil (mask) write value is constant within each pass; the semi pass is
@@ -2339,8 +2370,7 @@ static int  glb_render_display_hires(uint32_t *o,int p,int dx,int dy,int dw,int 
  * smaller texture A0s so post-FMV menus keep VRAM pages coherent.
  * On leave: clear the skipped FB union in the FBO — do NOT restage CPU RGB888
  * as 1555 (that painted MotK title rainbow/static). */
-static int s_depth24_skip_up = 0;
-static DirtyRect s_d24_skip_fb; /* union of skipped MDEC FB rects (VRAM halfwords) */
+/* (forward-declared above ensure_cpu) union of skipped MDEC FB rects, VRAM halfwords */
 
 static int depth24_is_fb_transfer(int x, int y, int w, int h) {
     if (!gpu_display_is_depth24() || w <= 0 || h <= 0) return 0;
@@ -2424,6 +2454,23 @@ static void depth24_clear_skipped_fb(void) {
 static void depth24_upload_policy(void) {
     int d24 = gpu_display_is_depth24();
     if (d24 && !s_depth24_skip_up) {
+        /* Entering 24-bit: from here the frame is presented from the CPU
+         * mirror, and MDEC only writes the movie's own rows. A letterboxed
+         * movie leaves the bars untouched, so they scan out whatever the
+         * mirror already held — and anything the game drew as a GPU PRIMITIVE
+         * (its pre-movie clear of those bars) lives only in the FBO and never
+         * reached the mirror. Sync once, here, at the transition.
+         *
+         * WipEout 3 intro without this: the movie is 320x192 written at +32
+         * inside a 320x240 band, double-buffered (rows 32-223 shown as band
+         * 0-239, rows 288-479 shown as band 256-495). The uncleared bars kept
+         * the previous SCEA screen, and because the two buffers hold it at
+         * different rows it alternated between the top and bottom bar every
+         * couple of frames — a flicker, not a static smear.
+         *
+         * Cost is one full-VRAM readback per 24-bit ENTRY (a handful per movie),
+         * not per frame; ensure_cpu is a no-op when the FBO is already clean. */
+        ensure_cpu();
         s_up_nrects = 0;
         rect_clear(&s_d24_skip_fb);
     } else if (!d24 && s_depth24_skip_up) {
@@ -2876,6 +2923,45 @@ void gl_renderer_present(const uint32_t *pixels, int src_w, int src_h, int linea
         uv_x1 = (float)content_w / (float)src_w;
         lw = (lw * content_w) / src_w;
         if (lw < 1) lw = 1;
+    }
+    /* PSX_PRESENT_DUMP=<dir>: write the CPU-present source (what the 24bpp FMV
+     * path actually shows) as PNGs, PSX_PRESENT_DUMP_FIRST..+COUNT frames. */
+    {
+        static int dump_init = 0;
+        static const char *dump_dir = NULL;
+        static long dump_first = 0, dump_count = 0, dumped = 0;
+        if (!dump_init) {
+            dump_init = 1;
+            dump_dir = getenv("PSX_PRESENT_DUMP");
+            const char *f = getenv("PSX_PRESENT_DUMP_FIRST");
+            const char *c = getenv("PSX_PRESENT_DUMP_COUNT");
+            dump_first = f ? atol(f) : 0;
+            dump_count = c ? atol(c) : 8;
+        }
+        if (dump_dir && dump_dir[0] && dumped < dump_count &&
+            (long)s_frame_count >= dump_first && src_w > 0 && src_h > 0) {
+            uint8_t *rgb = (uint8_t *)malloc((size_t)src_w * src_h * 3);
+            if (rgb) {
+                for (int i = 0; i < src_w * src_h; i++) {
+                    uint32_t p = pixels[i];          /* BGRA in memory */
+                    rgb[i * 3 + 0] = (uint8_t)(p >> 16);
+                    rgb[i * 3 + 1] = (uint8_t)(p >> 8);
+                    rgb[i * 3 + 2] = (uint8_t)(p);
+                }
+                char path[512];
+                snprintf(path, sizeof path, "%s/pres_%06llu.png", dump_dir,
+                         (unsigned long long)s_frame_count);
+                FILE *fp = fopen(path, "wb");
+                if (fp) {
+                    png_write_rgb(fp, rgb, (uint32_t)src_w, (uint32_t)src_h);
+                    fclose(fp);
+                    fprintf(stderr, "[PRESDUMP] %s (%dx%d)\n", path,
+                            src_w, src_h);
+                    dumped++;
+                }
+                free(rgb);
+            }
+        }
     }
     glViewport(lx, ly, lw, lh);
     p_glActiveTexture(PSXGL_TEXTURE0);

--- a/runtime/src/gpu_gl_renderer.c
+++ b/runtime/src/gpu_gl_renderer.c
@@ -146,6 +146,7 @@ typedef void   (APIENTRY *PFN_glUniform1i)(GLint, GLint);
 typedef void   (APIENTRY *PFN_glUniform1f)(GLint, GLfloat);
 typedef void   (APIENTRY *PFN_glUniform2i)(GLint, GLint, GLint);
 typedef void   (APIENTRY *PFN_glUniform4i)(GLint, GLint, GLint, GLint, GLint);
+typedef void   (APIENTRY *PFN_glUniform2f)(GLint, GLfloat, GLfloat);
 typedef void   (APIENTRY *PFN_glUniform4f)(GLint, GLfloat, GLfloat, GLfloat, GLfloat);
 typedef void   (APIENTRY *PFN_glBlendColor)(GLfloat, GLfloat, GLfloat, GLfloat);
 typedef void   (APIENTRY *PFN_glBlendFuncSeparate)(GLenum, GLenum, GLenum, GLenum);
@@ -211,6 +212,7 @@ static PFN_glUniform1i         p_glUniform1i;
 static PFN_glUniform1f         p_glUniform1f;
 static PFN_glUniform2i         p_glUniform2i;
 static PFN_glUniform4i         p_glUniform4i;
+static PFN_glUniform2f         p_glUniform2f;
 static PFN_glUniform4f         p_glUniform4f;
 static PFN_glBlendColor        p_glBlendColor;
 static PFN_glBlendFuncSeparate p_glBlendFuncSeparate;
@@ -268,6 +270,7 @@ static int load_modern_gl(void) {
     LOAD(p_glGetUniformLocation, "glGetUniformLocation"); LOAD(p_glUniform1i, "glUniform1i");
     LOAD(p_glUniform1f, "glUniform1f");
     LOAD(p_glUniform2i, "glUniform2i"); LOAD(p_glUniform4i, "glUniform4i");
+    LOAD(p_glUniform2f, "glUniform2f");
     LOAD(p_glUniform4f, "glUniform4f");
     LOAD(p_glBlendColor, "glBlendColor");
     LOAD(p_glBlendFuncSeparate, "glBlendFuncSeparate");
@@ -322,6 +325,8 @@ static int           s_osd_tw = 0, s_osd_th = 0;
 static GLuint        s_present_prog = 0, s_present_vao = 0;
 static void          gl_swap_with_osd(void);
 static GLint         s_present_uTex = -1, s_present_uUvRect = -1;
+static GLint         s_present_uTexSize = -1, s_present_uSharpScale = -1;
+static GLint         s_present_uSharp = -1;
 static GLuint        s_interp_prog = 0, s_interp_tex[3];
 static GLsync        s_interp_fence[3];
 static GLsync        s_interp_draw_fence = NULL;
@@ -885,10 +890,74 @@ static const char *PRESENT_VS =
     "  v_uv = vec2(mix(u_uv_rect.x,u_uv_rect.z,p.x),\n"
     "              mix(u_uv_rect.y,u_uv_rect.w,1.0-p.y));\n"
     "  gl_Position = vec4(p*2.0-1.0,0.0,1.0); }\n";
+/* Present sampling. u_sharp==0 is the historical behaviour: sample straight at
+ * v_uv, so the texture's own filter (NEAREST or LINEAR) decides everything.
+ *
+ * u_sharp==1 selects SHARP-BILINEAR, for upscaling a low-res source (FMV) to a
+ * much larger window. Plain GL_LINEAR blends across the whole texel and turns a
+ * 320x192 movie to mush; plain GL_NEAREST keeps it crisp but blocky and makes
+ * the non-integer scale factor beat (some source pixels land 3 window pixels
+ * wide, their neighbours 4). Sharp-bilinear keeps each texel flat across its
+ * interior and confines the linear ramp to a ONE-OUTPUT-PIXEL-wide band at the
+ * texel boundary: crisp like nearest, but without the uneven pixel widths.
+ *
+ * u_sharp_scale is output pixels per texel. At <=1 (downscale) the band covers
+ * the whole texel and this degrades to plain bilinear, which is what you want
+ * there. The result is clamped to u_uv_rect so the half-texel edge inset the
+ * caller applied still holds — that inset is what keeps LINEAR from bleeding
+ * the border texel into the image (the old reason FMV was pinned to NEAREST). */
 static const char *PRESENT_FS =
     "#version 330\n"
     "in vec2 v_uv; uniform sampler2D u_tex; out vec4 frag;\n"
-    "void main(){ frag = texture(u_tex, v_uv); }\n";
+    "uniform vec4 u_uv_rect;\n"
+    "uniform vec2 u_tex_size;\n"
+    "uniform vec2 u_sharp_scale;\n"
+    "uniform int  u_sharp;\n"
+    /* Catmull-Rom bicubic via 9 bilinear taps. Sharper than plain bilinear at
+     * the same smoothness, with mild overshoot that reads as edge definition.
+     * The present texture holds exactly the source rect and wraps CLAMP_TO_EDGE,
+     * so the +/-2 texel footprint clamps to real edge pixels, never garbage. */
+    "vec4 bicubic(vec2 uv){\n"
+    "  vec2 sp = uv * u_tex_size;\n"
+    "  vec2 t1 = floor(sp - 0.5) + 0.5;\n"
+    "  vec2 f  = sp - t1;\n"
+    "  vec2 w0 = f * (-0.5 + f * (1.0 - 0.5 * f));\n"
+    "  vec2 w1 = 1.0 + f * f * (-2.5 + 1.5 * f);\n"
+    "  vec2 w2 = f * (0.5 + f * (2.0 - 1.5 * f));\n"
+    "  vec2 w3 = f * f * (-0.5 + 0.5 * f);\n"
+    "  vec2 w12 = w1 + w2;\n"
+    "  vec2 t0 = (t1 - 1.0) / u_tex_size;\n"
+    "  vec2 t3 = (t1 + 2.0) / u_tex_size;\n"
+    "  vec2 t12 = (t1 + w2 / w12) / u_tex_size;\n"
+    "  vec4 r = vec4(0.0);\n"
+    "  r += texture(u_tex, vec2(t0.x , t0.y )) * (w0.x  * w0.y );\n"
+    "  r += texture(u_tex, vec2(t12.x, t0.y )) * (w12.x * w0.y );\n"
+    "  r += texture(u_tex, vec2(t3.x , t0.y )) * (w3.x  * w0.y );\n"
+    "  r += texture(u_tex, vec2(t0.x , t12.y)) * (w0.x  * w12.y);\n"
+    "  r += texture(u_tex, vec2(t12.x, t12.y)) * (w12.x * w12.y);\n"
+    "  r += texture(u_tex, vec2(t3.x , t12.y)) * (w3.x  * w12.y);\n"
+    "  r += texture(u_tex, vec2(t0.x , t3.y )) * (w0.x  * w3.y );\n"
+    "  r += texture(u_tex, vec2(t12.x, t3.y )) * (w12.x * w3.y );\n"
+    "  r += texture(u_tex, vec2(t3.x , t3.y )) * (w3.x  * w3.y );\n"
+    "  return r;\n"
+    "}\n"
+    "void main(){\n"
+    "  vec2 uv = v_uv;\n"
+    "  if (u_sharp == 2) { frag = bicubic(uv); return; }\n"
+    "  if (u_sharp == 1) {\n"
+    "    vec2 scale = max(u_sharp_scale, vec2(1.0));\n"
+    "    vec2 texel = uv * u_tex_size;\n"
+    "    vec2 tf    = floor(texel);\n"
+    "    vec2 cd    = (texel - tf) - 0.5;\n"
+    "    vec2 band  = 0.5 - 0.5 / scale;\n"
+    "    vec2 f     = (cd - clamp(cd, -band, band)) * scale + 0.5;\n"
+    "    uv = (tf + f) / u_tex_size;\n"
+    "    vec2 lo = min(u_uv_rect.xy, u_uv_rect.zw);\n"
+    "    vec2 hi = max(u_uv_rect.xy, u_uv_rect.zw);\n"
+    "    uv = clamp(uv, lo, hi);\n"
+    "  }\n"
+    "  frag = texture(u_tex, uv);\n"
+    "}\n";
 static const char *INTERP_FS =
     "#version 330\n"
     "in vec2 v_uv; uniform sampler2D u_prev; uniform sampler2D u_curr;\n"
@@ -2533,6 +2602,92 @@ static void upload_present_tex(const uint32_t *pixels, int w, int h, int linear)
     }
 }
 
+/* ---- present pixel dumps (diagnostic) -----------------------------------
+ * PSX_PRESENT_DUMP=<dir> writes the presented frame as PNG over the window
+ * [PSX_PRESENT_DUMP_FIRST, +PSX_PRESENT_DUMP_COUNT) guest frames. The source
+ * image always; with PSX_PRESENT_DUMP_OUT=1 also the drawn RESULT read back
+ * from the drawable, which is the only way to judge a present-filter change on
+ * the pixels the user actually sees. Frame-range gated (not counter gated) so
+ * the two stay in lockstep. Entirely inert when the env is unset. */
+static const char *present_dump_dir(void) {
+    static int init = 0;
+    static const char *dir = NULL;
+    if (!init) { init = 1; dir = getenv("PSX_PRESENT_DUMP"); }
+    return (dir && dir[0]) ? dir : NULL;
+}
+
+static int present_dump_active(void) {
+    static int init = 0;
+    static long first = 0, count = 0;
+    if (!present_dump_dir()) return 0;
+    if (!init) {
+        init = 1;
+        const char *f = getenv("PSX_PRESENT_DUMP_FIRST");
+        const char *c = getenv("PSX_PRESENT_DUMP_COUNT");
+        first = f ? atol(f) : 0;
+        count = c ? atol(c) : 8;
+    }
+    long f = (long)s_frame_count;
+    return f >= first && f < first + count;
+}
+
+static void present_dump_png(const char *tag, const uint8_t *rgb,
+                             int w, int h) {
+    const char *dir = present_dump_dir();
+    if (!dir || w <= 0 || h <= 0) return;
+    char path[512];
+    snprintf(path, sizeof path, "%s/%s_%06llu.png", dir, tag,
+             (unsigned long long)s_frame_count);
+    FILE *fp = fopen(path, "wb");
+    if (!fp) return;
+    png_write_rgb(fp, rgb, (uint32_t)w, (uint32_t)h);
+    fclose(fp);
+    fprintf(stderr, "[PRESDUMP] %s (%dx%d)\n", path, w, h);
+}
+
+/* Read the just-drawn letterbox rect back out of the drawable. Synchronous and
+ * slow — strictly a diagnostic, only ever reached while dumping. */
+static void present_dump_drawable(int lx, int ly, int lw, int lh) {
+    if (!present_dump_active() || lw <= 0 || lh <= 0) return;
+    const char *out = getenv("PSX_PRESENT_DUMP_OUT");
+    if (!out || out[0] == '0') return;
+    uint8_t *px = (uint8_t *)malloc((size_t)lw * lh * 3);
+    if (!px) return;
+    p_glBindFramebuffer(PSXGL_READ_FRAMEBUFFER, 0);
+    glPixelStorei(GL_PACK_ALIGNMENT, 1);
+    glReadPixels(lx, ly, lw, lh, GL_RGB, GL_UNSIGNED_BYTE, px);
+    /* GL is bottom-origin; PNG rows are top-down. */
+    uint8_t *flip = (uint8_t *)malloc((size_t)lw * lh * 3);
+    if (flip) {
+        for (int y = 0; y < lh; y++)
+            memcpy(flip + (size_t)y * lw * 3,
+                   px + (size_t)(lh - 1 - y) * lw * 3, (size_t)lw * 3);
+        present_dump_png("out", flip, lw, lh);
+        free(flip);
+    }
+    free(px);
+}
+
+/* Select the present-program sampling mode. s_present_prog is shared by the CPU
+ * present and both VRAM/FBO quad paths, and program uniforms persist, so every
+ * user states its choice rather than inheriting the last one's. sharp=0 keeps
+ * the historical straight sample. */
+static void present_set_sharp(int mode, int tex_w, int tex_h,
+                              int out_w, int out_h) {
+    if (s_present_uSharp < 0) return;
+    if (mode <= 0 || tex_w <= 0 || tex_h <= 0) {
+        p_glUniform1i(s_present_uSharp, 0);
+        return;
+    }
+    p_glUniform1i(s_present_uSharp, mode);
+    if (s_present_uTexSize >= 0)
+        p_glUniform2f(s_present_uTexSize, (float)tex_w, (float)tex_h);
+    if (s_present_uSharpScale >= 0)
+        p_glUniform2f(s_present_uSharpScale,
+                      (float)out_w / (float)tex_w,
+                      (float)out_h / (float)tex_h);
+}
+
 /* Display aspect for the present letterbox. Default 4:3 (native). When a wide
  * aspect is configured the 4:3 frame is stretched into it — paired with the
  * GTE X-squash (gte_set_display_aspect) this nets a wider field of view. */
@@ -2797,6 +2952,12 @@ int gl_renderer_init_context(SDL_Window *win) {
             p_glGenVertexArrays(1, &s_present_vao);
             s_present_uTex = p_glGetUniformLocation(s_present_prog, "u_tex");
             s_present_uUvRect = p_glGetUniformLocation(s_present_prog, "u_uv_rect");
+            s_present_uTexSize =
+                p_glGetUniformLocation(s_present_prog, "u_tex_size");
+            s_present_uSharpScale =
+                p_glGetUniformLocation(s_present_prog, "u_sharp_scale");
+            s_present_uSharp =
+                p_glGetUniformLocation(s_present_prog, "u_sharp");
             s_interp_uPrev = p_glGetUniformLocation(s_interp_prog, "u_prev");
             s_interp_uCurr = p_glGetUniformLocation(s_interp_prog, "u_curr");
             s_interp_uAlpha = p_glGetUniformLocation(s_interp_prog, "u_alpha");
@@ -2924,22 +3085,9 @@ void gl_renderer_present(const uint32_t *pixels, int src_w, int src_h, int linea
         lw = (lw * content_w) / src_w;
         if (lw < 1) lw = 1;
     }
-    /* PSX_PRESENT_DUMP=<dir>: write the CPU-present source (what the 24bpp FMV
-     * path actually shows) as PNGs, PSX_PRESENT_DUMP_FIRST..+COUNT frames. */
-    {
-        static int dump_init = 0;
-        static const char *dump_dir = NULL;
-        static long dump_first = 0, dump_count = 0, dumped = 0;
-        if (!dump_init) {
-            dump_init = 1;
-            dump_dir = getenv("PSX_PRESENT_DUMP");
-            const char *f = getenv("PSX_PRESENT_DUMP_FIRST");
-            const char *c = getenv("PSX_PRESENT_DUMP_COUNT");
-            dump_first = f ? atol(f) : 0;
-            dump_count = c ? atol(c) : 8;
-        }
-        if (dump_dir && dump_dir[0] && dumped < dump_count &&
-            (long)s_frame_count >= dump_first && src_w > 0 && src_h > 0) {
+    if (present_dump_active()) {
+        /* Source pixels, i.e. the frame BEFORE the present filter. */
+        if (src_w > 0 && src_h > 0) {
             uint8_t *rgb = (uint8_t *)malloc((size_t)src_w * src_h * 3);
             if (rgb) {
                 for (int i = 0; i < src_w * src_h; i++) {
@@ -2948,25 +3096,50 @@ void gl_renderer_present(const uint32_t *pixels, int src_w, int src_h, int linea
                     rgb[i * 3 + 1] = (uint8_t)(p >> 8);
                     rgb[i * 3 + 2] = (uint8_t)(p);
                 }
-                char path[512];
-                snprintf(path, sizeof path, "%s/pres_%06llu.png", dump_dir,
-                         (unsigned long long)s_frame_count);
-                FILE *fp = fopen(path, "wb");
-                if (fp) {
-                    png_write_rgb(fp, rgb, (uint32_t)src_w, (uint32_t)src_h);
-                    fclose(fp);
-                    fprintf(stderr, "[PRESDUMP] %s (%dx%d)\n", path,
-                            src_w, src_h);
-                    dumped++;
-                }
+                present_dump_png("pres", rgb, src_w, src_h);
                 free(rgb);
             }
         }
     }
+    /* This is the low-res source path (24-bit FMV, and the forced-CPU present
+     * diagnostic): a 320x192-class image blown up to fill the window, so how it
+     * is reconstructed is very visible. `linear` (the video AA setting) chooses
+     * filtered vs not; PSX_FMV_FILTER then picks which reconstruction:
+     *
+     *   nearest   hard pixels, uneven pixel widths at non-integer scale
+     *   bilinear  plain GL_LINEAR — smoothest, but blurs the whole texel
+     *   sharp     sharp-bilinear: flat texel interiors, ramp confined to a
+     *             one-output-pixel band at the boundary
+     *   bicubic   Catmull-Rom (default)
+     *
+     * Measured on this intro at 1280x960 (fraction of adjacent pixel pairs
+     * differing by >=24 luma = visible staircase, vs mean |dx| = overall
+     * sharpness): nearest 1.00%/1.028, sharp 0.87%/1.008, bicubic 0.34%/1.038,
+     * bilinear 0.14%/0.930. Bicubic removes two thirds of the staircase while
+     * holding gradient at the nearest level; bilinear removes the most but
+     * costs 10% of it, which reads as blur. Still a taste call, hence the knob. */
+    int filt_mode;
+    if (linear) {
+        static int mode_cached = -2;
+        if (mode_cached == -2) {
+            const char *e = getenv("PSX_FMV_FILTER");
+            mode_cached = 2;
+            if (e && e[0]) {
+                if (!strcmp(e, "nearest"))       mode_cached = -1;
+                else if (!strcmp(e, "bilinear")) mode_cached = 0;
+                else if (!strcmp(e, "sharp"))    mode_cached = 1;
+                else                             mode_cached = 2;
+            }
+        }
+        filt_mode = mode_cached;
+    } else {
+        filt_mode = -1;                   /* AA off: nearest, no shader work */
+    }
     glViewport(lx, ly, lw, lh);
     p_glActiveTexture(PSXGL_TEXTURE0);
-    upload_present_tex(pixels, src_w, src_h, linear);
+    upload_present_tex(pixels, src_w, src_h, filt_mode >= 0 ? 1 : 0);
     p_glUseProgram(s_present_prog); p_glUniform1i(s_present_uTex, 0);
+    present_set_sharp(filt_mode, src_w, src_h, lw, lh);
     if (crop) {
         /* Cropped present keeps left-aligned content; still inset so linear
          * AA does not blend the cut column with undefined border texels. */
@@ -2985,6 +3158,10 @@ void gl_renderer_present(const uint32_t *pixels, int src_w, int src_h, int linea
     }
     p_glBindVertexArray(s_present_vao); glDrawArrays(GL_TRIANGLES, 0, 3);
     p_glBindVertexArray(0); p_glUseProgram(0);
+    /* PSX_PRESENT_DUMP_OUT=1: dump the drawn RESULT (post-filter) as well as
+     * the source above, so a present-filter change can be judged on the pixels
+     * the user actually sees instead of by eye. Same frame window/count. */
+    present_dump_drawable(lx, ly, lw, lh);
     pres_record(GL_PRES_CPU, 0, 0, src_w, src_h, lx, ly, lw, lh);
     hold_capture_drawable();
     latency_ring_mark(LAT_SWAP_BEGIN);
@@ -3994,6 +4171,7 @@ static void gl_draw_osd_image(const uint32_t *px, int ow, int oh,
     glViewport(vx, wh - vy - dh, dw, dh);
     p_glUseProgram(s_present_prog);
     p_glUniform1i(s_present_uTex, 0);
+    present_set_sharp(0, 0, 0, 0, 0);   /* OSD is authored at output res */
     /* Host OSD bitmaps are top-down (row 0 = top), same as guest CPU
      * present with v_flip=1: uv (0,0)-(1,1). (0,1)-(1,0) was the hold-last
      * cancel for already-oriented captures and made toasts upside-down. */
@@ -4062,6 +4240,9 @@ static void present_target_quad(GLuint tex, int tex_w, int tex_h,
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, linear ? GL_LINEAR : GL_NEAREST);
     p_glUseProgram(s_present_prog);
     p_glUniform1i(s_present_uTex, 0);
+    /* The rasterized path already renders at the internal scale, so it has no
+     * low-res source to reconstruct — keep the plain sample. */
+    present_set_sharp(0, 0, 0, 0, 0);
     /* Half-texel inset: with GL_LINEAR, corner-mapped UVs make the outermost
      * dest pixels blend the border texel with VRAM outside the content rect
      * (visible edge stripe with AA on). Center-mapped UVs keep edge samples

--- a/runtime/src/main.cpp
+++ b/runtime/src/main.cpp
@@ -1103,6 +1103,23 @@ extern "C" EMSCRIPTEN_KEEPALIVE void psx_web_set_smooth_60fps(int enabled) {
 /* [video] options, resolved from the game config (defaults: native + AA). */
 static int           g_video_scale = 1;     /* internal-resolution SSAA factor */
 static bool          g_video_aa    = true;  /* linear present filtering */
+/* FMV present reconstruction (VIDEO_FMV_FILTER_*), pushed to the GL renderer
+ * once the config is resolved. Only consulted while g_video_aa is on. */
+static int           g_video_fmv_filter = PSXRecompV4::VIDEO_FMV_FILTER_DEFAULT;
+
+/* recomp-ui stores this 1-based so a zero-initialized (older) host reads as
+ * "unset" rather than pinning nearest; the config enum is 0-based. Convert at
+ * the boundary, and treat anything out of range as the default. */
+static inline int launcher_fmv_filter_to_cfg(int ls_value) {
+    if (ls_value < 1 || ls_value > RECOMP_LAUNCHER_FMV_FILTER_COUNT)
+        return PSXRecompV4::VIDEO_FMV_FILTER_DEFAULT;
+    return ls_value - 1;
+}
+static inline int cfg_fmv_filter_to_launcher(int cfg_value) {
+    if (cfg_value < 0 || cfg_value >= PSXRecompV4::VIDEO_FMV_FILTER_COUNT)
+        cfg_value = PSXRecompV4::VIDEO_FMV_FILTER_DEFAULT;
+    return cfg_value + 1;
+}
 static int           g_video_texfilter = 0; /* 0=nearest, 1=bilinear */
 /* Sub-pixel vertex precision + perspective-correct UVs (PGXP-style). Visual
  * only: the PS1-visible GTE SXY FIFO stays integer, so guest-side culling and
@@ -6832,6 +6849,7 @@ static NetplayVblankEpilogue sdl_vblank_present_body(void) {
          * default bicubic) instead of smearing whole texels. Measured: the
          * right-edge jump the old comment describes is 0 with filtering on.
          * Set video AA off to get nearest back. */
+        gl_renderer_set_fmv_filter(g_video_fmv_filter);
         gl_renderer_present(sdl_pixel_buf, src_w, src_h,
                             g_video_aa ? 1 : 0,
                             pin_43 ? 1 : 0, 0 /* full width */);
@@ -10642,6 +10660,7 @@ int main(int argc, char** argv) {
             g_video_scale      = gc.runtime.video_supersampling;
             g_video_aa         = gc.runtime.video_antialiasing;
             g_video_texfilter  = gc.runtime.video_texture_filter;
+            g_video_fmv_filter = gc.runtime.video_fmv_filter;
             g_video_geometry_correction   =
                 gc.runtime.video_geometry_correction ? 1 : 0;
             g_video_perspective_texturing =
@@ -11019,6 +11038,7 @@ int main(int argc, char** argv) {
         if (us.has_window_width)   g_video_win_w     = us.window_width;
         if (us.has_antialiasing)   g_video_aa        = us.antialiasing;
         if (us.has_texture_filter) g_video_texfilter = us.texture_filter;
+        if (us.has_fmv_filter)     g_video_fmv_filter = us.fmv_filter;
         if (us.has_geometry_correction)
             g_video_geometry_correction = us.geometry_correction ? 1 : 0;
         if (us.has_perspective_texturing)
@@ -11444,6 +11464,7 @@ int main(int argc, char** argv) {
             seed.supersampling = g_video_scale;           seed.has_supersampling = true;
             seed.antialiasing = g_video_aa;               seed.has_antialiasing = true;
             seed.texture_filter = g_video_texfilter;      seed.has_texture_filter = true;
+            seed.fmv_filter = g_video_fmv_filter;         seed.has_fmv_filter = true;
             /* Seeded (and marked present) so a launcher save round-trips the
              * player's hand-edited value instead of dropping the key. */
             seed.geometry_correction = (g_video_geometry_correction != 0);
@@ -11631,6 +11652,7 @@ int main(int argc, char** argv) {
             ls.supersampling      = seed.supersampling;
             ls.antialiasing       = seed.antialiasing ? 1 : 0;
             ls.texture_filter     = seed.texture_filter;
+            ls.fmv_filter         = cfg_fmv_filter_to_launcher(seed.fmv_filter);
             ls.geometry_correction   = seed.geometry_correction ? 1 : 0;
             ls.perspective_texturing = seed.perspective_texturing ? 1 : 0;
             ls.screen_kind        = seed.screen_kind;
@@ -11823,6 +11845,8 @@ int main(int argc, char** argv) {
                  * is the legacy fallback field for consoles without the cap and is
                  * left unused here. */
                 seed.texture_filter = ls.texture_filter ? 1 : 0; seed.has_texture_filter = true;
+                seed.fmv_filter = launcher_fmv_filter_to_cfg(ls.fmv_filter);
+                seed.has_fmv_filter = true;
                 {
                     const int n = std::min(PSX_MAX_PLAYERS, RECOMP_LAUNCHER_MAX_PLAYERS);
                     const int un = std::min(n, PSXRecompV4::UserSettings::kMaxControllerPlayers);
@@ -11868,6 +11892,8 @@ int main(int argc, char** argv) {
                 seed.has_geometry_correction = true;
                 seed.perspective_texturing = ls.perspective_texturing != 0;
                 seed.has_perspective_texturing = true;
+                seed.fmv_filter            = launcher_fmv_filter_to_cfg(ls.fmv_filter);
+                seed.has_fmv_filter        = true;
                 seed.screen_kind           = ls.screen_kind;           seed.has_screen_kind           = true;
                 seed.frame_interpolation   = ls.frame_interp != 0;     seed.has_frame_interpolation   = true;
                 seed.frame_interpolation_fps = ls.frame_interp_fps;    seed.has_frame_interpolation_fps = true;
@@ -12070,6 +12096,7 @@ int main(int argc, char** argv) {
                 g_video_scale     = seed.supersampling;
                 g_video_aa        = seed.antialiasing;
                 g_video_texfilter = seed.texture_filter;
+                g_video_fmv_filter = seed.fmv_filter;
                 g_video_geometry_correction   = seed.geometry_correction ? 1 : 0;
                 g_video_perspective_texturing = seed.perspective_texturing ? 1 : 0;
                 g_video_screen    = seed.screen_kind;
@@ -13437,6 +13464,7 @@ soft_return_lobby:
         ls.supersampling = g_video_scale;
         ls.antialiasing = g_video_aa ? 1 : 0;
         ls.texture_filter = g_video_texfilter;
+        ls.fmv_filter = cfg_fmv_filter_to_launcher(g_video_fmv_filter);
         ls.geometry_correction = g_video_geometry_correction ? 1 : 0;
         ls.perspective_texturing = g_video_perspective_texturing ? 1 : 0;
         ls.screen_kind = g_video_screen;
@@ -13689,6 +13717,8 @@ soft_return_lobby:
                 us.has_antialiasing = true;
                 us.texture_filter = ls.texture_filter;
                 us.has_texture_filter = true;
+                us.fmv_filter = launcher_fmv_filter_to_cfg(ls.fmv_filter);
+                us.has_fmv_filter = true;
                 us.geometry_correction = ls.geometry_correction != 0;
                 us.has_geometry_correction = true;
                 us.perspective_texturing = ls.perspective_texturing != 0;
@@ -13744,6 +13774,7 @@ soft_return_lobby:
             g_video_scale = ls.supersampling;
             g_video_aa = ls.antialiasing;
             g_video_texfilter = ls.texture_filter;
+            g_video_fmv_filter = launcher_fmv_filter_to_cfg(ls.fmv_filter);
             g_video_geometry_correction = ls.geometry_correction ? 1 : 0;
             g_video_perspective_texturing = ls.perspective_texturing ? 1 : 0;
             g_video_screen = ls.screen_kind;

--- a/runtime/src/main.cpp
+++ b/runtime/src/main.cpp
@@ -6823,10 +6823,17 @@ static NetplayVblankEpilogue sdl_vblank_present_body(void) {
         /* OpenGL present: upload the active display rect and draw a full-screen
          * quad. Either SwapWindow vsync OR the wall-clock pacer owns timing,
          * never both. 24-bit (FMV) frames pin to native 4:3. */
-        /* FMV: nearest present — linear filtering fringes the right edge of
-         * low-res 24-bit scanouts into adjacent (often garbage) texels. */
+        /* FMV follows the same AA setting as everything else. It used to be
+         * pinned to nearest because plain GL_LINEAR fringed the right edge of
+         * low-res 24-bit scanouts into adjacent (often garbage) texels — but
+         * gl_renderer_present now half-texel-insets its UV rect (and crops the
+         * depth24 margin via content_w), which is exactly that bleed, and it
+         * reconstructs a filtered low-res source properly (PSX_FMV_FILTER,
+         * default bicubic) instead of smearing whole texels. Measured: the
+         * right-edge jump the old comment describes is 0 with filtering on.
+         * Set video AA off to get nearest back. */
         gl_renderer_present(sdl_pixel_buf, src_w, src_h,
-                            (g_video_aa && !depth24_frame) ? 1 : 0,
+                            g_video_aa ? 1 : 0,
                             pin_43 ? 1 : 0, 0 /* full width */);
         netplay_note_present();
     } else {

--- a/runtime/src/main.cpp
+++ b/runtime/src/main.cpp
@@ -1111,7 +1111,7 @@ static int           g_video_fmv_filter = PSXRecompV4::VIDEO_FMV_FILTER_DEFAULT;
  * "unset" rather than pinning nearest; the config enum is 0-based. Convert at
  * the boundary, and treat anything out of range as the default. */
 static inline int launcher_fmv_filter_to_cfg(int ls_value) {
-    if (ls_value < 1 || ls_value > RECOMP_LAUNCHER_FMV_FILTER_COUNT)
+    if (ls_value < 1 || ls_value > PSXRecompV4::VIDEO_FMV_FILTER_COUNT)
         return PSXRecompV4::VIDEO_FMV_FILTER_DEFAULT;
     return ls_value - 1;
 }


### PR DESCRIPTION
Split from original PR #169 by tetrisgm; original PR intentionally left open.

Scope:
- Sync the CPU VRAM mirror when entering 24-bit/15-bit display paths.
- Reconstruct low-res 24-bit FMV presents in the GL renderer before window scaling.
- Add the shared [video] fmv_filter setting and runtime/launcher round-trip conversion.

Kept out of this split:
- PAL timing and guest-clock changes.
- Turbo/load-acceleration/audio-sink changes.
- Texture-pack and PGXP changes.

Validation:
- python runtime/tests/test_fmv_quiet_guards.py
- cmake --build build\\split-runtime --target psx-runtime
- cmake --build build\\split-recompiler --target psxrecomp-toml

Notes:
- Added one split-only fix to bound launcher conversion against PSXRecompV4::VIDEO_FMV_FILTER_COUNT instead of an unreconciled launcher-only constant.