### PR TITLE
runtime: fix headless generated-game builds without recomp-ui

### DIFF
--- a/runtime/runtime.cmake
+++ b/runtime/runtime.cmake
@@ -1795,8 +1795,12 @@ function(psxrecomp_add_game_runtime target)
     endif()
 
     set(_psxg_extras ${PSXG_CODEGEN_SETUP_SOURCES})
-    list(APPEND _psxg_extras
-        "${PSXRECOMP_ROOT}/host/psxrecomp_codegen_host.c")
+    # psxrecomp_codegen_host.c unconditionally includes recomp_launcher.h, so
+    # it can only be built alongside the recomp-ui submodule (PSX_RECOMP_UI).
+    if(PSX_RECOMP_UI)
+        list(APPEND _psxg_extras
+            "${PSXRECOMP_ROOT}/host/psxrecomp_codegen_host.c")
+    endif()
 
     set(_psxg_rt_args
         GAME_VERSION "${PSX_GAME_VERSION}"
@@ -1854,6 +1858,13 @@ function(psxrecomp_add_game_runtime target)
 
     foreach(_psxg_t IN LISTS _psxg_targets)
         target_compile_definitions(${_psxg_t} PRIVATE PSX_HAS_GAME_CODEGEN=1)
+        # Distinct from PSX_HAS_GAME_CODEGEN (which just means "generated game
+        # C is linked"): this only fires when a codegen_setup.c-style host was
+        # actually provided, since that file needs recomp-ui/launcher headers
+        # that a --no-recomp-ui build does not have.
+        if(PSXG_CODEGEN_SETUP_SOURCES)
+            target_compile_definitions(${_psxg_t} PRIVATE PSX_HAS_CODEGEN_SETUP_HOST=1)
+        endif()
 
         if(PSX_NET_LOBBY_DEFAULT_URL)
             # Stringify for C: PSX_NET_LOBBY_DEFAULT_URL="ws://..."

--- a/runtime/runtime.cmake
+++ b/runtime/runtime.cmake
@@ -1794,10 +1794,12 @@ function(psxrecomp_add_game_runtime target)
             "build the setup host.")
     endif()
 
-    set(_psxg_extras ${PSXG_CODEGEN_SETUP_SOURCES})
+    set(_psxg_extras)
     # psxrecomp_codegen_host.c unconditionally includes recomp_launcher.h, so
-    # it can only be built alongside the recomp-ui submodule (PSX_RECOMP_UI).
+    # the title's setup host and the shared host implementation can only be
+    # built alongside the recomp-ui submodule (PSX_RECOMP_UI).
     if(PSX_RECOMP_UI)
+        list(APPEND _psxg_extras ${PSXG_CODEGEN_SETUP_SOURCES})
         list(APPEND _psxg_extras
             "${PSXRECOMP_ROOT}/host/psxrecomp_codegen_host.c")
     endif()
@@ -1862,7 +1864,7 @@ function(psxrecomp_add_game_runtime target)
         # C is linked"): this only fires when a codegen_setup.c-style host was
         # actually provided, since that file needs recomp-ui/launcher headers
         # that a --no-recomp-ui build does not have.
-        if(PSXG_CODEGEN_SETUP_SOURCES)
+        if(PSX_RECOMP_UI AND PSXG_CODEGEN_SETUP_SOURCES)
             target_compile_definitions(${_psxg_t} PRIVATE PSX_HAS_CODEGEN_SETUP_HOST=1)
         endif()
 

--- a/runtime/src/main.cpp
+++ b/runtime/src/main.cpp
@@ -86,8 +86,15 @@ extern "C" void psx_event_step_conservative_env_init(void);
 #if defined(PSX_HAS_GAME_CODEGEN)
 extern "C" void psx_game_codegen_setup_apply(RecompLauncherCGameInfo* gi);
 extern "C" void psx_game_codegen_relaunch_or_exit(const char* disc_path);
-extern "C" void psx_game_codegen_forward_if_built(int argc, char** argv);
 #endif
+#endif
+/* Setup-host relaunch hook: only exists when a codegen_setup.c-style host was
+ * actually linked (PSX_HAS_CODEGEN_SETUP_HOST) — that file depends on
+ * recomp-ui/launcher headers a --no-recomp-ui build does not have, so this
+ * must NOT be gated on PSX_HAS_GAME_CODEGEN (set for any linked game C) or
+ * RECOMP_LAUNCHER alone. */
+#if defined(PSX_HAS_CODEGEN_SETUP_HOST)
+extern "C" void psx_game_codegen_forward_if_built(int argc, char** argv);
 #endif
 #include "psx_sdl.h"
 #if defined(PSX_SDL3)
@@ -10315,7 +10322,7 @@ int main(int argc, char** argv) {
 
     /* Setup-host zip-root exe: after Generate & rebuild, hand off to the
      * product binary under build-release/ (bios/, mods/, assets/, settings). */
-#if defined(PSX_HAS_GAME_CODEGEN)
+#if defined(PSX_HAS_CODEGEN_SETUP_HOST)
     psx_game_codegen_forward_if_built(argc, argv);
 #endif
 


### PR DESCRIPTION
Supersedes #199.

#199 had the right intent but still failed a real `PSX_RECOMP_UI=OFF` generated-game build: it omitted `host/psxrecomp_codegen_host.c`, but still linked the title `codegen_setup.c`, which calls `psxrecomp_codegen_host_apply`, `psxrecomp_codegen_host_relaunch_or_exit`, and `psxrecomp_codegen_host_forward_if_built`.

This replacement keeps the original fix and additionally:

- omits `CODEGEN_SETUP_SOURCES` when `PSX_RECOMP_UI=OFF`
- only defines `PSX_HAS_CODEGEN_SETUP_HOST` when both recomp-ui and setup sources are present

Validation performed:

- Tomba configure/build with `PSX_RECOMP_UI=OFF`, `PSX_REWIND=OFF`, `PSXRECOMP_ALLOW_NO_BIOS=ON`
- `git diff --check`

This is build-system/linkage only; no emulation behavior changes.