### PR TITLE
audio: report SDL3 stream input spec to runtime

### DIFF
--- a/runtime/src/psx_sdl_audio.cpp
+++ b/runtime/src/psx_sdl_audio.cpp
@@ -46,13 +46,14 @@ extern "C" SDL_AudioDeviceID psx_sdl_audio_open(
     }
 
     const SDL_AudioDeviceID device = SDL_GetAudioStreamDevice(s_audio_stream);
-    SDL_AudioSpec obtained = requested;
-    (void)SDL_GetAudioDeviceFormat(device, &obtained, nullptr);
     if (have) {
+        /* Report the stream input spec. SDL3 converts from this format to the
+         * device format internally; reporting the device format here makes the
+         * runtime generate at the wrong rate before SDL resamples it again. */
         std::memset(have, 0, sizeof(*have));
-        have->freq = obtained.freq;
-        have->format = obtained.format;
-        have->channels = obtained.channels;
+        have->freq = requested.freq;
+        have->format = requested.format;
+        have->channels = requested.channels;
         have->samples = want->samples;
     }
 


### PR DESCRIPTION
Split from parked PR #193 commit 42109c58. Original parking PR remains open.

This extracts only the SDL3 audio stream-format fix:
- `psx_sdl_audio_open` now reports the requested SDL3 audio stream input spec back to the runtime.
- SDL3 converts from the stream input format to the output device format internally, so reporting the device format here can make the runtime generate at the wrong rate before SDL resamples again.

What was intentionally not included:
- The unrelated present/menu/window behavior from the donor commit.

Validation:
- `git diff --check` passed.
- Configured runtime with `PSX_RECOMP_UI=OFF`, `PSX_REWIND=OFF`, `PSXRECOMP_ALLOW_NO_BIOS=ON`, `BUILD_TESTING=ON`.
- Built `psx-runtime` successfully; the touched `psx_sdl_audio.cpp` compiled and final runtime linked.

Manual validation:
- Best checked on an SDL3 runtime build by listening for normal pitch/rate and absence of audio buffer overfill/drop artifacts.