### PR TITLE
gl: sync CPU mirror on 24-bit FMV entry

### DIFF
--- a/runtime/src/gpu_gl_renderer.c
+++ b/runtime/src/gpu_gl_renderer.c
@@ -1409,6 +1409,10 @@ static void flush_pack_if_sampling(int tpage_x, int tpage_y, int depth,
 }
 
 /* ---- coherency: GPU -> CPU readback -------------------------------------- */
+/* Defined with the depth24 policy below; needed here for the readback guard. */
+static int s_depth24_skip_up = 0;
+static DirtyRect s_d24_skip_fb; /* union of skipped MDEC FB rects (VRAM halfwords) */
+
 static void ensure_cpu(void) {
     extern int psx_netplay_active(void);
     if (!s_raster_ok || !s_gpu_dirty) return;
@@ -2339,9 +2343,6 @@ static int  glb_render_display_hires(uint32_t *o,int p,int dx,int dy,int dw,int 
  * smaller texture A0s so post-FMV menus keep VRAM pages coherent.
  * On leave: clear the skipped FB union in the FBO — do NOT restage CPU RGB888
  * as 1555 (that painted MotK title rainbow/static). */
-static int s_depth24_skip_up = 0;
-static DirtyRect s_d24_skip_fb; /* union of skipped MDEC FB rects (VRAM halfwords) */
-
 static int depth24_is_fb_transfer(int x, int y, int w, int h) {
     if (!gpu_display_is_depth24() || w <= 0 || h <= 0) return 0;
     GpuDisplayInfo di;
@@ -2424,6 +2425,18 @@ static void depth24_clear_skipped_fb(void) {
 static void depth24_upload_policy(void) {
     int d24 = gpu_display_is_depth24();
     if (d24 && !s_depth24_skip_up) {
+        /* Entering 24-bit: from here the frame is presented from the CPU
+         * mirror, and MDEC only writes the movie's own rows. A letterboxed
+         * movie leaves the bars untouched, so they scan out whatever the
+         * mirror already held; pre-movie primitive clears live only in the FBO
+         * until this sync.
+         *
+         * WipEout 3's intro is 320x192 written inside a 320x240 band. Without
+         * syncing here, stale pre-FMV pixels can remain in the CPU mirror's
+         * top/bottom bars and flicker between double-buffered movie frames.
+         * Cost is one full-VRAM readback per 24-bit entry, not per frame, and
+         * ensure_cpu is a no-op when the FBO is already clean. */
+        ensure_cpu();
         s_up_nrects = 0;
         rect_clear(&s_d24_skip_fb);
     } else if (!d24 && s_depth24_skip_up) {


### PR DESCRIPTION
Split out of the original WipEout 3 monolith (#169) and the presentation/FMV PR (#189).

This PR keeps only the 24-bit FMV CPU-mirror coherency fix:

- sync the CPU VRAM mirror once when entering 24-bit display mode
- avoid stale letterbox pixels when MDEC only updates the movie rows
- leave FMV filtering/reconstruction, diagnostics, and default presentation behavior out of this branch

Rationale:

WipEout 3's intro uses a 320x192 movie inside a 320x240 band. The movie rows are written by MDEC, but the bars can be left untouched. If the GPU FBO has pre-movie clears that have not been read back to the CPU mirror, the 24-bit present path can sample stale CPU mirror contents in those untouched rows.

Validation performed:

- `git diff --check`
- Tomba runtime configure/build against this psxrecomp branch with `PSX_REWIND=OFF` and `PSXRECOMP_ALLOW_NO_BIOS=ON`

Runtime visual validation still wanted before merge:

- WipEout 3 intro / letterbox case this was split for
- Tomba 1 FMV spot check
- Tomba 2 FMV spot check
- Mega Man X6 FMV/warning-adjacent spot check