### PR TITLE
SteamOS/Steam Deck self-build: wire pack sysroot into CMake, surface CLI failure lines, toolchain-stamp hardening

### DIFF
--- a/host/psxrecomp_codegen_host.c
+++ b/host/psxrecomp_codegen_host.c
@@ -1496,6 +1496,55 @@ static void handle_progress_line(const char* line,
     }
 }
 
+/* Last-lines capture so a failed CLI run can say WHY in the wizard, which has
+ * no console: the child's stderr shares the progress pipe, JSON progress rows
+ * contribute their "message", raw rows (compiler/traceback text) contribute
+ * as-is, and the most recent error-looking line is appended to err_msg. This
+ * is what turns "psxrecomp rebuild failed (exit 1)" into "… failed (exit 1):
+ * Could NOT find OpenGL (missing: OPENGL_INCLUDE_DIR)". */
+typedef struct {
+    char last[480];
+    char last_err[480];
+} CliTail;
+
+static int cli_tail_line_is_error(const char* s) {
+    return strstr(s, "rror") != NULL || strstr(s, "ailed") != NULL ||
+           strstr(s, "FAILED") != NULL || strstr(s, "Traceback") != NULL ||
+           strstr(s, "fatal") != NULL || strstr(s, "Fatal") != NULL;
+}
+
+static void cli_tail_note(CliTail* t, const char* line) {
+    char msg[480];
+    const char* rec = line;
+    int is_error_event = 0;
+    if (line[0] == '{') {
+        /* sdk_progress emits compact JSON: {"event":"error","message":…}. */
+        is_error_event = strstr(line, "\"event\":\"error\"") != NULL;
+        if (!json_get_string(line, "message", msg, sizeof(msg)))
+            return; /* structured row without text (e.g. result) */
+        rec = msg;
+    }
+    if (!rec[0])
+        return;
+    snprintf(t->last, sizeof(t->last), "%s", rec);
+    if (is_error_event || cli_tail_line_is_error(rec))
+        snprintf(t->last_err, sizeof(t->last_err), "%s", rec);
+}
+
+static void cli_fail_msg(char* err_msg, size_t err_cap, const char* fail_label,
+                         long code, const CliTail* t) {
+    const char* why = t->last_err[0] ? t->last_err : t->last;
+    if (code == 3) {
+        snprintf(err_msg, err_cap, "Disc verification failed (wrong dump).");
+        return;
+    }
+    if (why[0])
+        snprintf(err_msg, err_cap, "%s failed (exit %ld): %s", fail_label,
+                 code, why);
+    else
+        snprintf(err_msg, err_cap, "%s failed (exit %ld).", fail_label, code);
+}
+
 #if defined(_WIN32)
 static int run_cli_win(const char* cmdline,
                        RecompLauncherCPrepareProgressFn on_progress,
@@ -1519,7 +1568,9 @@ static int run_cli_win(const char* cmdline,
     si.cb = sizeof(si);
     si.dwFlags = STARTF_USESTDHANDLES;
     si.hStdOutput = wr;
-    si.hStdError = GetStdHandle(STD_ERROR_HANDLE);
+    /* stderr shares the pipe: Python tracebacks and raw tool output feed the
+     * CliTail capture instead of vanishing (the wizard has no console). */
+    si.hStdError = wr;
     si.hStdInput = GetStdHandle(STD_INPUT_HANDLE);
 
     char mutable_cmd[4096];
@@ -1538,6 +1589,8 @@ static int run_cli_win(const char* cmdline,
     char line[16384];
     size_t line_len = 0;
     DWORD n = 0;
+    CliTail tail;
+    memset(&tail, 0, sizeof(tail));
     while (ReadFile(rd, buf, sizeof(buf), &n, NULL) && n > 0) {
         for (DWORD i = 0; i < n; ++i) {
             char c = buf[i];
@@ -1545,6 +1598,7 @@ static int run_cli_win(const char* cmdline,
             if (c == '\n') {
                 line[line_len] = '\0';
                 handle_progress_line(line, on_progress, progress_ctx);
+                cli_tail_note(&tail, line);
                 line_len = 0;
                 continue;
             }
@@ -1555,6 +1609,7 @@ static int run_cli_win(const char* cmdline,
     if (line_len) {
         line[line_len] = '\0';
         handle_progress_line(line, on_progress, progress_ctx);
+        cli_tail_note(&tail, line);
     }
     CloseHandle(rd);
     WaitForSingleObject(pi.hProcess, INFINITE);
@@ -1563,11 +1618,7 @@ static int run_cli_win(const char* cmdline,
     CloseHandle(pi.hThread);
     CloseHandle(pi.hProcess);
     if (code == 0) return 1;
-    if (code == 3)
-        snprintf(err_msg, err_cap, "Disc verification failed (wrong dump).");
-    else
-        snprintf(err_msg, err_cap, "%s failed (exit %lu).", fail_label,
-                 (unsigned long)code);
+    cli_fail_msg(err_msg, err_cap, fail_label, (long)code, &tail);
     return 0;
 }
 #else
@@ -1585,6 +1636,9 @@ static int run_cli_posix(char* const argv[],
     posix_spawn_file_actions_init(&actions);
     posix_spawn_file_actions_addclose(&actions, pipefd[0]);
     posix_spawn_file_actions_adddup2(&actions, pipefd[1], STDOUT_FILENO);
+    /* stderr shares the pipe: Python tracebacks and raw tool output feed the
+     * CliTail capture instead of vanishing (the wizard has no console). */
+    posix_spawn_file_actions_adddup2(&actions, pipefd[1], STDERR_FILENO);
     posix_spawn_file_actions_addclose(&actions, pipefd[1]);
 
     pid_t pid = 0;
@@ -1606,11 +1660,14 @@ static int run_cli_posix(char* const argv[],
         return 0;
     }
     char line[16384];
+    CliTail tail;
+    memset(&tail, 0, sizeof(tail));
     while (fgets(line, sizeof(line), out)) {
         size_t n = strlen(line);
         while (n && (line[n - 1] == '\n' || line[n - 1] == '\r'))
             line[--n] = '\0';
         handle_progress_line(line, on_progress, progress_ctx);
+        cli_tail_note(&tail, line);
     }
     fclose(out);
 
@@ -1621,10 +1678,7 @@ static int run_cli_posix(char* const argv[],
     }
     int code = WIFEXITED(status) ? WEXITSTATUS(status) : 1;
     if (code == 0) return 1;
-    if (code == 3)
-        snprintf(err_msg, err_cap, "Disc verification failed (wrong dump).");
-    else
-        snprintf(err_msg, err_cap, "%s failed (exit %d).", fail_label, code);
+    cli_fail_msg(err_msg, err_cap, fail_label, (long)code, &tail);
     return 0;
 }
 #endif

--- a/host/psxrecomp_codegen_host.c
+++ b/host/psxrecomp_codegen_host.c
@@ -1697,14 +1697,25 @@ static const char* toolchain_zip_asset_name(void) {
 #endif
 }
 
-/* Optional floor via RETCOMM_TOOLCHAIN_MIN_VERSION. Wizard/default is empty:
- * download GitHub /releases/latest and accept any usable pack (no per-title
- * version pinning to maintain). */
+/* Framework floor for accepted packs, not a per-title pin. v1.0.14 is the
+ * first cmake-clang-v1 with the Linux build sysroot; older cached packs
+ * compile against host headers (absent on stock SteamOS) and mis-link after a
+ * pack upgrade (__isoc23_strtoul). The cache is otherwise accepted forever
+ * once any cmake runs, so the floor is what makes a stale pre-sysroot pack
+ * get replaced. RETCOMM_TOOLCHAIN_MIN_VERSION overrides in either direction;
+ * "0" / "off" / "none" disables the floor (pre-floor behavior). Mirrors
+ * tools/toolchain_pack.py default_min_version(). */
+#define TOOLCHAIN_DEFAULT_MIN_VERSION "1.0.14"
+
 static const char* toolchain_min_version(void) {
     const char* env = getenv("RETCOMM_TOOLCHAIN_MIN_VERSION");
-    if (env && env[0])
+    if (env && env[0]) {
+        if (strcmp(env, "0") == 0 || strcasecmp(env, "off") == 0 ||
+            strcasecmp(env, "none") == 0)
+            return "";
         return env;
-    return "";
+    }
+    return TOOLCHAIN_DEFAULT_MIN_VERSION;
 }
 
 /* Parse leading dotted integers from a version / tag (optional leading 'v'). */

--- a/psxrecomp_cli.py
+++ b/psxrecomp_cli.py
@@ -449,6 +449,7 @@ def ensure_emitters(
     # no MSYS2 GCC DLLs (same as tools/ci/build_emitters.sh).
     if clang_c is not None or clang_cxx is not None:
         cmake_args.append("-DPSXRECOMP_STATIC_CLI=ON")
+    cmake_args.extend(_pack_sysroot_cmake_args(clang_c, cmake_args))
 
     progress.log(" ".join(cmake_args))
     proc = subprocess.run(
@@ -966,6 +967,30 @@ def _which_tool(name: str) -> Optional[Path]:
     return None
 
 
+def _pack_sysroot_cmake_args(
+    clang_path: Optional[Path], existing: list[str] | tuple[str, ...] = ()
+) -> list[str]:
+    """CMake args that wire the portable pack's bundled sysroot (Linux only).
+
+    clang.cfg already gives the *compiler* ``--sysroot``, but CMake's find_*
+    still searches the host, so on a headerless host (stock SteamOS) recomp-ui's
+    ``find_package(OpenGL REQUIRED)`` fails at configure with "Could NOT find
+    OpenGL (missing: OPENGL_INCLUDE_DIR)". CMAKE_SYSROOT re-roots find_* into
+    the pack. OpenGL_GL_PREFERENCE=LEGACY is required with it: the sysroot
+    ships legacy ``libGL.so`` + ``GL/gl.h`` but no GLVND dev files
+    (``glx.h`` / ``libOpenGL.so`` / ``libGLX.so``), so the GLVND path cannot
+    complete inside the sysroot and ``OpenGL::GL`` would never be created.
+    """
+    if not sys.platform.startswith("linux") or clang_path is None:
+        return []
+    if any("CMAKE_SYSROOT" in str(a) for a in existing):
+        return []
+    sysroot = Path(clang_path).resolve().parent.parent / "sysroot"
+    if not (sysroot / "usr" / "include").is_dir():
+        return []
+    return [f"-DCMAKE_SYSROOT={sysroot}", "-DOpenGL_GL_PREFERENCE=LEGACY"]
+
+
 def _read_cmake_cache_generator(cache_file: Path) -> str:
     if not cache_file.is_file():
         return ""
@@ -1015,6 +1040,7 @@ def _cmake_configure(
         compiler_args.append(f"-DCMAKE_C_COMPILER={clang_c}")
     if clang_cxx is not None:
         compiler_args.append(f"-DCMAKE_CXX_COMPILER={clang_cxx}")
+    compiler_args.extend(_pack_sysroot_cmake_args(clang_c, extra))
 
     cmd = [
         "cmake",

--- a/psxrecomp_cli.py
+++ b/psxrecomp_cli.py
@@ -355,6 +355,44 @@ def recompiler_source_dir(project_root: Path) -> Path:
     return src
 
 
+def _toolchain_stamp(
+    clang_cxx: Optional[Path], cmake_tool: Optional[Path]
+) -> str:
+    """Identity of the toolchain that a build directory's objects were made with.
+
+    The portable toolchain is addressed through a stable ``latest`` symlink, so
+    an upgrade behind it leaves CMAKE_CXX_COMPILER unchanged and CMake's
+    compiler-change detection never fires. Ninja then relinks object files
+    built by the previous toolchain.
+
+    That is not theoretical: cmake-clang-v1 v1.0.10 shipped no sysroot and
+    compiled against the host's glibc, so `strtoul` became `__isoc23_strtoul`
+    (glibc >= 2.38). v1.0.14 added a bundled older sysroot that exports no such
+    symbol, and every build tree from before the upgrade failed to link with
+    "undefined symbol: __isoc23_strtoul" while nothing looked out of date.
+
+    Resolving the symlink puts the concrete version in the stamp, so the
+    upgrade becomes visible and the tree can be wiped.
+    """
+    parts: list[str] = []
+    for tool in (clang_cxx, cmake_tool):
+        if not tool:
+            continue
+        real = Path(tool).resolve()
+        parts.append(str(real))
+        try:
+            parts.append(str(real.stat().st_size))
+        except OSError:
+            pass
+        manifest = real.parent.parent / "retcomm-toolchain.json"
+        if manifest.is_file():
+            try:
+                parts.append(manifest.read_text(encoding="utf-8", errors="replace"))
+            except OSError:
+                pass
+    return "\n".join(parts)
+
+
 def ensure_emitters(
     project_root: Path,
     progress: ProgressReporter,
@@ -417,6 +455,33 @@ def ensure_emitters(
     cmake = _which_tool("cmake")
     if cmake is None:
         raise RuntimeError("cmake not found on PATH after toolchain activate")
+
+    # Wipe when the toolchain that produced this tree's objects is not the one
+    # about to link them (ported from feat/rbengine — see _toolchain_stamp).
+    stamp_file = build_dir / ".retcomm-toolchain-stamp"
+    stamp = _toolchain_stamp(clang_cxx, cmake)
+    if stamp and stamp_file.is_file():
+        try:
+            previous = stamp_file.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            previous = ""
+        if previous and previous != stamp:
+            progress.log(
+                "Toolchain changed since this build directory was configured — "
+                f"removing {build_dir} so objects are rebuilt against it"
+            )
+            shutil.rmtree(build_dir, ignore_errors=True)
+            build_dir.mkdir(parents=True, exist_ok=True)
+    elif stamp and not stamp_file.is_file() and (build_dir / "CMakeCache.txt").is_file():
+        # A tree configured before stamping existed. Its objects may predate the
+        # current toolchain with no way to tell, and a mismatch surfaces only as
+        # an undefined symbol at link time. Rebuild once, then stamp.
+        progress.log(
+            f"Unstamped build directory {build_dir} — rebuilding once so its "
+            "objects are known to match the active toolchain"
+        )
+        shutil.rmtree(build_dir, ignore_errors=True)
+        build_dir.mkdir(parents=True, exist_ok=True)
 
     cache_file = build_dir / "CMakeCache.txt"
     gen: list[str] = []
@@ -486,6 +551,11 @@ def ensure_emitters(
                     progress.log(line)
     if proc.returncode != 0:
         raise RuntimeError(f"emitters cmake build failed (exit {proc.returncode})")
+    if stamp:
+        try:
+            stamp_file.write_text(stamp, encoding="utf-8")
+        except OSError:
+            pass
 
     try:
         game, bios = find_emitters(project_root)

--- a/tools/toolchain_pack.py
+++ b/tools/toolchain_pack.py
@@ -20,8 +20,6 @@ import shutil
 import subprocess
 import sys
 import tempfile
-import urllib.error
-import urllib.request
 import zipfile
 from pathlib import Path
 from typing import Optional
@@ -860,6 +858,10 @@ def install_from_zip(
 
 
 def download_url(url: str, dest: Path, token: Optional[str] = None) -> None:
+    # Lazy: keep urllib off the import path so `python tools/…` still works when
+    # ambient PYTHONHOME breaks _socket (launcher clears PYTHONHOME on spawn).
+    import urllib.request
+
     dest.parent.mkdir(parents=True, exist_ok=True)
     req = urllib.request.Request(url, headers={"User-Agent": "psxrecomp-toolchain"})
     if token:
@@ -876,6 +878,8 @@ def download_latest_pack(
     project_root: Optional[Path] = None,
     min_version: str = "",
 ) -> Path:
+    import urllib.error
+
     art = artifact or host_artifact()
     asset = _ASSET.get(art)
     if not asset:

--- a/tools/toolchain_pack.py
+++ b/tools/toolchain_pack.py
@@ -331,12 +331,29 @@ def version_satisfies(have: str, need: str) -> bool:
     return parse_version_tuple(have) >= parse_version_tuple(need)
 
 
-def default_min_version() -> str:
-    """Optional semver floor. Empty by default — wizard downloads /releases/latest.
+# Framework floor, not a per-title pin: v1.0.14 is the first pack with the
+# Linux build sysroot (glibc/libstdc++/GL headers + stubs). Older cached packs
+# compile against host headers, which do not exist on stock SteamOS, and their
+# objects mis-link after a pack upgrade (__isoc23_strtoul). Because the cache
+# is accepted forever once any cmake runs, a floor is the only way a stale
+# pre-sysroot pack ever gets replaced.
+DEFAULT_MIN_VERSION = "1.0.14"
 
-    Set RETCOMM_TOOLCHAIN_MIN_VERSION only when you need to reject stale caches.
+# RETCOMM_TOOLCHAIN_MIN_VERSION values that disable the floor entirely.
+_MIN_VERSION_DISABLE = {"0", "off", "none"}
+
+
+def default_min_version() -> str:
+    """Semver floor for accepted packs (DEFAULT_MIN_VERSION unless overridden).
+
+    RETCOMM_TOOLCHAIN_MIN_VERSION overrides in either direction: a version
+    raises/lowers the floor, and "0" / "off" / "none" disables it (accept any
+    usable pack, matching the pre-floor behavior).
     """
-    return (os.environ.get("RETCOMM_TOOLCHAIN_MIN_VERSION") or "").strip()
+    env = (os.environ.get("RETCOMM_TOOLCHAIN_MIN_VERSION") or "").strip()
+    if env:
+        return "" if env.lower() in _MIN_VERSION_DISABLE else env
+    return DEFAULT_MIN_VERSION
 
 
 def pack_satisfies_min(root: Path, min_version: str = "") -> bool:
@@ -973,7 +990,8 @@ def ensure_toolchain(
         )
 
     # Usable pack exists but is too old — fall through to download/replace.
-    stale = resolve_toolchain_bin(project_root, min_version="")
+    # min_version="0" probes without the default floor ("" would re-apply it).
+    stale = resolve_toolchain_bin(project_root, min_version="0")
     if stale and need and not existing and log:
         log(
             f"Cached toolchain does not meet min_version {need}; "


### PR DESCRIPTION
## Problem

Steam Deck users on stock SteamOS hit **"psxrecomp rebuild failed (exit 1)"** in the setup wizard with no further detail ([mstan/recomp-ui#34](https://github.com/mstan/recomp-ui/issues/34), Tomba 0.12.0-alpha and Klonoa).

Root cause (reproduced in a bwrap stock-SteamOS simulation — tmpfs over `/usr/include`, GL dev symlinks removed — with the shipped cmake-clang-v1 v1.0.14 pack): the pack bundles a jammy build sysroot (glibc, libstdc++, GL headers, legacy `libGL.so` stub), but only `clang.cfg` uses it. CMake's `find_*` still searches the host, so recomp-ui's `find_package(OpenGL REQUIRED)` dies at configure with `Could NOT find OpenGL (missing: OPENGL_INCLUDE_DIR)` — and the wizard swallowed everything except the exit code.

## Changes

**1. Wire the pack sysroot into CMake** (`psxrecomp_cli.py`)
- New `_pack_sysroot_cmake_args()`: when the active pack carries `sysroot/usr/include` on Linux, both the game configure and the emitters configure get `-DCMAKE_SYSROOT=<pack>/sysroot -DOpenGL_GL_PREFERENCE=LEGACY`.
- `LEGACY` is load-bearing: the sysroot ships legacy `libGL.so` + `GL/gl.h` but no GLVND dev files (`glx.h`/`libOpenGL.so`/`libGLX.so`), so under GLVND preference `OpenGL::GL` is never created even with the sysroot.
- Skipped when the caller already passes `CMAKE_SYSROOT`, on non-Linux, or with a system clang.

**2. Surface the actual failure in the wizard** (`host/psxrecomp_codegen_host.c`)
- `run_cli_posix`/`run_cli_win` route the child's stderr into the progress pipe and keep a last-lines capture (`CliTail`). On failure, `err_msg` now carries the most recent error-looking line — JSON progress rows contribute their `message`, raw rows (compiler output, Python tracebacks) contribute as-is:
  `psxrecomp rebuild failed (exit 1): CMake Error: Could NOT find OpenGL (missing: OPENGL_INCLUDE_DIR)`
- Exit-3 disc-verify message unchanged.

**3. Toolchain hardening ported from feat/rbengine**
- `_toolchain_stamp` + wipe-on-mismatch in `ensure_emitters`: an upgrade behind the stable `latest` symlink (e.g. v1.0.10 → v1.0.14, which changed the glibc objects were compiled against) never trips CMake compiler-change detection and old objects fail to link with `undefined symbol: __isoc23_strtoul`. The stamp resolves the symlink to the concrete pack version; a changed or missing stamp over an existing `CMakeCache.txt` wipes the tree once.
- `toolchain_pack.py`: lazy `urllib` imports so the module still loads when an ambient `PYTHONHOME` breaks `_socket`.

## Verification

- Deck simulation (bwrap, no `/usr/include`, no GL dev symlinks, real v1.0.14 pack): unpatched `_cmake_configure` reproduces the exact Deck failure; patched path configures, builds, and the binary runs.
- `_pack_sysroot_cmake_args` unit-tested (pack clang / already-set / no clang / system clang).
- `CliTail` exercised against real compact-JSON rows (`sdk_progress` format), an `event:error` row, raw stderr tracebacks, success, and exit-3.
- Host file syntax-checked on both Linux (clang) and Windows (mingw) branches.
- Stamp: differs across cached v1.0.10/v1.0.14 packs, resolves `latest` to the concrete version; full `ensure_emitters` build writes it; tampered and missing stamps each trigger the wipe + clean rebuild.

**4. Default toolchain min-version floor 1.0.14** (`tools/toolchain_pack.py` + host)
- The cache was accepted forever once any cmake ran, so a host that cached a pre-sysroot pack (≤1.0.13) never re-downloaded. Both resolvers now floor at 1.0.14 (first pack with the Linux build sysroot). `RETCOMM_TOOLCHAIN_MIN_VERSION` overrides in either direction; `0`/`off`/`none` disables. Verified against the real cached v1.0.10/v1.0.14 packs on both the Python and C sides, including an isolated stale-only cache no longer resolving.

## Companion PR

- [TechnicallyComputers/retcomm-toolchains#2](https://github.com/TechnicallyComputers/retcomm-toolchains/pull/2) — sysroot GLVND completion (`libglx-dev`/`libopengl0`/`libopengl-dev`, pack 1.0.15) so FindOpenGL's default GLVND path also resolves from the pack; the LEGACY preference here keeps 1.0.14 packs working either way.

## Not in this PR

- Tomba/Klonoa releases must be re-cut with a new framework pin for this to reach users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vc7zPEnfUFMhMtJzUEruyb
