### PR TITLE
Fix psxrecomp_add_game_runtime for --no-recomp-ui headless builds

### DIFF
--- a/runtime/runtime.cmake
+++ b/runtime/runtime.cmake
@@ -1795,8 +1795,12 @@ function(psxrecomp_add_game_runtime target)
     endif()
 
     set(_psxg_extras ${PSXG_CODEGEN_SETUP_SOURCES})
-    list(APPEND _psxg_extras
-        "${PSXRECOMP_ROOT}/host/psxrecomp_codegen_host.c")
+    # psxrecomp_codegen_host.c unconditionally includes recomp_launcher.h, so
+    # it can only be built alongside the recomp-ui submodule (PSX_RECOMP_UI).
+    if(PSX_RECOMP_UI)
+        list(APPEND _psxg_extras
+            "${PSXRECOMP_ROOT}/host/psxrecomp_codegen_host.c")
+    endif()
 
     set(_psxg_rt_args
         GAME_VERSION "${PSX_GAME_VERSION}"
@@ -1854,6 +1858,13 @@ function(psxrecomp_add_game_runtime target)
 
     foreach(_psxg_t IN LISTS _psxg_targets)
         target_compile_definitions(${_psxg_t} PRIVATE PSX_HAS_GAME_CODEGEN=1)
+        # Distinct from PSX_HAS_GAME_CODEGEN (which just means "generated game
+        # C is linked"): this only fires when a codegen_setup.c-style host was
+        # actually provided, since that file needs recomp-ui/launcher headers
+        # that a --no-recomp-ui build does not have.
+        if(PSXG_CODEGEN_SETUP_SOURCES)
+            target_compile_definitions(${_psxg_t} PRIVATE PSX_HAS_CODEGEN_SETUP_HOST=1)
+        endif()
 
         if(PSX_NET_LOBBY_DEFAULT_URL)
             # Stringify for C: PSX_NET_LOBBY_DEFAULT_URL="ws://..."

--- a/runtime/src/main.cpp
+++ b/runtime/src/main.cpp
@@ -86,8 +86,15 @@ extern "C" void psx_event_step_conservative_env_init(void);
 #if defined(PSX_HAS_GAME_CODEGEN)
 extern "C" void psx_game_codegen_setup_apply(RecompLauncherCGameInfo* gi);
 extern "C" void psx_game_codegen_relaunch_or_exit(const char* disc_path);
-extern "C" void psx_game_codegen_forward_if_built(int argc, char** argv);
 #endif
+#endif
+/* Setup-host relaunch hook: only exists when a codegen_setup.c-style host was
+ * actually linked (PSX_HAS_CODEGEN_SETUP_HOST) — that file depends on
+ * recomp-ui/launcher headers a --no-recomp-ui build does not have, so this
+ * must NOT be gated on PSX_HAS_GAME_CODEGEN (set for any linked game C) or
+ * RECOMP_LAUNCHER alone. */
+#if defined(PSX_HAS_CODEGEN_SETUP_HOST)
+extern "C" void psx_game_codegen_forward_if_built(int argc, char** argv);
 #endif
 #include "psx_sdl.h"
 #if defined(PSX_SDL3)
@@ -10315,7 +10322,7 @@ int main(int argc, char** argv) {
 
     /* Setup-host zip-root exe: after Generate & rebuild, hand off to the
      * product binary under build-release/ (bios/, mods/, assets/, settings). */
-#if defined(PSX_HAS_GAME_CODEGEN)
+#if defined(PSX_HAS_CODEGEN_SETUP_HOST)
     psx_game_codegen_forward_if_built(argc, argv);
 #endif
 


### PR DESCRIPTION
## Summary

`psxrecomp_add_game_runtime()` (added in #110) breaks with `PSX_RECOMP_UI=OFF` and real generated game C linked — a documented, supported config (`docs/BUILDING.md`: *"PSX_RECOMP_UI OFF for headless/generated builds"*) that, as far as I can tell, nothing currently exercises. Found while bringing up a new title with recomp-ui intentionally left out for the first bring-up pass.

Two independent breaks in that combination:

1. **Declaration/call-site guard mismatch** (`runtime/src/main.cpp`). `main()` calls `psx_game_codegen_forward_if_built()` whenever `PSX_HAS_GAME_CODEGEN` is set (i.e. any time real game C is linked), but the function is only *declared* under the narrower `RECOMP_LAUNCHER` guard. Any no-launcher build with generated game C fails to compile: `use of undeclared identifier 'psx_game_codegen_forward_if_built'`.

   Fix: introduced a precise `PSX_HAS_CODEGEN_SETUP_HOST` macro (set only when a codegen-setup host is actually linked, i.e. `CODEGEN_SETUP_SOURCES` was provided) and re-guarded both the declaration and the call site on it, instead of the previous mismatched guard pair.

2. **Unconditional recomp-ui dependency** (`runtime/runtime.cmake`). `psxrecomp_codegen_host.c` was unconditionally appended to every game target's extras sources, but it unconditionally `#include`s `recomp_launcher.h` from the optional recomp-ui submodule. Any `--no-recomp-ui` build fails: `recomp_launcher.h file not found`.

   Fix: gated its inclusion on `PSX_RECOMP_UI`.

## Why nothing caught this

`psxrecomp_add_game_runtime()` is currently used by exactly one shipped title — TombaRecomp — and Tomba always sets `PSX_RECOMP_UI=ON`. Every other title repo (ApeEscapeRecomp, Tomba2Recomp, MegaManX4/5/6Recomp, TsumuLightRecomp) calls the lower-level `psxrecomp_add_runtime_target()` directly and never reaches this code path at all.

## Verification

- **New title, the actual broken config**: built and ran end to end with `PSX_RECOMP_UI=OFF`, real generated game C, no launcher. OpenBIOS → game entry → continuous gameplay, clean `atexit` shutdown, no crash, no `interp_unsupported` faults.
- **Regression check on the one title that could actually regress**: cloned TombaRecomp, pointed `PSXRECOMP_ROOT` at this branch via configure-time override (no submodule surgery, per `docs/BUILDING.md#linking-the-framework`), and built Tomba's real production config — `PSX_RECOMP_UI=ON`, `ENABLE_SETUP_WIZARD`, recomp-ui launcher, mod catalog, setup-host/no-disc mode. Clean build, ran to the launcher, no regressions. Both changes are conditionally gated on flags Tomba always sets the opposite way from the broken config, so this result was expected — but confirmed empirically rather than left as inference.
- Ran the recompiler's `ctest` suite before/after: same pass rate (47/51; the 4 pre-existing failures are unrelated — a timing-sensitive overlay-pair-lock flake and three content checks against files that only exist when the `recomp-ui`/`recomp-net` submodules are populated).

## Not covered here

`CMAKE_CXX_STANDARD 17` (`runtime/CMakeLists.txt`) is also never inherited by a game repo that `include()`s `runtime.cmake` directly rather than `add_subdirectory()`-ing the framework's own `CMakeLists.txt` — this silently compiles `text_xlate.cpp`'s `std::filesystem` usage against whatever the host compiler's default standard happens to be. Six of seven other title repos work around this by setting `CMAKE_CXX_STANDARD 17` themselves. Happy to send a follow-up PR enforcing it inside `runtime.cmake` directly if that's preferred over per-repo workarounds — kept out of this PR to keep it focused on the one bug.

## Test plan

- [x] `ctest` in `recompiler/build` — same pass/fail counts before and after
- [x] New headless title boots and runs continuously with the fix
- [x] TombaRecomp's production config builds and runs unchanged against this branch