### PR TITLE
boot_state: skip unknown savestate sections

### DIFF
--- a/runtime/include/boot_state.h
+++ b/runtime/include/boot_state.h
@@ -74,8 +74,9 @@ typedef struct {
  *     uint64_t len;        LE payload byte count
  *     uint8_t  payload[len];   (module payloads are LE field wires too)
  * When BOOT_STATE_SEC_ZLIB is set, payload = u32 LE raw_len + zlib(raw).
- * An unknown tag, a length mismatch, or a missing required section on load is a
- * hard reject (incomplete restore is never allowed) -> normal boot + recapture.
+ * Unknown tags are skipped for forward compatibility. A malformed known section
+ * or a missing required section on load is a hard reject (incomplete restore is
+ * never allowed) -> normal boot + recapture.
  */
 enum {
     BS_SEC_CPU    = 0x01,  /* CPUState: gpr/pc/hi/lo/cop0/gte_data/gte_ctrl       */

--- a/runtime/src/boot_state.c
+++ b/runtime/src/boot_state.c
@@ -677,7 +677,14 @@ static int apply_section(uint32_t tag, const uint8_t* p, uint32_t len,
         return 1;
     }
     default:
-        return 0;
+        /* Unknown section: SKIP, never fail. This was `return 0`, which made
+         * every state written by a build with one extra section a poison pill
+         * for every build without it -- and worse than unloadable: the apply
+         * loop had already restored RAM/VRAM/CPU by the time it hit the
+         * unknown tag, so the refusal left a HALF-RESTORED machine that
+         * wedged or died at PC=0. A sectioned state format exists precisely
+         * so readers can step over what they do not know. */
+        return 1;
     }
 }
 


### PR DESCRIPTION
Split from parked PR #193, which was itself split from the original WipEout 3/PR #169 work. Original parking PR remains open.

This extracts only the generic boot-state forward-compatibility fix:
- Unknown boot-state/savestate sections now skip successfully instead of failing the whole load after earlier sections may already have partially restored machine state.
- Known-but-malformed sections still fail through their existing case handlers.

Why this should be independent:
- One file changed: runtime/src/boot_state.c.
- No title-specific policy.
- No new section is written by this PR; it only makes future/foreign sections non-fatal to older readers.

Validation:
- Cherry-picked cleanly onto current master.
- `git diff --check HEAD~1..HEAD` passed.
- Configured runtime with `PSX_RECOMP_UI=OFF`, `PSX_REWIND=OFF`, `PSXRECOMP_ALLOW_NO_BIOS=ON`, `BUILD_TESTING=ON`.
- Built `psx-runtime` successfully.

Caveat:
- There is no focused unit test for the full boot-state loader path in this split yet; this was build-validated and reviewed as a narrow compatibility behavior change.