### PR TITLE
recompiler: allow zero-padded PS-X EXE BSS overlap

### DIFF
--- a/recompiler/src/ps1_exe_parser.cpp
+++ b/recompiler/src/ps1_exe_parser.cpp
@@ -1,4 +1,5 @@
 #include "ps1_exe_parser.h"
+#include <algorithm>
 #include <fstream>
 #include <cstring>
 #include <fmt/core.h>
@@ -157,19 +158,37 @@ bool PS1Executable::validate(std::string& error_msg) const {
         return false;
     }
 
-    // Check BSS section doesn't overlap code
+    // A few retail PS-X EXEs round the payload up to a disc-sector boundary
+    // while declaring BSS at the end of the meaningful bytes. Loading those
+    // zero padding bytes and then clearing them as BSS is equivalent. Reject
+    // every overlap that contains actual code/data.
     if (header.memfill_size > 0) {
         uint32_t bss_start = header.memfill_start;
         uint32_t bss_end = header.bss_end();
         uint32_t code_end = end_address();
 
-        // BSS should come after code
         if (bss_start < code_end) {
-            error_msg = fmt::format(
-                "BSS section [0x{:08X}, 0x{:08X}) overlaps code [0x{:08X}, 0x{:08X})",
-                bss_start, bss_end, load_address(), code_end
-            );
-            return false;
+            if (bss_start < load_address()) {
+                error_msg = fmt::format(
+                    "BSS section [0x{:08X}, 0x{:08X}) begins before code "
+                    "[0x{:08X}, 0x{:08X})",
+                    bss_start, bss_end, load_address(), code_end
+                );
+                return false;
+            }
+            const size_t overlap_offset =
+                static_cast<size_t>(bss_start - load_address());
+            const bool has_nonzero_payload = std::any_of(
+                code_data.begin() + overlap_offset, code_data.end(),
+                [](uint8_t byte) { return byte != 0; });
+            if (has_nonzero_payload) {
+                error_msg = fmt::format(
+                    "BSS section [0x{:08X}, 0x{:08X}) overlaps non-zero "
+                    "code/data [0x{:08X}, 0x{:08X})",
+                    bss_start, bss_end, load_address(), code_end
+                );
+                return false;
+            }
         }
     }
 

--- a/recompiler/tests/reachable_discovery_test.cpp
+++ b/recompiler/tests/reachable_discovery_test.cpp
@@ -702,6 +702,35 @@ int main() {
     CHECK(rounded.code_size() == 0x1800,
           "page reservation does not widen static analysis payload");
 
+    // Retail PS-X EXEs may declare BSS inside a sector-rounded payload. The
+    // overlap is safe only when every overlapped file byte is padding zero.
+    auto zero_padded_bss = make_exe_buffer(0x1000);
+    put32(zero_padded_bss, 0x28, kLoad + 0xDBC); // 0x244-byte overlap
+    put32(zero_padded_bss, 0x2C, 0x400);
+    std::string zero_bss_error;
+    const auto zero_bss_exe = PSXRecomp::PS1ExeParser::parse_buffer(
+        zero_padded_bss, zero_bss_error);
+    CHECK(zero_bss_exe.has_value(),
+          "zero-only BSS/payload overlap is accepted");
+
+    auto nonzero_bss = zero_padded_bss;
+    nonzero_bss[text + 0xE00] = 1;
+    std::string nonzero_bss_error;
+    const auto nonzero_bss_exe = PSXRecomp::PS1ExeParser::parse_buffer(
+        nonzero_bss, nonzero_bss_error);
+    CHECK(!nonzero_bss_exe.has_value(),
+          "non-zero BSS/code overlap remains rejected");
+    CHECK(nonzero_bss_error.find("overlaps non-zero code/data") !=
+              std::string::npos,
+          "non-zero overlap reports the unsafe bytes");
+
+    auto before_code_bss = zero_padded_bss;
+    put32(before_code_bss, 0x28, kLoad - 4);
+    std::string before_code_error;
+    CHECK(!PSXRecomp::PS1ExeParser::parse_buffer(
+               before_code_bss, before_code_error).has_value(),
+          "BSS beginning before the payload remains rejected");
+
     if (failures) {
         std::fprintf(stderr, "FAILED (%d)\n", failures);
         return 1;


### PR DESCRIPTION
## Summary

- accept a declared PS-X EXE BSS range that overlaps only zero-valued payload padding;
- continue rejecting overlaps containing any non-zero code/data;
- continue rejecting BSS ranges that begin before the loaded payload;
- add positive and negative parser regression cases.

## Why

Some retail PS-X EXEs round their file payload up to a sector boundary while declaring BSS at the end of the meaningful data. Loading those zero padding bytes and then clearing the same bytes as BSS is equivalent, so treating the layout as code/BSS corruption rejects valid executables.

The motivating retained executable has a 580-byte nominal overlap. A direct byte audit found every overlapped byte zero and the final non-zero byte two bytes before BSS begins. This change is deliberately title-neutral and does not add an executable-specific exception.

## Safety

The parser checks the entire overlap. Any non-zero byte remains a hard error, as does BSS beginning before the payload. Existing RAM-bound and overflow validation remains unchanged.

## Validation

- fresh rebase on `upstream/master` (`13a56626`);
- Clang 22.1.8 Release build of `reachable_discovery_test`: PASS;
- `ctest -R ^reachable_discovery_test$ --output-on-failure`: PASS;
- exact retained motivating executable accepted by the same focused parser change in the isolated campaign tree;
- non-zero overlap and BSS-before-payload cases: PASS (correctly rejected).