### PR TITLE
text: load fix-only translation tables

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -223,6 +223,14 @@ if(BUILD_TESTING)
         ../recompiler/lib/toml11)
     add_test(NAME mod_packages_test COMMAND mod_packages_test)
 
+    add_executable(text_xlate_fix_only_test
+        tests/test_text_xlate_fix_only.cpp
+        src/text_xlate.cpp)
+    target_include_directories(text_xlate_fix_only_test PRIVATE
+        include
+        ../recompiler/lib/toml11)
+    add_test(NAME text_xlate_fix_only_test COMMAND text_xlate_fix_only_test)
+
     add_executable(mod_runtime_test
         tests/test_mod_runtime.cpp
         src/mod_runtime.cpp

--- a/runtime/src/text_xlate.cpp
+++ b/runtime/src/text_xlate.cpp
@@ -495,10 +495,11 @@ void load_tables_locked() {
         try { data = toml::parse(de.path().string()); }
         catch (...) { continue; }
         ++files;
-        if (!data.contains("entry")) continue;
-        const auto& arr = toml::find(data, "entry");
-        if (!arr.is_array()) continue;
-        for (const auto& e : arr.as_array()) {
+        /* A fixes-only file (vram_patch / glyph-label / msg blocks, no string
+         * table) is valid: gate each block on its own key, never the file. */
+        const auto arr = data.contains("entry") ? toml::find(data, "entry")
+                                                : toml::value(toml::array{});
+        if (arr.is_array()) for (const auto& e : arr.as_array()) {
             if (!e.contains("src_hex")) continue;
             std::string hex = toml::find_or<std::string>(e, "src_hex", "");
             auto bytes = hex_to_bytes(hex);

--- a/runtime/tests/test_text_xlate_fix_only.cpp
+++ b/runtime/tests/test_text_xlate_fix_only.cpp
@@ -1,0 +1,80 @@
+#include "text_xlate.h"
+
+#include <array>
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+
+namespace fs = std::filesystem;
+
+static std::array<uint8_t, 2u * 1024u * 1024u> g_ram{};
+static std::array<uint16_t, 1024u * 512u> g_vram{};
+
+extern "C" {
+uint64_t s_frame_count;
+
+uint8_t* memory_get_ram_ptr(void) { return g_ram.data(); }
+uint16_t gr_vram_read(int x, int y) {
+    return g_vram[static_cast<size_t>(y) * 1024u + static_cast<size_t>(x)];
+}
+void gr_vram_write(int x, int y, uint16_t pixel) {
+    g_vram[static_cast<size_t>(y) * 1024u + static_cast<size_t>(x)] = pixel;
+}
+void dirty_ram_text_bless(uint32_t, const uint8_t*, uint32_t) {}
+}
+
+static bool set_test_language(void) {
+#ifdef _WIN32
+    return _putenv_s("PSX_LANG", "en") == 0;
+#else
+    return setenv("PSX_LANG", "en", 1) == 0;
+#endif
+}
+
+int main(void) {
+    const auto nonce = std::chrono::high_resolution_clock::now()
+                           .time_since_epoch().count();
+    const fs::path root = fs::temp_directory_path() /
+        ("psxrecomp-text-xlate-fix-only-" + std::to_string(nonce));
+    const fs::path translations = root / "translations";
+    const fs::path table = translations / "pixels.toml";
+    std::error_code ec;
+
+    if (!set_test_language() || !fs::create_directories(translations, ec)) {
+        std::cerr << "failed to prepare test directory\n";
+        return 1;
+    }
+
+    {
+        std::ofstream out(table);
+        out << "[[vram_patch]]\n"
+               "x = 4\n"
+               "y = 5\n"
+               "w = 1\n"
+               "h = 1\n"
+               "src_hex = \"3412\"\n"
+               "en_hex = \"7856\"\n";
+        if (!out) {
+            std::cerr << "failed to write test table\n";
+            fs::remove_all(root, ec);
+            return 1;
+        }
+    }
+
+    g_vram[5u * 1024u + 4u] = 0x1234u;
+    text_xlate_init(root.string().c_str(), "en");
+    text_xlate_vram_upload(0, 0, 16, 16);
+
+    const bool passed = g_vram[5u * 1024u + 4u] == 0x5678u;
+    fs::remove_all(root, ec);
+    if (!passed) {
+        std::cerr << "fix-only VRAM patch table was ignored\n";
+        return 1;
+    }
+    std::cout << "PASS: fix-only translation table loaded\n";
+    return 0;
+}


### PR DESCRIPTION
## Summary

- load each translation-table block independently instead of requiring a `[[entry]]` string table
- add an end-to-end fixture proving a `[[vram_patch]]`-only file is parsed, armed, matched, and applied

## Failure

`load_tables_locked` returned to the next file whenever `entry` was absent or not an array. That made otherwise valid files containing only `[[vram_patch]]`, `[[glyph_label]]`, or message-fix blocks silently inert. Each block already has its own validation and language gate, so the file-level `entry` requirement was accidental coupling.

## Verification

- fresh runtime configure with all 99 test files registered
- built and ran `text_xlate_fix_only_test`: passed
- built the complete `psx-runtime` target
- `git diff --check`

The default remains inert when no fixes are configured or localization is disabled.
