### PR TITLE
timing: add rational VBlank period generator

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -382,6 +382,12 @@ if(BUILD_TESTING)
     add_test(NAME psx_cycle_event_boundaries_test
              COMMAND psx_cycle_event_boundaries_test)
 
+    add_executable(psx_vblank_clock_test
+        tests/test_psx_vblank_clock.c
+        src/psx_vblank_clock.c)
+    target_include_directories(psx_vblank_clock_test PRIVATE include)
+    add_test(NAME psx_vblank_clock_test COMMAND psx_vblank_clock_test)
+
     add_executable(spu_end_without_repeat_test
         tests/test_spu_end_without_repeat.c)
     target_include_directories(spu_end_without_repeat_test PRIVATE include)

--- a/runtime/include/psx_vblank_clock.h
+++ b/runtime/include/psx_vblank_clock.h
@@ -1,0 +1,36 @@
+#ifndef PSXRECOMP_PSX_VBLANK_CLOCK_H
+#define PSXRECOMP_PSX_VBLANK_CLOCK_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Exact rational native-cycle period generator. `fraction` is the remainder
+ * after selecting `current_cycles`, which makes the five fields complete
+ * deterministic save-state data once the configured ratio is fixed. */
+typedef struct PSXVBlankClock {
+    uint32_t period_floor;
+    uint32_t period_remainder;
+    uint32_t period_denominator;
+    uint32_t fraction;
+    uint32_t current_cycles;
+} PSXVBlankClock;
+
+int      psx_vblank_clock_configure(PSXVBlankClock *clock,
+                                    uint64_t period_numerator,
+                                    uint32_t period_denominator);
+void     psx_vblank_clock_next(PSXVBlankClock *clock);
+int      psx_vblank_clock_restore_fraction(PSXVBlankClock *clock,
+                                           uint32_t fraction);
+uint64_t psx_vblank_clock_cycles_for_frames_ceil(
+             const PSXVBlankClock *clock, uint32_t frames);
+uint64_t psx_vblank_clock_frames_for_cycles_floor(
+             const PSXVBlankClock *clock, uint64_t cycles);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/runtime/src/psx_vblank_clock.c
+++ b/runtime/src/psx_vblank_clock.c
@@ -1,0 +1,88 @@
+#include "psx_vblank_clock.h"
+
+#include <limits.h>
+
+void psx_vblank_clock_next(PSXVBlankClock *clock) {
+    uint64_t fraction;
+    if (!clock || clock->period_denominator == 0u) return;
+    fraction = (uint64_t)clock->fraction +
+               (uint64_t)clock->period_remainder;
+    clock->current_cycles = clock->period_floor;
+    if (fraction >= clock->period_denominator) {
+        fraction -= clock->period_denominator;
+        clock->current_cycles++;
+    }
+    clock->fraction = (uint32_t)fraction;
+}
+
+int psx_vblank_clock_configure(PSXVBlankClock *clock,
+                               uint64_t period_numerator,
+                               uint32_t period_denominator) {
+    uint64_t floor64;
+    if (!clock || period_denominator == 0u) return 0;
+    floor64 = period_numerator / period_denominator;
+    if (floor64 == 0u || floor64 >= UINT32_MAX) return 0;
+    clock->period_floor = (uint32_t)floor64;
+    clock->period_remainder =
+        (uint32_t)(period_numerator % period_denominator);
+    clock->period_denominator = period_denominator;
+    clock->fraction = 0u;
+    psx_vblank_clock_next(clock);
+    return 1;
+}
+
+int psx_vblank_clock_restore_fraction(PSXVBlankClock *clock,
+                                      uint32_t fraction) {
+    if (!clock || clock->period_denominator == 0u ||
+        fraction >= clock->period_denominator) {
+        return 0;
+    }
+    clock->fraction = fraction;
+    clock->current_cycles = clock->period_floor;
+    /* If the most recent addition wrapped, the post-add remainder lies below
+     * period_remainder and the selected period was floor+1. */
+    if (clock->period_remainder != 0u &&
+        fraction < clock->period_remainder) {
+        clock->current_cycles++;
+    }
+    return 1;
+}
+
+uint64_t psx_vblank_clock_cycles_for_frames_ceil(
+    const PSXVBlankClock *clock, uint32_t frames) {
+    uint64_t whole, fractional;
+    if (!clock || clock->period_denominator == 0u) return 0u;
+    whole = (uint64_t)frames * (uint64_t)clock->period_floor;
+    fractional =
+        ((uint64_t)frames * (uint64_t)clock->period_remainder +
+         (uint64_t)clock->period_denominator - 1u) /
+        (uint64_t)clock->period_denominator;
+    return whole > UINT64_MAX - fractional
+        ? UINT64_MAX : whole + fractional;
+}
+
+uint64_t psx_vblank_clock_frames_for_cycles_floor(
+    const PSXVBlankClock *clock, uint64_t cycles) {
+    uint64_t lo, hi;
+    if (!clock || clock->period_floor == 0u ||
+        clock->period_denominator == 0u) {
+        return 0u;
+    }
+    lo = 0u;
+    hi = cycles / (uint64_t)clock->period_floor;
+    while (lo < hi) {
+        const uint64_t mid = lo + (hi - lo + 1u) / 2u;
+        const uint64_t whole = mid * (uint64_t)clock->period_floor;
+        const uint64_t groups = mid / clock->period_denominator;
+        const uint64_t tail = mid % clock->period_denominator;
+        uint64_t fractional =
+            groups * (uint64_t)clock->period_remainder;
+        fractional += (tail * (uint64_t)clock->period_remainder) /
+                      clock->period_denominator;
+        if (whole <= cycles && fractional <= cycles - whole)
+            lo = mid;
+        else
+            hi = mid - 1u;
+    }
+    return lo;
+}

--- a/runtime/tests/test_psx_vblank_clock.c
+++ b/runtime/tests/test_psx_vblank_clock.c
@@ -1,0 +1,67 @@
+#include "psx_vblank_clock.h"
+
+#include <stdint.h>
+#include <stdio.h>
+
+#define PSX_CPU_HZ 33868800u
+#define PAL_VIDEO_CLOCK_HZ 53203425u
+#define PAL_TICKS_PER_FRAME (3406u * 314u)
+
+int main(void) {
+    PSXVBlankClock clock;
+    const uint64_t numerator =
+        (uint64_t)PSX_CPU_HZ * (uint64_t)PAL_TICKS_PER_FRAME;
+    const uint32_t denominator = PAL_VIDEO_CLOCK_HZ * 2u;
+    const uint64_t frames = 1000000u;
+    uint64_t sum = 0u;
+
+    if (!psx_vblank_clock_configure(&clock, numerator, denominator)) {
+        fputs("FAIL PALx2 clock configuration\n", stderr);
+        return 1;
+    }
+    for (uint64_t i = 0; i < frames; ++i) {
+        if (clock.current_cycles != 340411u &&
+            clock.current_cycles != 340412u) {
+            fputs("FAIL PALx2 emitted an invalid period\n", stderr);
+            return 1;
+        }
+        sum += clock.current_cycles;
+        psx_vblank_clock_next(&clock);
+    }
+    {
+        const uint64_t expected =
+            frames * (numerator / denominator) +
+            (frames * (numerator % denominator)) / denominator;
+        const uint64_t scaled_residual =
+            (frames * (numerator % denominator)) % denominator;
+        if (sum != expected || scaled_residual >= denominator) {
+            fprintf(stderr,
+                    "FAIL PALx2 drift sum=%llu expected=%llu residual=%llu\n",
+                    (unsigned long long)sum,
+                    (unsigned long long)expected,
+                    (unsigned long long)scaled_residual);
+            return 1;
+        }
+    }
+    {
+        const PSXVBlankClock saved = clock;
+        psx_vblank_clock_next(&clock);
+        if (!psx_vblank_clock_restore_fraction(&clock, saved.fraction) ||
+            clock.current_cycles != saved.current_cycles) {
+            fputs("FAIL PALx2 fractional phase restore\n", stderr);
+            return 1;
+        }
+    }
+    {
+        const uint64_t ten_frames =
+            psx_vblank_clock_cycles_for_frames_ceil(&clock, 10u);
+        if (psx_vblank_clock_frames_for_cycles_floor(&clock, ten_frames) < 10u ||
+            psx_vblank_clock_frames_for_cycles_floor(&clock,
+                ten_frames - clock.current_cycles) >= 10u) {
+            fputs("FAIL PALx2 frame/native conversion\n", stderr);
+            return 1;
+        }
+    }
+    puts("PASS: PALx2 rational clock stays below one native-cycle drift");
+    return 0;
+}


### PR DESCRIPTION
## Summary

Add a small deterministic rational-period helper for video-clock/VBlank schedules that cannot be represented by one integer number of native PSX CPU cycles.

The existing runtime uses an integer interval. That is sufficient for exact divisors, but PAL-derived multiplied CRTC rates such as 53,203,425 / (3406*314) * 2 yield 340411.728... native cycles per frame. Rounding that interval accumulates drift. This helper emits the exact floor/floor+1 sequence with a bounded fractional remainder and exposes deterministic frame/cycle conversions.

This PR is intentionally only the arithmetic primitive and its exhaustive long-run test. It changes no runtime clock, title behavior, defaults, audio, or pacing. The interrupt/CRTC consumer can be reviewed independently after this lands.

## Properties

- zero/overflowing configurations fail closed
- every selected period is floor or floor+1
- fractional phase is explicit deterministic state and can be restored
- cycle/frame conversions use the configured rational average
- one million PALx2 periods equal the exact rational floor with residual below one denominator
- no title-specific discriminator or compatibility flag

## Verification

- fresh runtime configure: 99 test files, all registered
- `cmake --build build-rational-vblank --target psx_vblank_clock_test -j 4`
- `ctest --test-dir build-rational-vblank -R psx_vblank_clock_test --output-on-failure`

Passes on MinGW/GCC 16.1.0.