### PR TITLE
config: honor title window width

### DIFF
--- a/recompiler/src/config_loader.cpp
+++ b/recompiler/src/config_loader.cpp
@@ -545,6 +545,14 @@ static RuntimeConfig parse_runtime_block(const toml::value& cfg, const fs::path&
             }
             rt.video_supersampling = static_cast<int>(n);
         }
+        if (video.contains("window_width")) {
+            const auto n = toml::find<int64_t>(video, "window_width");
+            if (n < 640 || n > 7680) {
+                throw std::runtime_error(fmt::format(
+                    "[video] window_width out of range (640..7680): {}", n));
+            }
+            rt.video_window_width = static_cast<int>(n);
+        }
         if (video.contains("antialiasing")) {
             rt.video_antialiasing = toml::find<bool>(video, "antialiasing");
         }

--- a/recompiler/src/config_loader.h
+++ b/recompiler/src/config_loader.h
@@ -376,6 +376,10 @@ struct RuntimeConfig {
     // supersampling + edge anti-aliasing. Cost scales ~N^2 in fill rate.
     int                   video_supersampling = 1;
 
+    // Optional initial window width declared by the title profile. Zero keeps
+    // the historical fit-to-display behavior; player settings may override it.
+    int                   video_window_width = 0;
+
     // antialiasing: when true the present path uses linear filtering when
     // scaling the framebuffer to the window (smooths the supersample
     // downscale and any window resize). false = nearest (sharp pixels).

--- a/recompiler/tests/video_enhancement_settings_test.cpp
+++ b/recompiler/tests/video_enhancement_settings_test.cpp
@@ -78,13 +78,30 @@ static void test_defaults_off() {
 static void test_game_toml_opt_in() {
     fs::path p = write_game_toml("psxrecomp_pgxp_on.toml",
         "[video]\n"
+        "window_width = 1920\n"
         "geometry_correction = true\n"
         "perspective_texturing = true\n");
     auto gc = PSXRecompV4::load_game_config(p);
+    check(gc.runtime.video_window_width == 1920,
+          "[video] window_width is honoured");
     check(gc.runtime.video_geometry_correction,
           "[video] geometry_correction = true is honoured");
     check(gc.runtime.video_perspective_texturing,
           "[video] perspective_texturing = true is honoured");
+    fs::remove(p);
+}
+
+static void test_game_window_width_validation() {
+    fs::path p = write_game_toml("psxrecomp_window_too_small.toml",
+        "[video]\n"
+        "window_width = 639\n");
+    bool rejected = false;
+    try {
+        (void)PSXRecompV4::load_game_config(p);
+    } catch (const std::exception&) {
+        rejected = true;
+    }
+    check(rejected, "[video] window_width rejects values below 640");
     fs::remove(p);
 }
 
@@ -173,6 +190,7 @@ static void test_user_settings_round_trip() {
 int main() {
     test_defaults_off();
     test_game_toml_opt_in();
+    test_game_window_width_validation();
     test_knobs_independent();
     test_user_settings_read();
     test_user_settings_absent_key();

--- a/runtime/src/main.cpp
+++ b/runtime/src/main.cpp
@@ -10693,6 +10693,10 @@ int main(int argc, char** argv) {
             for (uint32_t site : gc.vsync_event_horizon_extra_sites)
                 psx_vsync_query_hle_add_extra_event_horizon_site(site);
             g_video_scale      = gc.runtime.video_supersampling;
+            if (gc.runtime.video_window_width > 0) {
+                g_video_win_w = gc.runtime.video_window_width;
+                g_video_win_w_explicit = true;
+            }
             g_video_aa         = gc.runtime.video_antialiasing;
             g_video_texfilter  = gc.runtime.video_texture_filter;
             g_video_fmv_filter = gc.runtime.video_fmv_filter;


### PR DESCRIPTION
## Summary

Allow a title's `game.toml` `[video]` block to declare its initial window width.

`settings.toml` already supports `window_width`, but the same key in the shipped title profile was silently ignored. This meant a title could declare its renderer, aspect, and supersampling while its intended initial window geometry was lost.

A positive title-profile width is treated as an explicit window request, so the existing fit-to-display maximize path does not replace it. Player `settings.toml` is loaded afterward and retains precedence. When the key is absent, the historical fit-to-display behavior is unchanged.

## Scope

- one optional `RuntimeConfig` field, defaulting to zero/inert
- `[video].window_width` parsing and range validation (640..7680)
- runtime application before player settings
- focused config regression coverage
- no height/UI schema expansion and no title-specific behavior
- no dependency on another unmerged PR

## Verification

- `video_enhancement_settings_test` passes, including valid and rejected-width cases
- fresh recompiler configure: 98 test files, all registered
- `cmake --build build-game-window-width --target video_enhancement_settings_test -j 4`
- `ctest --test-dir build-game-window-width -R video_enhancement_settings_test --output-on-failure`
- complete `psx-runtime` build succeeds from a fresh runtime configure

Verified on MinGW/GCC 16.1.0.