### PR TITLE
autocompile: define lower-cull helper in overlay shim

### DIFF
--- a/recompiler/tests/test_overlay_shim_compile.py
+++ b/recompiler/tests/test_overlay_shim_compile.py
@@ -36,6 +36,7 @@ void func_80010000(CPUState *cpu) {
     psx_advance_cycles(1u);
     cpu->gpr[2] = psx_cyc_load_word(cpu, cpu->gpr[4], 2u, 0u);
     cpu->gpr[3] = psx_cyc_load_half(cpu, cpu->gpr[5], 3u, 0u);
+    cpu->gpr[6] = psx_ws_cull_slti_lower(cpu->gpr[7], 0xff00u);
     psx_cyc_bb_defer_flush();
     psx_cyc_bb_defer_end();
     if (psx_slice_block(cpu, 0x80010000u, 1u, 0)) return;
@@ -55,6 +56,7 @@ void func_80010000(CPUState *cpu) {
             "-DPSX_NO_DEBUG_TOOLS",
             "-DPSX_ENABLE_BLOCK_CYCLES=1",
             "-DPSX_OVERLAY_FLAVOR=0",
+            "-Werror=implicit-function-declaration",
         ]
         if os.name != "nt":
             command.append("-fPIC")

--- a/runtime/include/overlay_dispatch_preamble.c.inc
+++ b/runtime/include/overlay_dispatch_preamble.c.inc
@@ -202,6 +202,10 @@ int psx_ws_cull_sltiu(uint32_t sx, uint32_t imm) {
 int psx_ws_cull_slti(uint32_t sx, uint32_t imm) {
     return ((int32_t)sx < (int32_t)imm + psx_ws_x_margin()) ? 1 : 0;
 }
+int psx_ws_cull_slti_lower(uint32_t sx, uint32_t imm) {
+    int32_t bound = (int32_t)(int16_t)(uint16_t)imm;
+    return ((int32_t)sx < bound - psx_ws_x_margin()) ? 1 : 0;
+}
 int psx_ws_cull_bltz(uint32_t v) {
     return ((int32_t)v < -psx_ws_x_margin()) ? 1 : 0;
 }


### PR DESCRIPTION
## Summary

- define `psx_ws_cull_slti_lower` in the self-contained overlay dispatch shim
- compile a representative generated overlay call under an implicit-declaration error guard

## Failure

The recompiler emits `psx_ws_cull_slti_lower` at configured signed lower-bound cull sites and declares it in generated translation units. The normal runtime defines the helper, but overlay DLLs link against the self-contained dispatch preamble, where the definition was missing. A shard containing such a site therefore failed to link and fell back to interpreted dispatch.

The shim implementation matches the normal runtime helper and remains identity behavior at a zero widescreen margin.

## Verification

- configured the recompiler test tree with all 98 test files registered
- `ctest -R overlay_shim_compile_contract`: passed
- `git diff --check`

This has no dependency on the open overlay tooling PRs; it only completes the already-generated callback ABI.
