### PR TITLE
savestate: defer saves until a safe resume PC exists

### DIFF
--- a/runtime/src/savestate.c
+++ b/runtime/src/savestate.c
@@ -708,7 +708,16 @@ void savestate_poll(CPUState* cpu, uint32_t resume_pc) {
         int slot = s_save_pending;
         char path[600];
         uint32_t pc = savestate_resolve_resume_pc(cpu, resume_pc);
-        if (!savestate_resume_pc_ok(pc)) {
+        /* hint==0 ALSO defers, even when the resolver found a plausible-looking
+         * substitute. The substitute chain ends in sticky-BB latches and $ra,
+         * which pass the sanity check while being the wrong place to resume:
+         * the first F7 of a session saved such a state, it loaded, ran for
+         * ~150M instructions off the rails, and died at PC=0 -- poison that
+         * looks valid at save time and only fails minutes later. Deferring
+         * reuses the existing retry: the save completes at the next poll where
+         * a real block-leader PC is published, or fails LOUDLY after the
+         * timeout instead of writing a corrupt state silently. */
+        if (resume_pc == 0u || !savestate_resume_pc_ok(pc)) {
             /* FMV/present edges often poll with hint=0; wait briefly for a
              * sticky BB / IRQ latch rather than writing pc=0 poison. */
             const double now = savestate_mono_ms();


### PR DESCRIPTION
Split from parked PR #193 commit 1469550c. Original parking PR remains open.

This extracts only the independent savestate safety half:
- If `savestate_poll` is asked to save while the published resume hint is `0`, defer instead of immediately falling back to sticky/latch/$ra candidates.
- The save then completes once a real block-leader resume PC is published, or fails loudly after the existing timeout.
- This avoids writing a state that looks valid at save time but later resumes from the wrong place or eventually dies at `pc=0`.

What was intentionally not included:
- The mod-state preservation half of the original commit is already covered on current master by the built-in mod staging cleanup, so this PR leaves `runtime/runtime.cmake` unchanged.

Validation:
- Cherry-picked onto current master with the already-merged mod-state half dropped.
- `git diff --check HEAD~1..HEAD` passed.
- Configured runtime with `PSX_RECOMP_UI=OFF`, `PSX_REWIND=OFF`, `PSXRECOMP_ALLOW_NO_BIOS=ON`, `BUILD_TESTING=ON`.
- Built `psx-runtime` successfully.

Recommended manual validation before merge:
- In a title with working save states, request a save during normal gameplay and confirm it still saves/loads.
- If possible, request a save at an FMV/present/loading edge where `resume_pc` may be 0 and confirm it defers briefly rather than writing a bad state.