### PR TITLE
tests: prefer PATH compiler for overlay shim

### DIFF
--- a/recompiler/tests/test_overlay_shim_compile.py
+++ b/recompiler/tests/test_overlay_shim_compile.py
@@ -16,9 +16,9 @@ INCLUDE = ROOT / "runtime" / "include"
 def find_gcc() -> str:
     candidates = [
         os.environ.get("CC"),
-        r"C:\msys64\mingw64\bin\gcc.exe" if os.name == "nt" else None,
         shutil.which("gcc"),
         shutil.which("cc"),
+        r"C:\msys64\mingw64\bin\gcc.exe" if os.name == "nt" else None,
     ]
     for candidate in candidates:
         if candidate and pathlib.Path(candidate).is_file():


### PR DESCRIPTION
## Summary

- prefer an explicitly configured or PATH-resolved compiler before the legacy hard-coded MSYS2 fallback
- retain the MSYS2 path as a final compatibility fallback

## Failure

On Windows, a stale `C:\msys64\mingw64\bin\gcc.exe` can exist while its runtime DLLs are unavailable. The test selected it ahead of the working compiler on PATH, spawning `cc1.exe` system-error dialogs for missing `libgmp-10.dll`, `libgcc_s_seh-1.dll`, and `libisl-23.dll`.

## Verification

- `python recompiler/tests/test_overlay_shim_compile.py`: passed with `C:\ProgramData\CodexTools\w64devkit-2.9.0\bin\gcc.exe`
- `git diff --check`
