### PR TITLE
validation rollup: built-in mod packages from PR 169

### DIFF
--- a/mods/builtin/packages/psx.enhancement.fast-loading/1.0.0/manifest.toml
+++ b/mods/builtin/packages/psx.enhancement.fast-loading/1.0.0/manifest.toml
@@ -15,9 +15,9 @@ game_id = "*"
 [[feature]]
 id = "fast-loading"
 name = "Fast Loading (host pacing)"
-description = "Disabled by default. Host pacing is the safe accelerator: it only changes how fast real time is fed to a load, so the guest cannot desync. It does speed the game up while a load is detected, which some speedrun routes rely on NOT happening -- if that is you, leave this off and use CD Speed instead."
+description = "Enabled by default. Host pacing changes only how quickly real time is fed to a load; guest frames, CD interrupts, and callbacks retain their normal schedule. Disable it for strictly authentic wall-clock loading."
 group = "Quality of Life"
-default_enabled = false
+default_enabled = true
 
 [[option]]
 feature = "fast-loading"

--- a/mods/builtin/packages/psx.enhancement.fast-loading/1.0.0/manifest.toml
+++ b/mods/builtin/packages/psx.enhancement.fast-loading/1.0.0/manifest.toml
@@ -15,9 +15,9 @@ game_id = "*"
 [[feature]]
 id = "fast-loading"
 name = "Fast Loading (host pacing)"
-description = "Enabled by default. Host pacing changes only how quickly real time is fed to a load; guest frames, CD interrupts, and callbacks retain their normal schedule. Disable it for strictly authentic wall-clock loading."
+description = "Disabled by default. Host pacing is the safe accelerator: it only changes how fast real time is fed to a load, so the guest cannot desync. It does speed the game up while a load is detected, which some speedrun routes rely on NOT happening -- if that is you, leave this off and use CD Speed instead."
 group = "Quality of Life"
-default_enabled = true
+default_enabled = false
 
 [[option]]
 feature = "fast-loading"

--- a/mods/builtin/packages/psx.enhancement.skip-fmv/1.0.0/manifest.toml
+++ b/mods/builtin/packages/psx.enhancement.skip-fmv/1.0.0/manifest.toml
@@ -1,0 +1,24 @@
+format_version = 5
+id = "psx.enhancement.skip-fmv"
+version = "1.0.0"
+name = "Skip FMVs"
+author = "psxrecomp"
+description = "Skip full-motion video the moment it starts, so a launch goes straight to the game instead of sitting through logos and the attract intro. Detection is the documented signature of a streaming FMV (XA audio feeding the SPU while the MDEC produces frames), not a per-title frame count or address, so it applies to any disc without knowing anything about it. Presentation-only: the game still runs the sequence, it is simply not waited on."
+resolver = "declarative"
+save_compatibility = "shared"
+
+# FMV playback is a property of the emulated CD/MDEC/SPU path rather than of any
+# particular disc, so this ships with the framework and targets every game.
+[[target]]
+game_id = "*"
+
+[[feature]]
+id = "skip_fmv"
+name = "Skip FMVs"
+description = "Off by default. This is presentation, not simulation: skipping a video changes no game state and no timing the game can observe, and save compatibility is unchanged. Turn it on to skip intros and attract sequences."
+group = "Quality of life"
+default_enabled = false
+
+[[plugin]]
+feature = "skip_fmv"
+id = "psx.skip_fmv"

--- a/runtime/runtime.cmake
+++ b/runtime/runtime.cmake
@@ -333,6 +333,7 @@ set(PSXRECOMP_RUNTIME_SOURCES
     ${PSXRECOMP_ROOT}/runtime/src/game_options.c
     ${PSXRECOMP_ROOT}/runtime/src/mod_builtin_speed.c
     ${PSXRECOMP_ROOT}/runtime/src/mod_builtin_pgxp.c
+    ${PSXRECOMP_ROOT}/runtime/src/mod_builtin_skip_fmv.c
     ${PSXRECOMP_ROOT}/runtime/src/mod_packages.cpp
     ${PSXRECOMP_ROOT}/runtime/src/mod_runtime.cpp
     ${PSXRECOMP_ROOT}/runtime/src/psx_keybinds.c
@@ -1257,7 +1258,7 @@ function(psxrecomp_add_runtime_target target)
                 "${PSXRECOMP_BUNDLED_BIOS_LICENSE}")
         endif()
 
-    # Framework-owned mod catalog (loading speed). These target game_id "*" and
+    # Framework-owned mod catalog. These target game_id "*" and
     # are emulator features rather than per-disc content, so every game gets
     # them without carrying a copy of the manifests. Staged BEFORE the game's
     # own POST_BUILD copy so a title may still override an id if it ever needs

--- a/runtime/runtime.cmake
+++ b/runtime/runtime.cmake
@@ -1264,19 +1264,37 @@ function(psxrecomp_add_runtime_target target)
     # own POST_BUILD copy so a title may still override an id if it ever needs
     # to; copy_directory merges rather than replacing the tree.
     if(EXISTS "${PSXRECOMP_ROOT}/mods/builtin/packages")
+        # Clear first: copy_directory MERGES, so a mod deleted from source
+        # would otherwise survive in the build output forever and keep
+        # appearing on the Mods page (and inflate release catalog assertions).
+        # Scoped to mods/packages, not mods/: state.toml is launcher-owned user
+        # state and must survive a rebuild.
+        set(_psx_builtin_mod_copy_commands "")
+        if(DEFINED PSX_BUILTIN_MOD_ALLOWLIST AND NOT
+           "${PSX_BUILTIN_MOD_ALLOWLIST}" STREQUAL "")
+            foreach(_psx_builtin_mod IN LISTS PSX_BUILTIN_MOD_ALLOWLIST)
+                if(NOT EXISTS "${PSXRECOMP_ROOT}/mods/builtin/packages/${_psx_builtin_mod}")
+                    message(FATAL_ERROR
+                        "PSX_BUILTIN_MOD_ALLOWLIST names missing package: ${_psx_builtin_mod}")
+                endif()
+                list(APPEND _psx_builtin_mod_copy_commands
+                    COMMAND ${CMAKE_COMMAND} -E copy_directory
+                        "${PSXRECOMP_ROOT}/mods/builtin/packages/${_psx_builtin_mod}"
+                        "$<TARGET_FILE_DIR:${target}>/mods/packages/${_psx_builtin_mod}")
+            endforeach()
+        else()
+            list(APPEND _psx_builtin_mod_copy_commands
+                COMMAND ${CMAKE_COMMAND} -E copy_directory
+                    "${PSXRECOMP_ROOT}/mods/builtin"
+                    "$<TARGET_FILE_DIR:${target}>/mods")
+        endif()
         add_custom_command(TARGET ${target} POST_BUILD
-            # Clear first: copy_directory MERGES, so a mod deleted from source
-            # would otherwise survive in the build output forever and keep
-            # appearing on the Mods page (and inflate the release packagers'
-            # catalog assertions). This runs before the game's own staging, so
-            # both catalogs land on a clean slate.
             COMMAND ${CMAKE_COMMAND} -E rm -rf
-                "$<TARGET_FILE_DIR:${target}>/mods"
-            COMMAND ${CMAKE_COMMAND} -E copy_directory
-                "${PSXRECOMP_ROOT}/mods/builtin"
-                "$<TARGET_FILE_DIR:${target}>/mods"
-            COMMENT "Staging framework-owned mod catalog (loading speed)"
+                "$<TARGET_FILE_DIR:${target}>/mods/packages"
+            ${_psx_builtin_mod_copy_commands}
+            COMMENT "Staging framework-owned mod catalog"
             VERBATIM)
+        unset(_psx_builtin_mod_copy_commands)
     endif()
     endif()
 

--- a/runtime/src/mod_builtin_skip_fmv.c
+++ b/runtime/src/mod_builtin_skip_fmv.c
@@ -1,0 +1,33 @@
+/*
+ * Framework-owned "skip FMVs" mod, available to every game.
+ *
+ * The runtime has been able to do this since auto_skip_fmv existed, but the
+ * setting is deliberately inert on PSX: main.cpp holds skip_fmv_offered at
+ * constexpr false and clears g_auto_skip_fmv right after config resolution,
+ * with "Skip FMVs is mod-owned on PSX; ignoring the legacy Settings value".
+ * That is the correct design -- the feature is a per-user choice with a real
+ * behavioural effect, so it belongs in the mod plan where it can be toggled and
+ * recorded, not in a config file a game ships. What was missing was the mod
+ * itself, so the capability existed with no way to reach it.
+ *
+ * Activation runs after the final mod-plan commit, which is what makes this
+ * work where the config key cannot: the guard that clears the legacy value has
+ * already run by then.
+ *
+ * Detection is the framework's, not ours: a streaming FMV is XA audio plus MDEC
+ * output, a documented signature, so nothing here is keyed to a frame count or
+ * a per-title address.
+ */
+#include "mod_plugins.h"
+
+/* main.cpp -- validates and applies; refuses anything but 0/1. */
+extern int psx_mod_set_auto_skip_fmv(int enabled);
+
+static void builtin_skip_fmv_activate(void) {
+    (void)psx_mod_set_auto_skip_fmv(1);
+}
+
+PSX_MOD_CONSTRUCTOR(psx_register_builtin_skip_fmv_plugin) {
+    (void)psx_mod_register_activation_plugin("psx.skip_fmv",
+                                             builtin_skip_fmv_activate);
+}


### PR DESCRIPTION
Draft validation rollup for the PR #169 mod-package policy slice. Original PR #169 intentionally remains open.

Includes these already-open split PRs:
- #181 mods: add default-off Skip FMVs package
- #185 release: allowlist staged built-in mod packages

Removed after validation:
- #183 mods: enable Fast Loading by default was rejected/closed. MMX6 still reproduces the known WARNING-screen pacing regression when Fast Loading is default-on. The branch now reverts that default flip; Fast Loading remains available as an optional/default-off built-in mod.

Intent:
- Validate framework-owned built-in mod packaging together because #181 and #185 both affect staged package output.
- Keep merge decisions at the individual PR level; do not merge this rollup in addition to #181/#185.

Validation so far:
- git diff --check origin/master...HEAD
- cmake --build build\\split-runtime --target psx-runtime
- staged build output contains fast-loading and skip-fmv manifests under build\\split-runtime\\mods\\packages
- cmake --build build\\split-runtime --target mod_packages_test mod_runtime_test
- .\\build\\split-runtime\\mod_packages_test.exe
- python runtime/tests/test_mod_owned_display_controls.py
- Ape Escape: pass
- Tomba 2: pass
- MMX6 warning-screen check: #183 default-on Fast Loading rejected; WARNING-screen pacing regression still reproduces

Caveats / not counted as batch failures yet:
- runtime/tests/test_mod_load_acceleration.py currently has a stale exact-text assertion: it looks for `gi.has_turbo_loads`, while origin/master already uses `gi->has_turbo_loads` in the helper. This mismatch is pre-existing relative to this branch.
- mod_runtime_test.exe exits with 0xC00000FD stack overflow in this local build, with no diff in mod_runtime sources/tests in this batch. Needs separate follow-up, but the touched mod-package staging path is covered by mod_packages_test and build-output inspection.

Manual validation still needed:
- Tomba 1
- Mega Man X6, after confirming Fast Loading is default-off in this revised rollup

Focus: built-in Mods page/package staging, Skip FMVs present but default-off, Fast Loading present but default-off, normal controls, and save/load sanity.