### PR TITLE
Treat RAM below a high-loading boot EXE as overlay region

### DIFF
--- a/runtime/include/dirty_ram_interp.h
+++ b/runtime/include/dirty_ram_interp.h
@@ -99,6 +99,34 @@ void dirty_ram_irq_ambient_resync_after_restore(void);
 extern uint32_t g_overlay_region_floor;
 #define OVERLAY_REGION_FLOOR (g_overlay_region_floor)
 
+/* The text-image BASE (phys) = this game's main-EXE load address. The floor
+ * above only bounds the text from ABOVE; on its own it encodes the assumption
+ * that the boot EXE sits at the bottom of usable RAM, so that [KERNEL_END,
+ * FLOOR) is text and [FLOOR, RAM) is overlay. That holds for a load_address of
+ * 0x80010000 (text base == KERNEL_END, so the region below text is empty) but
+ * is FALSE for a boot EXE that loads HIGH and streams its gameplay code into
+ * the RAM BELOW itself: Klonoa loads at 0x80180000 (text 0x180000-0x18B000,
+ * overlays at 0x10000-0x130000), Street Fighter Alpha 3 at 0x80113B00,
+ * Bomberman Fantasy Race at 0x8003004C. For those the sub-text RAM was
+ * misclassified as main-EXE text — clear_image_baseline() wiped its dirty bits
+ * and the dispatch admit-heuristic refused it, so a JALR into an overlay page
+ * the CD DMA'd there fell through to psx_unknown_dispatch and fail-fast
+ * exit(1) (Klonoa, frame 687, target 0x80123D00).
+ *
+ * The overlay region is therefore BOTH sides of the text image, not just above
+ * it. main.cpp pins g_text_image_lo = load_address & 0x1FFFFFFF at game load;
+ * the default equals DIRTY_RAM_KERNEL_WINDOW_END so the below-text clause is
+ * empty for BIOS-only runs and for every bottom-loading game. */
+extern uint32_t g_text_image_lo;
+
+/* 1 iff phys is runtime-loaded overlay RAM rather than main-EXE text — either
+ * side of the text image. Identical to `phys >= FLOOR` whenever the game loads
+ * at the bottom of RAM (g_text_image_lo == KERNEL_WINDOW_END). */
+static inline int phys_is_overlay_region(uint32_t phys) {
+    return phys >= g_overlay_region_floor ||
+           (phys >= DIRTY_RAM_KERNEL_WINDOW_END && phys < g_text_image_lo);
+}
+
 /* Test whether a given physical kernel-RAM address is in a page that was
  * written-to since boot.  Defined in memory.c. */
 int      dirty_ram_is_dirty(uint32_t phys);

--- a/runtime/src/dirty_ram_interp.c
+++ b/runtime/src/dirty_ram_interp.c
@@ -478,6 +478,11 @@ static void callret_end(uint32_t idx, CPUState *cpu, uint32_t path) {
  * load. See dirty_ram_interp.h for the per-game rationale. */
 uint32_t g_overlay_region_floor = OVERLAY_REGION_FLOOR_DEFAULT;
 
+/* Text-image base (phys) = the loaded game's main-EXE load address. Defaults to
+ * the kernel-window end so the below-text overlay clause is empty until a
+ * high-loading game pins it; main.cpp sets it at game load. See the header. */
+uint32_t g_text_image_lo = DIRTY_RAM_KERNEL_WINDOW_END;
+
 #ifdef PSX_HAS_GAME_DISPATCH
 extern int psx_dispatch_game_compiled(CPUState* cpu, uint32_t addr);
 extern int psx_game_address_in_text(uint32_t addr);
@@ -2831,11 +2836,17 @@ static int dirty_ram_dispatch_inner(CPUState* cpu, uint32_t addr, uint32_t stop_
     if (!dirty_ram_is_dirty(phys) && !clean_game_text_miss) {
         /* Bulk host transfers can populate post-EXE executable RAM without
          * passing through the write hooks that mark dirty pages. A real
-         * control transfer to a decodable word above the configured boot-EXE
-         * text end is enough evidence to admit that word to the interpreter.
-         * Data and invalid targets still fail closed. */
+         * control transfer to a decodable word OUTSIDE the configured boot-EXE
+         * text image is enough evidence to admit that word to the interpreter.
+         * "Outside" is both sides of the text: a boot EXE that loads high
+         * streams its gameplay overlays into the RAM below itself (Klonoa's
+         * text is 0x180000-0x18B000, its overlays run from 0x10000+), and
+         * gating on the floor alone rejected every one of those targets —
+         * a JALR into a CD-DMA'd overlay page then fell through to
+         * psx_unknown_dispatch and fail-fast exit(1). Data and invalid targets
+         * still fail closed via the decodability check. */
         if (phys < (2u * 1024u * 1024u) &&
-            phys >= g_overlay_region_floor &&
+            phys_is_overlay_region(phys) &&
             dirty_ram_word_looks_decodable(fetch_word(phys))) {
             dirty_ram_mark_executable_range(phys, 4u);
         } else {

--- a/runtime/src/main.cpp
+++ b/runtime/src/main.cpp
@@ -181,6 +181,7 @@ extern "C" {
     extern uint64_t psx_cycle_count;
     extern uint64_t s_frame_count;
     extern uint32_t g_overlay_region_floor;
+    extern uint32_t g_text_image_lo;
     extern int      g_psx_cps_mode;
     extern uint64_t g_slice_fired, g_slice_irq_taken, g_dirty_ram_insns_run;
     extern uint64_t g_dirty_window_dispatches;
@@ -10959,9 +10960,17 @@ int main(int argc, char** argv) {
              * 0x85000+) at the Whoopee-Camp splash. See dirty_ram_interp.h. */
             {
                 extern uint32_t g_overlay_region_floor;
+                extern uint32_t g_text_image_lo;
                 uint32_t text_end = (gc.load_address + gc.text_size) & 0x1FFFFFFFu;
                 if (text_end > 0x00010000u /* DIRTY_RAM_KERNEL_WINDOW_END */)
                     g_overlay_region_floor = text_end;
+                /* Pin the text BASE too. The floor alone assumes the boot EXE
+                 * sits at the bottom of RAM; a high-loading EXE (Klonoa
+                 * 0x180000, SFA3 0x113B00) streams its overlays into the RAM
+                 * BELOW itself, which must be overlay region, not text. */
+                uint32_t text_lo = gc.load_address & 0x1FFFFFFFu;
+                if (text_lo > 0x00010000u && text_lo < g_overlay_region_floor)
+                    g_text_image_lo = text_lo;
                 /* PSX_OVERLAY_REGION_FLOOR: per-title override for games whose TEXT
                  * range is itself partially overwritten by streamed level data
                  * (Driver 2 streams mission code over pages inside its static text
@@ -10977,8 +10986,9 @@ int main(int argc, char** argv) {
                     }
                 }
                 std::fprintf(stdout,
-                    "psxrecomp: overlay_region_floor = 0x%05X (game text end)\n",
-                    g_overlay_region_floor);
+                    "psxrecomp: overlay_region_floor = 0x%05X (game text end), "
+                    "text_image_lo = 0x%05X\n",
+                    g_overlay_region_floor, g_text_image_lo);
             }
             /* Overlay DLL cache (Layer A): stash config now; heavy init
              * (cache scan / ABI preflight / resident LoadLibrary) runs after

--- a/runtime/src/memory.c
+++ b/runtime/src/memory.c
@@ -362,13 +362,19 @@ int dirty_ram_is_dirty(uint32_t phys);
  * trust a clean text page to run its compiled function and divert only truly-
  * overlaid pages to the interpreter (Tomba 2 loads a loader overlay over
  * 0x8001Dxxx). The kernel window [0,0x10000) (BIOS install stubs) and the overlay
- * region [FLOOR, RAM) are left untouched. */
+ * region OUTSIDE [BASE, FLOOR) are left untouched — including the RAM BELOW the
+ * text image, which is overlay space for a high-loading boot EXE (Klonoa loads
+ * at 0x180000). Baselining from the kernel-window end instead of the real text
+ * base wiped that whole region's dirty bits. See dirty_ram_interp.h. */
 extern uint32_t g_overlay_region_floor;
 void dirty_ram_clear_image_baseline(void) {
     uint32_t floor = g_overlay_region_floor;
     if (floor <= DIRTY_RAM_KERNEL_TRACK_BYTES) return;
     if (floor > RAM_SIZE) floor = RAM_SIZE;
-    uint32_t first_page = DIRTY_RAM_KERNEL_TRACK_BYTES >> DIRTY_RAM_PAGE_SHIFT;
+    uint32_t base = g_text_image_lo;
+    if (base < DIRTY_RAM_KERNEL_TRACK_BYTES) base = DIRTY_RAM_KERNEL_TRACK_BYTES;
+    if (base >= floor) return;
+    uint32_t first_page = base >> DIRTY_RAM_PAGE_SHIFT;
     uint32_t last_page  = (floor - 1u) >> DIRTY_RAM_PAGE_SHIFT;
     for (uint32_t page = first_page; page <= last_page; page++)
         dirty_ram_bitmap[page >> 5] &= ~(1u << (page & 31u));
@@ -633,9 +639,13 @@ int dirty_ram_is_dirty(uint32_t phys) {
     if (dirty_ram_force_interp() && phys >= DIRTY_RAM_KERNEL_TRACK_BYTES) return 1;
     if (dirty_ram_shellwin_interp() && phys >= 0x00030000u && phys <= 0x0005AFFFu) return 1;
     /* Experimental fallback for overlays copied into their final location by
-     * ordinary guest CPU stores rather than CD DMA. Dispatch above the static
-     * image floor is treated as dynamic and validated by the interpreter. */
-    if (phys >= g_overlay_region_floor) return 1;
+     * ordinary guest CPU stores rather than CD DMA. Dispatch OUTSIDE the static
+     * image (either side of it) is treated as dynamic and validated by the
+     * interpreter. Below-text RAM counts too: a high-loading boot EXE streams
+     * its gameplay code into the RAM beneath itself (Klonoa loads at 0x180000
+     * and runs overlays from 0x10000+), and gating on the floor alone left
+     * those pages unreachable by the interpreter. See dirty_ram_interp.h. */
+    if (phys_is_overlay_region(phys)) return 1;
     uint32_t page = phys >> DIRTY_RAM_PAGE_SHIFT;
     return (dirty_ram_bitmap[page >> 5] >> (page & 31u)) & 1u;
 }

--- a/runtime/tests/test_overlay_decodable_fallback.py
+++ b/runtime/tests/test_overlay_decodable_fallback.py
@@ -8,10 +8,16 @@ import sys
 
 ROOT = Path(__file__).resolve().parents[2]
 SOURCE = ROOT / "runtime" / "src" / "dirty_ram_interp.c"
+HEADER = ROOT / "runtime" / "include" / "dirty_ram_interp.h"
+MEMORY = ROOT / "runtime" / "src" / "memory.c"
 
 
 def function_body(source: str, name: str) -> str:
-    match = re.search(rf"\bstatic\s+int\s+{re.escape(name)}\s*\([^;]*?\)\s*\{{", source, re.S)
+    match = re.search(
+        rf"\bstatic\s+(?:inline\s+)?int\s+{re.escape(name)}\s*\([^;]*?\)\s*\{{",
+        source,
+        re.S,
+    )
     if not match:
         raise AssertionError(f"missing function definition: {name}")
     start = match.end()
@@ -28,17 +34,47 @@ def function_body(source: str, name: str) -> str:
 
 def main() -> int:
     source = SOURCE.read_text(encoding="utf-8")
+    header = HEADER.read_text(encoding="utf-8")
+    memory = MEMORY.read_text(encoding="utf-8")
     body = function_body(source, "dirty_ram_dispatch_inner")
+    overlay_region = function_body(header, "phys_is_overlay_region")
+    baseline = re.search(
+        r"\bvoid\s+dirty_ram_clear_image_baseline\s*\([^;]*?\)\s*\{",
+        memory,
+        re.S,
+    )
+    if not baseline:
+        raise AssertionError("missing function definition: dirty_ram_clear_image_baseline")
+    start = baseline.end()
+    depth = 1
+    for pos in range(start, len(memory)):
+        if memory[pos] == "{":
+            depth += 1
+        elif memory[pos] == "}":
+            depth -= 1
+            if depth == 0:
+                baseline_body = memory[start:pos]
+                break
+    else:
+        raise AssertionError("unterminated function definition: dirty_ram_clear_image_baseline")
 
     dirty_gate = body.find("!dirty_ram_is_dirty(phys) && !clean_game_text_miss")
-    floor_gate = body.find("phys >= g_overlay_region_floor", dirty_gate)
+    region_gate = body.find("phys_is_overlay_region(phys)", dirty_gate)
     ram_gate = body.find("phys < (2u * 1024u * 1024u)", dirty_gate)
     decode_gate = body.find("dirty_ram_word_looks_decodable(fetch_word(phys))", dirty_gate)
     mark = body.find("dirty_ram_mark_executable_range(phys, 4u)", dirty_gate)
-    if min(dirty_gate, floor_gate, ram_gate, decode_gate, mark) < 0:
-        raise AssertionError("missing dirty/floor/RAM/decode/mark fallback chain")
-    if not (dirty_gate < floor_gate < decode_gate < mark and dirty_gate < ram_gate < mark):
+    if min(dirty_gate, region_gate, ram_gate, decode_gate, mark) < 0:
+        raise AssertionError("missing dirty/region/RAM/decode/mark fallback chain")
+    if not (dirty_gate < region_gate < decode_gate < mark and dirty_gate < ram_gate < mark):
         raise AssertionError("fallback checks or executable marking are out of order")
+    if "phys >= g_overlay_region_floor" not in overlay_region:
+        raise AssertionError("overlay-region helper lost the above-text floor check")
+    if "phys < g_text_image_lo" not in overlay_region:
+        raise AssertionError("overlay-region helper lost the below-text high-load check")
+    if "uint32_t base = g_text_image_lo" not in baseline_body:
+        raise AssertionError("baseline clear no longer starts from text_image_lo")
+    if "if (base >= floor) return;" not in baseline_body:
+        raise AssertionError("baseline clear no longer guards high-load/empty ranges")
 
     fallback = body[dirty_gate:mark + 200]
     if "else {\n            return 0;" not in fallback:


### PR DESCRIPTION
## Summary

A boot EXE that loads **high** and streams its gameplay code into the RAM
*beneath* itself had every one of those overlay targets refused by the
interpreter, falling through to `psx_unknown_dispatch` and a fail-fast
`exit(1)`.

The overlay-region model assumed the boot EXE sits at the bottom of RAM:
`[KERNEL_END, text_end)` is main-EXE text, `[text_end, RAM)` is runtime-loaded
overlay code. That holds for a `load_address` of `0x80010000`, where the text
base equals the kernel-window end and the region below the text is empty. It is
false for a high-loading title.

Klonoa loads a 46 KB stub at `0x80180000` (`text_size = 0xB000`) and runs its
overlays from `0x10000`–`0x130000`, so the floor landed at `0x18B000` and the
**entire** overlay region fell below it.

## Root cause

Two gates keyed off `g_overlay_region_floor` alone, and the floor is one-sided:

1. `dirty_ram_interp.c` — the admission heuristic for executable RAM that is not
   marked dirty requires `phys >= g_overlay_region_floor`. Overlay pages arrive
   by **CD DMA**, which never passes through the CPU write hooks, so they are
   never marked dirty. A `JALR` into one was refused and became a fatal
   unknown-dispatch.
2. `memory.c` — `dirty_ram_clear_image_baseline()` wiped the dirty bits across
   `[0x10000, 0x18B000)` believing that span was the clean compiled text image.

Traced on Klonoa (SLUS-00585). The failing call is an ordinary vtable dispatch:

```
0x80018018: lw   $v1, 2404($gp)
0x80018020: lw   $a3, 12($v1)          ; callback field -> 0x80123D00
0x80018028: beq  $a3, $zero, ...       ; null-guarded, so the game expects it live
0x8001805C: jalr $ra, $a3
```

and `0x80123D00` is real, valid code — an overlay relocation routine that reads a
descriptor and publishes section pointers. It is present in the region's
`executed_pcs` from a working run, so the code executes correctly whenever it is
allowed to run at all.

## The fix

Pin the text **base** (`g_text_image_lo`) alongside the floor and route both
gates through one predicate — the overlay region is both sides of the text image,
not just above it:

```c
static inline int phys_is_overlay_region(uint32_t phys) {
    return phys >= g_overlay_region_floor ||
           (phys >= DIRTY_RAM_KERNEL_WINDOW_END && phys < g_text_image_lo);
}
```

**No-op for bottom-loading games:** `g_text_image_lo` stays at its `0x10000`
default, the below-text clause is empty, and the baseline clear starts at the
same page as before.

Other titles that load high and should benefit: Street Fighter Alpha 3
(`0x80113B00`) and Bomberman Fantasy Race (`0x8003004C`).

## Verification

Klonoa, Linux, Release, OpenGL:

| | before | after |
|---|---|---|
| exit reason | `FAIL-FAST unknown dispatch @0x80123D00` | `atexit` (clean) |
| frame reached | 687–701, every run | 3364, still running when killed |
| dispatch misses | fatal on the first | **0 recorded for the whole run** (`unknown_dispatch_tail: total 0`) |
| crash file / freeze dump | both written | neither |

Startup now reports the pinned base:

```
psxrecomp: overlay_region_floor = 0x18B000 (game text end), text_image_lo = 0x180000
```

Independent of #226 (the Linux self-compile PR) — the two touch disjoint
files and can merge in either order.
