### PR TITLE
runtime: fix high-resolution screenshot byte stride

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -409,6 +409,9 @@ if(BUILD_TESTING)
         add_test(NAME savestate_status_protocol_test
                  COMMAND ${Python3_EXECUTABLE}
                          ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_savestate_status_protocol.py)
+        add_test(NAME screenshot_hires_pitch_test
+                 COMMAND ${Python3_EXECUTABLE}
+                         ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_screenshot_hires_pitch.py)
     endif()
 
     # DISABLED, not de-registered. It links and runs, but 147 of its 309 checks

--- a/runtime/src/debug_server.c
+++ b/runtime/src/debug_server.c
@@ -8703,13 +8703,21 @@ static void handle_screenshot_hires(int id, const char *json)
 
     uint32_t *argb = (uint32_t *)malloc((size_t)ow * oh * sizeof(uint32_t));
     if (!argb) { send_err(id, "alloc failed"); return; }
-    int got = gr_render_display_hires(argb, (int)ow, (int)di.display_x,
+    /* Renderer pitches are byte strides (the live SDL presentation path uses
+     * the same contract). Passing `ow` here advanced each row by only one
+     * quarter of its ARGB width, overlapping four rows and producing a PNG
+     * with repeated horizontal strips followed by untouched black storage. */
+    int got = gr_render_display_hires(argb,
+                                      (int)(ow * sizeof(*argb)),
+                                      (int)di.display_x,
                                       (int)di.display_y, (int)w, (int)h);
     if (!got) {
         /* No hi-res surface (scale 1, or a backend without one): resolve the
          * native display instead and say so, rather than emitting a blank. */
         scale = 1; ow = w; oh = h;
-        got = gr_render_display(argb, (int)ow, (int)di.display_x,
+        got = gr_render_display(argb,
+                                (int)(ow * sizeof(*argb)),
+                                (int)di.display_x,
                                 (int)di.display_y, (int)w, (int)h);
         if (!got) { free(argb); send_err(id, "no display surface"); return; }
     }

--- a/runtime/tests/test_screenshot_hires_pitch.py
+++ b/runtime/tests/test_screenshot_hires_pitch.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Guard the debug hi-res screenshot's byte-stride renderer contract."""
+
+from pathlib import Path
+import re
+
+
+SOURCE = Path(__file__).resolve().parents[1] / "src" / "debug_server.c"
+
+
+def function_body(source: str, name: str) -> str:
+    match = re.search(rf"\bstatic\s+void\s+{name}\s*\([^;]*?\)\s*\{{", source, re.S)
+    if not match:
+        raise AssertionError(f"missing function {name}")
+    start, depth = match.end(), 1
+    for position in range(start, len(source)):
+        depth += source[position] == "{"
+        depth -= source[position] == "}"
+        if depth == 0:
+            return source[start:position]
+    raise AssertionError(f"unterminated function {name}")
+
+
+body = function_body(SOURCE.read_text(encoding="utf-8"), "handle_screenshot_hires")
+required = "(int)(ow * sizeof(*argb))"
+if body.count(required) != 2:
+    raise AssertionError(
+        "hi-res and native-fallback screenshot renders must both pass an ARGB byte pitch"
+    )
+if re.search(r"gr_render_display(?:_hires)?\s*\(\s*argb\s*,\s*\(int\)ow\s*,", body):
+    raise AssertionError("screenshot renderer still passes its pitch in pixels")
+
+print("PASS: screenshot_hires uses byte strides for both renderer paths.")


### PR DESCRIPTION
## Summary

Fix the `screenshot_hires` debug command's output pitch. The renderer APIs consume byte strides, but this call site passed the output width in pixels. At 4x resolution, each ARGB row advanced by one quarter of its required byte width, overlapping four rows and leaving the rest of the allocation untouched.

This changes both the high-resolution render path and its native fallback to pass `width * sizeof(uint32_t)` and registers a focused structural regression test.

## Scope

- one debug-server call site
- one focused Python regression test
- one CTest registration
- no title-specific behavior, package policy, or default-setting changes
- no dependency on another unmerged PR

## Verification

- `python runtime/tests/test_screenshot_hires_pitch.py`
- fresh CMake configure with the test-registration guard: 99 test files, all registered
- `ctest --test-dir build-screenshot-stride -R screenshot_hires_pitch_test --output-on-failure`
- `cmake --build build-screenshot-stride --target psx-runtime -j 4`

The runtime build completed successfully on MinGW/GCC 16.1.0.