### PR TITLE
input: stop folding the D-pad onto the analog stick

### DIFF
--- a/runtime/src/main.cpp
+++ b/runtime/src/main.cpp
@@ -4147,18 +4147,23 @@ static uint16_t pad_buttons_for(const PlayerInput& p, int player, bool suppress_
 
 /* Analog stick bytes (lx,ly,rx,ry) for a player; centred if no live source.
  *
- * The host left stick maps to the LEFT analog axes (variable). When fold_dpad
- * is set, the physical D-pad (and, for a keyboard player, the arrow keys) is
- * ALSO folded onto the left axes at full deflection, so an analog-mode game
- * whose movement reads only the stick magnitude (e.g. Tomba) still responds to
- * the D-pad/keyboard — the faithful "seamless" behaviour: the stick gives
- * variable speed, the D-pad gives full speed, both at once. Only the PHYSICAL
- * D-pad is folded in (not the stick->d-pad button mapping), so the stick keeps
- * its true variable magnitude. fold_dpad is false in HYBRID mode (there the
- * D-pad instead flips the pad to digital, so the game runs its own d-pad path)
- * and true in pinned-ANALOG mode. The keyboard branch always folds the arrows
- * — they are that player's only stick source. */
-static void pad_sticks_for(const PlayerInput& p, int player, uint8_t out[4], bool fold_dpad) {
+ * The host left stick maps to the LEFT analog axes (variable). The physical
+ * D-pad is deliberately NOT folded onto those axes: a real DualShock holds
+ * both sticks at 0x80 while the D-pad is pressed, so presenting a direction
+ * as a button bit AND a full stick deflection at once is a state no hardware
+ * produces. An analog-aware game that reads both sources then acts on one
+ * press twice — measured on Legend of Mana's land-placement cursor, which
+ * stepped two entries per tap in pinned-ANALOG and exactly one in DIGITAL.
+ *
+ * A game whose movement reads only the stick magnitude (e.g. Tomba) is served
+ * by HYBRID mode, where pressing the D-pad flips the pad to digital and the
+ * game runs its own d-pad path — without ever presenting the impossible
+ * both-at-once state.
+ *
+ * The keyboard branch is unaffected: psx_keybinds_sticks maps that player's
+ * bound stick-direction keys onto the axes, which is their only stick
+ * source. */
+static void pad_sticks_for(const PlayerInput& p, int player, uint8_t out[4]) {
     out[0] = out[1] = out[2] = out[3] = 0x80;
     if (p.kind == 1) {
         /* Keyboard analog: the configurable left/right stick-direction binds
@@ -4227,25 +4232,6 @@ static void pad_sticks_for(const PlayerInput& p, int player, uint8_t out[4], boo
         } else {
             apply_discrete_stick("rs_up", "rs_down", "rs_left", "rs_right",
                                  &out[2], &out[3]);
-        }
-        if (fold_dpad) {
-            /* Fold physical D-pad (mapped "up"/etc. button sources that are
-             * d-pad buttons) — prefer the mapped sources over hardcoded buttons
-             * so a remapped d-pad still folds onto the left stick. */
-            auto dpad_pressed = [&](const char* n) {
-                const PsxButtonMap* e = find_entry(n);
-                if (!e) return false;
-                for (const auto& s : e->sources) {
-                    if (source_is_stick_axis(s)) continue;
-                    if (controller_source_pressed_h(p.handle, s, p.deadzone))
-                        return true;
-                }
-                return false;
-            };
-            if (dpad_pressed("left"))  out[0] = 0x00;
-            if (dpad_pressed("right")) out[0] = 0xFF;
-            if (dpad_pressed("up"))    out[1] = 0x00;
-            if (dpad_pressed("down"))  out[1] = 0xFF;
         }
     }
 }
@@ -4530,9 +4516,16 @@ static void apply_input_override_to_sio(int override_word) {
         else if (dpad_live) p.hybrid_analog = false;
         eff_analog = p.hybrid_analog ? 1 : 0;
     }
-    /* Pinned-ANALOG folds injected D-pad onto the left stick (same as a real
-     * DualShock seat). Without this, stick-only menu/move paths ignore
-     * button-bit injection even though pad_status shows the bits pressed. */
+    /* Injected input only (set_input / dev routing): fold the injected D-pad
+     * word onto the left stick so stick-only menu/move paths respond to a
+     * button-bit injection that has no physical stick behind it.
+     *
+     * This is NOT hardware behaviour -- a real DualShock keeps its sticks at
+     * 0x80 while the D-pad is held -- and a game reading both sources will
+     * act on one injected press twice. It is kept only because injection has
+     * no other way to steer such a game; the equivalent fold for physical
+     * controllers was removed (see pad_sticks_for) after it was measured
+     * double-stepping Legend of Mana's land-placement cursor. */
     if (eff_analog && mode == (int)PSXRecompV4::PAD_MODE_ANALOG && !stick_live) {
         if ((uint16_t)(~w & 0x0010u)) st[1] = 0x00; /* Up */
         if ((uint16_t)(~w & 0x0040u)) st[1] = 0xFF; /* Down */
@@ -4611,15 +4604,13 @@ static int capture_pad_slot(int s, PsxNetPad* out) {
     if (src.all_pads)
         btn &= dev_all_controllers_buttons(suppress_stick);
 
-    /* Analog axes. Pinned-ANALOG folds the physical D-pad onto the left axes
-     * (fold_dpad) so the D-pad still moves stick-only games; HYBRID feeds the
-     * raw stick when currently analog (no fold — the D-pad drives its own
-     * digital path there); DIGITAL leaves the axes centred. */
+    /* Analog axes. Pinned-ANALOG and HYBRID both feed the raw stick only; the
+     * D-pad is never folded in, matching a real DualShock, which keeps its
+     * sticks centred while the D-pad is held. DIGITAL leaves the axes
+     * centred. */
     uint8_t st[4] = { 0x80, 0x80, 0x80, 0x80 };
-    if (mode == PSXRecompV4::PAD_MODE_ANALOG) {
-        pad_sticks_for(p, player, st, /*fold_dpad=*/true);
-    } else if (eff_analog) {  /* HYBRID, currently presenting analog */
-        pad_sticks_for(p, player, st, /*fold_dpad=*/false);
+    if (mode == PSXRecompV4::PAD_MODE_ANALOG || eff_analog) {
+        pad_sticks_for(p, player, st);
     }
     /* Stick fold, driven by the SAME source set as the buttons above: whatever
      * may press a button may also steer. kind==1 already folded its binds
@@ -4677,10 +4668,8 @@ static int capture_pad_slot_exclusive(int s, PsxNetPad* out, int present_sio_slo
     uint16_t btn = pad_buttons_for(p, player, suppress_stick);
 
     uint8_t st[4] = { 0x80, 0x80, 0x80, 0x80 };
-    if (mode == PSXRecompV4::PAD_MODE_ANALOG) {
-        pad_sticks_for(p, player, st, /*fold_dpad=*/true);
-    } else if (eff_analog) {  /* HYBRID, currently presenting analog */
-        pad_sticks_for(p, player, st, /*fold_dpad=*/false);
+    if (mode == PSXRecompV4::PAD_MODE_ANALOG || eff_analog) {
+        pad_sticks_for(p, player, st);
     }
 
     out->buttons = btn;
@@ -4815,6 +4804,9 @@ static void capture_override_pad(int override_word, PsxNetPad* out) {
         else if (dpad_live) p.hybrid_analog = false;
         eff_analog = p.hybrid_analog ? 1 : 0;
     }
+    /* Injected input only; see the note on the sibling fold above. Not
+     * hardware behaviour, retained solely so injection can steer stick-only
+     * games. */
     if (eff_analog && mode == (int)PSXRecompV4::PAD_MODE_ANALOG && !stick_live) {
         if ((uint16_t)(~w & 0x0010u)) st[1] = 0x00;
         if ((uint16_t)(~w & 0x0040u)) st[1] = 0xFF;

--- a/tools/cursor_writers.py
+++ b/tools/cursor_writers.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""
+cursor_writers.py — Catch every write to the menu cursor and name the writer.
+
+menu_scan.py located a variable that moved two steps from one D-pad tap.
+This registers a write-trace range over it and records each write during a
+capture: the value before and after, the PC that made it, and the frame.
+
+That distinguishes the two ways one tap becomes two moves:
+
+  two writes, two PCs   two independent code paths each acted on the input.
+                        If one reads the button bits and the other the stick
+                        bytes, the D-pad/stick fold is implicated.
+  two writes, one PC    one path ran twice — the game polled or ticked twice.
+  one write of -2       one path computed a step of two; the doubling is in
+                        the step calculation, and input is not to blame.
+
+Usage:
+    python3 cursor_writers.py --seconds 12 --focus 0x8004A5F5
+
+Registers a trace range, captures, then always removes the range it added.
+"""
+
+import argparse
+import json
+import sys
+import time
+
+sys.path.insert(0, __file__.rsplit("/", 1)[0])
+
+PHYS_MASK = 0x1FFFFFFF
+
+
+def phys(addr):
+    """The trace ring records physical addresses; KSEG0/KSEG1 map down."""
+    return addr & PHYS_MASK
+
+
+def writes_in_range(entries, lo, hi):
+    """Trace entries whose address falls in [lo, hi), oldest first."""
+    out = []
+    for e in entries:
+        a = int(e["addr"], 16)
+        if phys(lo) <= a < phys(hi):
+            out.append(e)
+    out.sort(key=lambda e: e["seq"])
+    return out
+
+
+def covers(e, addr):
+    """Does this write touch `addr`?
+
+    The ring records a write at its base address and width, so a halfword
+    store to 0x...F4 changes the byte at 0x...F5 without ever appearing at
+    that address.  Matching on address equality misses those entirely.
+    """
+    a = int(e["addr"], 16)
+    return a <= phys(addr) < a + e.get("w", 4)
+
+
+def byte_value(e, key, addr):
+    """The byte this write put at `addr` ("old" or "new")."""
+    shift = (phys(addr) - int(e["addr"], 16)) * 8
+    return (int(e[key], 16) >> shift) & 0xFF
+
+
+def byte_delta(e, addr):
+    """Signed change this write made to the single byte at `addr`."""
+    d = byte_value(e, "new", addr) - byte_value(e, "old", addr)
+    if d > 128:
+        d -= 256
+    elif d < -128:
+        d += 256
+    return d
+
+
+def touching_writes(writes, addr):
+    """Writes that actually changed the byte at `addr`.
+
+    A wide store may cover the byte while leaving it alone; that is not a
+    cursor move and must not be counted as one.
+    """
+    return [e for e in writes if covers(e, addr) and byte_delta(e, addr) != 0]
+
+
+def delta(e):
+    """Signed change this write made, at the traced width."""
+    w = e.get("w", 4)
+    bits = w * 8
+    old = int(e["old"], 16) & ((1 << bits) - 1)
+    new = int(e["new"], 16) & ((1 << bits) - 1)
+    d = new - old
+    # Interpret a large jump as a small signed step (wrap at the width).
+    if d > (1 << (bits - 1)):
+        d -= (1 << bits)
+    elif d < -(1 << (bits - 1)):
+        d += (1 << bits)
+    return d
+
+
+def summarize(writes, focus):
+    """Per-address rollup, with the focus address reported in full."""
+    by_addr = {}
+    for e in writes:
+        a = int(e["addr"], 16)
+        s = by_addr.setdefault(a, {"addr": a, "writes": 0, "pcs": set(),
+                                   "funcs": set(), "deltas": []})
+        s["writes"] += 1
+        s["pcs"].add(e["pc"])
+        s["funcs"].add(e.get("func", "?"))
+        s["deltas"].append(delta(e))
+    for s in by_addr.values():
+        s["pcs"] = sorted(s["pcs"])
+        s["funcs"] = sorted(s["funcs"])
+    focus_writes = touching_writes(writes, focus)
+    return by_addr, focus_writes
+
+
+def group_events(writes, focus, gap_frames=8):
+    """Split writes into one group per press.
+
+    A press produces its writes within a frame or two; separate presses are
+    seconds apart.  Grouping keeps a capture containing several presses from
+    being read as one confused event.
+    """
+    events, cur = [], []
+    for e in sorted(writes, key=lambda x: x["seq"]):
+        if cur and (e.get("frame", 0) - cur[-1].get("frame", 0)) > gap_frames:
+            events.append(cur)
+            cur = []
+        cur.append(e)
+    if cur:
+        events.append(cur)
+    return events
+
+
+def describe_event(ev, focus):
+    total = sum(byte_delta(e, focus) for e in ev)
+    pcs = sorted({e["pc"] for e in ev})
+    if len(ev) == 1:
+        kind = ("single_write_double_step" if abs(total) >= 2
+                else "single_write_single_step")
+    elif len(pcs) > 1:
+        kind = "two_paths"
+    else:
+        kind = "one_path_twice"
+    return {"kind": kind, "writes": len(ev), "total": total, "pcs": pcs,
+            "frame0": ev[0].get("frame"), "frame1": ev[-1].get("frame"),
+            "funcs": sorted({e.get("func", "?") for e in ev})}
+
+
+def verdict(focus_writes, focus=None):
+    """Name the mechanism, per press and overall."""
+    if not focus_writes:
+        return ("no_writes",
+                "the focus byte was never changed during the capture")
+    events = [describe_event(ev, focus)
+              for ev in group_events(focus_writes, focus)]
+    doubled = [e for e in events if abs(e["total"]) >= 2]
+    if not doubled:
+        return ("no_double_step",
+                "%d press(es) seen, none moved the cursor more than one step"
+                % len(events))
+    kinds = {e["kind"] for e in doubled}
+    if kinds == {"single_write_double_step"}:
+        return ("single_write_double_step",
+                "%d of %d press(es) moved the cursor %s in ONE write — the "
+                "step size was computed wrong; the input path is not at fault"
+                % (len(doubled), len(events),
+                   "/".join(str(e["total"]) for e in doubled)))
+    if "two_paths" in kinds:
+        pcs = sorted({pc for e in doubled if e["kind"] == "two_paths"
+                      for pc in e["pcs"]})
+        return ("two_paths",
+                "%d of %d press(es) were acted on by MULTIPLE code paths "
+                "(PCs: %s) — two handlers consumed one press"
+                % (len(doubled), len(events), ", ".join(pcs)))
+    return ("one_path_twice",
+            "%d of %d press(es) ran the same handler twice"
+            % (len(doubled), len(events)))
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--host", default="127.0.0.1")
+    ap.add_argument("--port", type=int, default=4370)
+    ap.add_argument("--lo", default="0x8004A500")
+    ap.add_argument("--hi", default="0x8004A600")
+    ap.add_argument("--focus", default="0x8004A5F5")
+    ap.add_argument("--seconds", type=float, default=12.0)
+    ap.add_argument("--count", type=int, default=4096)
+    ap.add_argument("--json")
+    args = ap.parse_args()
+
+    lo, hi, focus = int(args.lo, 16), int(args.hi, 16), int(args.focus, 16)
+
+    import pad_trace
+    link = pad_trace.Link(args.host, args.port)
+    slot = None
+    try:
+        r = link.cmd_with({"cmd": "wtrace_add",
+                           "lo": "0x%08X" % lo, "hi": "0x%08X" % hi})
+        if not r or not r.get("ok"):
+            raise RuntimeError("wtrace_add failed: %r" % (r,))
+        slot = r["slot"]
+        print("tracing 0x%08X..0x%08X (slot %d) for %.0fs — tap the D-pad "
+              "ONCE, and note whether it doubles."
+              % (lo, hi, slot, args.seconds))
+        time.sleep(args.seconds)
+        d = link.cmd_with({"cmd": "wtrace_dump", "addr_lo": "0x%08X" % lo,
+                           "addr_hi": "0x%08X" % hi, "count": args.count,
+                           "newest": 1})
+        entries = (d or {}).get("entries", [])
+    finally:
+        if slot is not None:
+            link.cmd_with({"cmd": "wtrace_del", "slot": slot})
+        link.close()
+
+    writes = writes_in_range(entries, lo, hi)
+    print("\n%d write(s) in range during the capture" % len(writes))
+    by_addr, focus_writes = summarize(writes, focus)
+
+    for a in sorted(by_addr):
+        s = by_addr[a]
+        print("  0x%08X  writes=%-3d deltas=%-18s pc=%s"
+              % (0x80000000 | a, s["writes"],
+                 ",".join(str(x) for x in s["deltas"][:6]),
+                 ",".join(s["pcs"][:3])))
+
+    print("\nfocus 0x%08X:" % focus)
+    for e in focus_writes:
+        print("  frame=%-8s @0x%08X w=%s  %s -> %s   byte %d -> %d (%+d)"
+              "  pc=%s func=%s ra=%s"
+              % (e.get("frame"), int(e["addr"], 16), e.get("w"),
+                 e["old"], e["new"], byte_value(e, "old", focus),
+                 byte_value(e, "new", focus), byte_delta(e, focus),
+                 e["pc"], e.get("func"), e.get("ra")))
+
+    print("\nper-press breakdown:")
+    for ev in group_events(focus_writes, focus):
+        d = describe_event(ev, focus)
+        print("  frames %s..%s  writes=%d  step=%+d  %s  pc=%s"
+              % (d["frame0"], d["frame1"], d["writes"], d["total"],
+                 d["kind"], ",".join(d["pcs"])))
+
+    kind, text = verdict(focus_writes, focus)
+    print("\n[%s] %s" % (kind, text))
+
+    if args.json:
+        with open(args.json, "w") as fh:
+            json.dump({"writes": writes, "verdict": kind, "detail": text},
+                      fh, indent=2)
+        print("wrote %s" % args.json)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/menu_scan.py
+++ b/tools/menu_scan.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python3
+"""
+menu_scan.py — Find the menu cursor variable, then prove how far it moves.
+
+The reported bug is that one D-pad tap moves the menu cursor twice.  Both the
+host pad state and the delivered SIO polls have been measured clean, so the
+next question is what the *game* does with the input.  This finds the RAM
+location holding the cursor index by snapshotting main RAM while you tap, and
+keeping only the locations whose value changes when — and only when — a tap
+happened, by a small step.
+
+Taps are located exactly, using the SIO byte ring rather than the snapshot
+sampling rate: a 100 ms tap falls between two 250 ms snapshots and would be
+invisible otherwise.  Each snapshot records the ring's sequence counter, and
+the taps decoded from the ring afterwards are placed into the interval they
+fall in.
+
+Usage:
+    python3 menu_scan.py --snapshots 40 --interval 0.25 --json /tmp/menu.json
+
+Sit in the menu and tap the SAME direction several times, evenly spaced.
+"""
+
+import argparse
+import json
+import sys
+import time
+
+sys.path.insert(0, __file__.rsplit("/", 1)[0])
+
+RAM_BASE = 0x80000000
+RAM_SIZE = 0x200000
+CHUNK = 0x40000
+BLOCK = 1024
+
+
+def find_changed_offsets(a, b, block=BLOCK):
+    """Byte offsets where two snapshots differ.
+
+    Compares block-at-a-time first: in a static menu almost all of RAM is
+    unchanged, so this skips the vast majority at C speed and only walks
+    bytes inside blocks that actually moved.
+    """
+    out = []
+    n = min(len(a), len(b))
+    for base in range(0, n, block):
+        end = min(base + block, n)
+        if a[base:end] == b[base:end]:
+            continue
+        for i in range(base, end):
+            if a[i] != b[i]:
+                out.append(i)
+    return out
+
+
+def held_spans(entries, button):
+    """Ring-sequence spans during which `button` was held.
+
+    Rising edges alone are the wrong model: holding a direction makes the
+    game auto-repeat, so the cursor moves repeatedly with no new edge.
+    Treating those moves as "movement without input" disqualifies the very
+    variable being hunted, so the whole held period counts as input.
+    """
+    import pad_delivery
+    polls = pad_delivery.decode_polls(entries)
+    spans, start, last = [], None, None
+    for p in polls:
+        if p["buttons"] is None:
+            continue
+        down = pad_delivery.pressed(p["buttons"], button)
+        if down and start is None:
+            start = p["seq"]
+        elif not down and start is not None:
+            spans.append((start, last))
+            start = None
+        last = p["seq"]
+    if start is not None:
+        spans.append((start, last))
+    return spans
+
+
+def input_intervals(before, after, spans_by_button, settle=1):
+    """Intervals where movement is legitimate, and which press caused each.
+
+    Every direction must be supplied, not just the one under study: a cursor
+    moves on `up` as well as `down`, and treating an unmonitored direction as
+    "no input" disqualifies the cursor itself.
+
+    A change seen between snapshots i and i+1 was caused by input somewhere
+    between the start of snapshot i's read and the end of snapshot i+1's --
+    reads take real time, so that window is the honest bound.
+
+    Returns (allowed, presses) where presses is a list of
+    (button, first_interval, last_interval) in capture order.
+    """
+    allowed, presses = set(), []
+    n = len(before)
+    for button, spans in sorted(spans_by_button.items()):
+        for s0, s1 in spans:
+            touched = []
+            for i in range(n - 1):
+                if s0 < after[i + 1] and s1 >= before[i]:
+                    touched.append(i)
+            if not touched:
+                continue
+            lo, hi = touched[0], touched[-1]
+            for i in range(lo, min(hi + settle, n - 2) + 1):
+                allowed.add(i)
+            presses.append((button, lo, min(hi + settle, n - 2)))
+    presses.sort(key=lambda p: p[1])
+    return allowed, presses
+
+
+def press_deltas(values, presses, n):
+    """Net movement across each press, measured settled-to-settled.
+
+    An animated cursor slides into place over several frames, so a per-interval
+    delta samples the animation rather than the step.  Comparing the value
+    before the press with the value once it has settled measures the step the
+    game actually took.
+    """
+    out = []
+    for button, lo, hi in presses:
+        a = values[lo]
+        b = values[min(hi + 1, n - 1)]
+        out.append((button, byte_delta(a, b)))
+    return out
+
+
+def byte_delta(a, b):
+    """Signed step from byte value a to b, accounting for 8-bit wrap."""
+    d = b - a
+    if d > 128:
+        d -= 256
+    elif d < -128:
+        d += 256
+    return d
+
+
+def classify_offset(values, allowed, presses, max_multiple=2, min_moves=3):
+    """Does this location behave like a cursor?
+
+    Disqualified if it ever moves with no input.  Otherwise judged on the
+    net step per press, measured settled-to-settled:
+
+      * each direction must move it consistently one way -- `up` and `down`
+        move a cursor opposite ways, so a single global sign test would
+        reject the very thing we are looking for;
+      * every step must be one stride or exactly two, with the stride taken
+        from the data rather than assumed;
+      * it must respond to several presses, since one press cannot establish
+        a stride and coincidences are cheap.
+    """
+    n = len(values)
+    for i in range(n - 1):
+        if values[i] != values[i + 1] and i not in allowed:
+            return None                       # moved with no input
+
+    per = press_deltas(values, presses, n)
+    moves = [(b, d) for b, d in per if d != 0]
+    if not moves:
+        return None
+
+    by_button = {}
+    for b, d in moves:
+        by_button.setdefault(b, []).append(d)
+    consistent = all(all(x > 0 for x in v) or all(x < 0 for x in v)
+                     for v in by_button.values())
+
+    base = min(abs(d) for _, d in moves)
+    regular = base > 0 and all(abs(d) % base == 0 and abs(d) // base <= max_multiple
+                               for _, d in moves)
+    # Opposite directions moving opposite ways is the signature of an axis.
+    opposed = False
+    for a, b in (("up", "down"), ("left", "right")):
+        if a in by_button and b in by_button:
+            if by_button[a][0] * by_button[b][0] < 0:
+                opposed = True
+
+    strict = consistent and regular and len(moves) >= min_moves
+    return {"moves": len(moves), "per_press": per, "base": base,
+            "strict": strict, "values": list(values), "opposed": opposed,
+            "deltas": [d for _, d in moves], "consistent": consistent,
+            "doubled": strict and any(abs(d) // base == 2 for _, d in moves)}
+
+
+def decode_taps(entries, button):
+    """Ring sequence of each rising edge of `button` in the SIO stream."""
+    import pad_delivery
+    polls = pad_delivery.decode_polls(entries)
+    taps, held = [], False
+    for p in polls:
+        if p["buttons"] is None:
+            continue
+        now = pad_delivery.pressed(p["buttons"], button)
+        if now and not held:
+            taps.append(p["seq"])
+        held = now
+    return taps
+
+
+def read_ram(link, base, size):
+    out = bytearray()
+    for off in range(0, size, CHUNK):
+        n = min(CHUNK, size - off)
+        r = link.cmd_with({"cmd": "read_ram",
+                           "addr": "0x%08X" % (base + off), "len": n})
+        if not r or not r.get("ok"):
+            raise RuntimeError("read_ram failed at 0x%08X: %r" % (base + off, r))
+        out.extend(bytes.fromhex(r["hex"]))
+    return bytes(out)
+
+
+def capture(host, port, snapshots, interval, ring_count=512):
+    """Snapshot RAM repeatedly, stitching the SIO ring as we go.
+
+    The ring is pulled every round and merged by sequence number.  Pulling
+    once at the end instead would silently lose any tap that scrolled out of
+    the window, and a lost tap does not merely go unseen -- it disqualifies
+    the very variable we are looking for, because that variable then appears
+    to move with no input.
+    """
+    import pad_trace
+    link = pad_trace.Link(host, port)
+    snaps, before, after, ring, seen_max, gaps = [], [], [], [], -1, 0
+    for _ in range(snapshots):
+        t0 = time.time()
+        r = link.cmd_with({"cmd": "sio_trace", "count": ring_count})
+        before.append(int(r["total"]) if r and "total" in r else -1)
+        for e in (r or {}).get("entries", []):
+            if e["seq"] > seen_max:
+                if seen_max >= 0 and e["seq"] > seen_max + 1 and not ring:
+                    pass
+                ring.append(e)
+                seen_max = e["seq"]
+        snaps.append(read_ram(link, RAM_BASE, RAM_SIZE))
+        r2 = link.cmd_with({"cmd": "sio_trace", "count": ring_count})
+        after.append(int(r2["total"]) if r2 and "total" in r2 else -1)
+        for e in (r2 or {}).get("entries", []):
+            if e["seq"] > seen_max:
+                ring.append(e)
+                seen_max = e["seq"]
+        spent = time.time() - t0
+        if interval > spent:
+            time.sleep(interval - spent)
+    r = link.cmd_with({"cmd": "sio_trace", "count": ring_count})
+    for e in (r or {}).get("entries", []):
+        if e["seq"] > seen_max:
+            ring.append(e)
+            seen_max = e["seq"]
+    link.close()
+    ring.sort(key=lambda e: e["seq"])
+    for i in range(1, len(ring)):
+        if ring[i]["seq"] != ring[i - 1]["seq"] + 1:
+            gaps += ring[i]["seq"] - ring[i - 1]["seq"] - 1
+    return snaps, before, after, ring, gaps
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--host", default="127.0.0.1")
+    ap.add_argument("--port", type=int, default=4370)
+    ap.add_argument("--snapshots", type=int, default=40)
+    ap.add_argument("--interval", type=float, default=0.25)
+    ap.add_argument("--buttons", default="up,down,left,right",
+                    help="all directions that should count as input")
+    ap.add_argument("--max-report", type=int, default=40)
+    ap.add_argument("--min-moves", type=int, default=3,
+                    help="presses a location must respond to")
+    ap.add_argument("--settle", type=int, default=2,
+                    help="intervals after a tap in which movement is still "
+                         "allowed (animated cursors)")
+    ap.add_argument("--json")
+    args = ap.parse_args()
+
+    print("Capturing %d snapshots %.2fs apart (%.0fs) — sit in the menu and "
+          "tap %s several times."
+          % (args.snapshots, args.interval,
+             args.snapshots * args.interval, args.buttons))
+    snaps, before, after, ring, gaps = capture(
+        args.host, args.port, args.snapshots, args.interval)
+    if gaps:
+        print("WARNING: %d SIO bytes missed; a tap may be undetected." % gaps)
+    buttons = [b.strip() for b in args.buttons.split(",") if b.strip()]
+    spans_by_button = {b: held_spans(ring, b) for b in buttons}
+    tapped, presses = input_intervals(before, after, spans_by_button,
+                                      settle=args.settle)
+    counts = ", ".join("%s=%d" % (b, len(spans_by_button[b])) for b in buttons)
+    print("%d snapshots, presses in ring: %s -> %d located, %d interval(s) "
+          "where movement is allowed"
+          % (len(snaps), counts, len(presses), len(tapped)))
+    located = len(presses)
+    if not tapped:
+        print("No taps located inside the capture window — nothing to "
+              "correlate against. Tap during the capture and retry.")
+        return 1
+
+    # Union of everything that ever moved, then test each against the taps.
+    moved = set()
+    for i in range(len(snaps) - 1):
+        moved.update(find_changed_offsets(snaps[i], snaps[i + 1]))
+    print("%d bytes changed at least once" % len(moved))
+
+    strict, loose = [], []
+    for off in sorted(moved):
+        vals = [s_[off] for s_ in snaps]
+        sc = classify_offset(vals, tapped, presses,
+                             min_moves=args.min_moves)
+        if not sc:
+            continue
+        sc["addr"] = RAM_BASE + off
+        (strict if sc["strict"] else loose).append(sc)
+    strict.sort(key=lambda h: (-h["moves"], not h["opposed"]))
+    loose.sort(key=lambda h: -h["moves"])
+
+    def show(rows, label):
+        print("\n%d %s:" % (len(rows), label))
+        for h in rows[:args.max_report]:
+            flag = "  <-- DOUBLE STEP" if h.get("doubled") else ""
+            if h.get("opposed"):
+                flag += "  [axis]"
+            per = " ".join("%s:%+d" % (b, d)
+                           for b, d in h.get("per_press", []) if d)
+            print("  0x%08X  moves=%d/%d base=%d  [%s]%s"
+                  % (h["addr"], h["moves"], located, h["base"], per, flag))
+        if len(rows) > args.max_report:
+            print("  ... %d more (raise --max-report)"
+                  % (len(rows) - args.max_report))
+
+    show(strict, "location(s) stepping consistently on presses")
+    if not strict:
+        show(loose, "location(s) that moved only on taps, but irregularly")
+    hits = strict or loose
+
+    if args.json:
+        with open(args.json, "w") as fh:
+            json.dump({"presses": presses, "allowed": sorted(tapped),
+                       "strict": strict, "loose": loose}, fh, indent=2)
+        print("\nwrote %s" % args.json)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/pad_delivery.py
+++ b/tools/pad_delivery.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""
+pad_delivery.py — Decode the pad polls the game actually received over SIO.
+
+pad_trace.py measures what the runtime *presented*; this measures what the
+game *read*.  A single physical tap must appear as one contiguous run of
+polls with the button held.  If the delivered stream drops back to "released"
+in the middle of a press and then reports it held again, the game's edge
+detector fires twice and the menu moves twice — from one tap.
+
+Reads the always-on SIO byte ring (sio_trace) and reconstructs each pad
+transaction:
+
+    tx 0x01 -> rx 0xFF     address the controller
+    tx 0x42 -> rx id       0x41 digital, 0x73 analog, 0xF3 config
+    tx 0x00 -> rx 0x5A
+    tx 0x00 -> rx btn_lo   active low
+    tx 0x00 -> rx btn_hi
+    tx 0x00 -> rx rx,ry,lx,ly   (analog only)
+
+Usage:
+    python3 pad_delivery.py --seconds 8 --json /tmp/delivery.json
+
+Tap the D-pad once per press you want classified.
+"""
+
+import argparse
+import json
+import sys
+import time
+
+sys.path.insert(0, __file__.rsplit("/", 1)[0])
+
+PAD_ADDR = 0x01
+MC_ADDR = 0x81
+CMD_POLL = 0x42
+
+BUTTONS = {
+    "select": 0x0001, "l3": 0x0002, "r3": 0x0004, "start": 0x0008,
+    "up": 0x0010, "right": 0x0020, "down": 0x0040, "left": 0x0080,
+    "l2": 0x0100, "r2": 0x0200, "l1": 0x0400, "r1": 0x0800,
+    "triangle": 0x1000, "circle": 0x2000, "cross": 0x4000, "square": 0x8000,
+}
+DPAD = ("up", "right", "down", "left")
+
+
+def _b(v):
+    """sio_trace reports bytes as '0x41' strings."""
+    return int(v, 16) if isinstance(v, str) else int(v)
+
+
+def decode_polls(entries):
+    """Reconstruct pad polls from an ordered SIO byte stream.
+
+    `entries` must be ordered by seq and may contain memory-card traffic,
+    which is skipped.  Returns one dict per pad transaction that got far
+    enough to carry a button word.
+    """
+    polls = []
+    txn = None
+    for e in entries:
+        tx, rx = _b(e["tx"]), _b(e["rx"])
+        if tx in (PAD_ADDR, MC_ADDR):
+            # A new address byte always ends the previous transaction.
+            if txn is not None:
+                polls.append(txn) if txn["complete"] else None
+            txn = {"seq": e["seq"], "addr": tx, "bytes": [], "frame": e.get("frame", -1),
+                   "cmd": None, "id": None, "buttons": None, "sticks": None,
+                   "complete": False} if tx == PAD_ADDR else None
+            continue
+        if txn is None:
+            continue
+        txn["bytes"].append(rx)
+        n = len(txn["bytes"])
+        if n == 1:
+            txn["cmd"] = tx      # the command byte we clocked out
+            txn["id"] = rx
+        elif n == 4:
+            txn["buttons"] = txn["bytes"][2] | (txn["bytes"][3] << 8)
+            txn["complete"] = txn["cmd"] == CMD_POLL
+        elif n == 8:
+            txn["sticks"] = [txn["bytes"][6], txn["bytes"][7],
+                             txn["bytes"][4], txn["bytes"][5]]  # lx,ly,rx,ry
+    if txn is not None and txn["complete"]:
+        polls.append(txn)
+    return polls
+
+
+def pressed(word, name):
+    return (word & BUTTONS[name]) == 0
+
+
+def poll_runs(polls, name):
+    """Contiguous spans of polls where `name` is held. Returns (i0, i1) pairs."""
+    runs, start = [], None
+    for i, p in enumerate(polls):
+        if p["buttons"] is not None and pressed(p["buttons"], name):
+            if start is None:
+                start = i
+        elif start is not None:
+            runs.append((start, i - 1))
+            start = None
+    if start is not None:
+        runs.append((start, len(polls) - 1))
+    return runs
+
+
+def analyze(polls, bounce_polls=12):
+    """Classify delivered pad polls.
+
+    bounce_polls: two runs separated by fewer than this many polls came from
+    one physical tap (a tap is ~4 polls; a deliberate second tap is ~30+).
+    """
+    runs, findings = [], []
+    for name in BUTTONS:
+        spans = poll_runs(polls, name)
+        for i0, i1 in spans:
+            runs.append({
+                "button": name, "i0": i0, "i1": i1,
+                "polls": i1 - i0 + 1,
+                "seq0": polls[i0]["seq"], "seq1": polls[i1]["seq"],
+                "frame0": polls[i0].get("frame", -1),
+                "frame1": polls[i1].get("frame", -1),
+            })
+        for (a0, a1), (b0, _b1) in zip(spans, spans[1:]):
+            gap = b0 - a1 - 1
+            if gap <= bounce_polls:
+                findings.append({
+                    "kind": "delivered_bounce", "button": name,
+                    "gap_polls": gap,
+                    "detail": "the game read %s as released for %d poll(s) in "
+                              "the middle of one press, then held again — two "
+                              "rising edges, two menu moves" % (name, gap),
+                })
+    runs.sort(key=lambda r: r["i0"])
+    return runs, findings
+
+
+def polls_per_frame(polls):
+    """How many times the game read the pad in each frame it polled."""
+    counts = {}
+    for p in polls:
+        f = p.get("frame", -1)
+        if f >= 0:
+            counts[f] = counts.get(f, 0) + 1
+    return counts
+
+
+def resolve_frame(prev_frame, frame):
+    """Exact frame for entries seen between two reads, or -1 if unknowable.
+
+    Entries newly visible in this batch were generated between the previous
+    read and this one.  If the frame counter did not advance across that
+    interval, every one of them belongs to that frame.  If it did advance,
+    they straddle a boundary and this ring carries no per-entry stamp to
+    separate them — so say -1 rather than invent one.
+    """
+    if prev_frame is None or frame < 0 or prev_frame != frame:
+        return -1
+    return frame
+
+
+def capture(host, port, seconds, count):
+    import pad_trace
+    link = pad_trace.Link(host, port)
+    seen_max, entries, gaps = -1, [], 0
+    prev_frame = None
+    t_end = time.time() + seconds
+    while time.time() < t_end:
+        r = link.cmd_with({"cmd": "sio_trace", "count": count})
+        fr = link.cmd_with({"cmd": "frame"})
+        frame = int(fr.get("frame", -1)) if fr else -1
+        if not r or "entries" not in r:
+            raise RuntimeError("sio_trace failed: %r" % (r,))
+        batch = r["entries"]
+        if not batch:
+            continue
+        first = batch[0]["seq"]
+        if seen_max >= 0 and first > seen_max + 1:
+            gaps += first - seen_max - 1
+        stamp = resolve_frame(prev_frame, frame)
+        prev_frame = frame
+        for e in batch:
+            if e["seq"] > seen_max:
+                e["frame"] = stamp
+                entries.append(e)
+                seen_max = e["seq"]
+    link.close()
+    return entries, gaps, link
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--host", default="127.0.0.1")
+    ap.add_argument("--port", type=int, default=4370)
+    ap.add_argument("--seconds", type=float, default=8.0)
+    ap.add_argument("--count", type=int, default=192,
+                    help="sio_trace entries per poll; raise if gaps appear")
+    ap.add_argument("--json")
+    args = ap.parse_args()
+
+    print("Capturing %.0fs — tap the D-pad." % args.seconds)
+    entries, gaps, link = capture(args.host, args.port, args.seconds, args.count)
+    polls = decode_polls(entries)
+    print("%d SIO bytes, %d pad polls%s"
+          % (len(entries), len(polls),
+             "" if not link.persistent else ""))
+    if gaps:
+        print("WARNING: %d bytes missed between reads — raise --count." % gaps)
+
+    ppf = polls_per_frame(polls)
+    unknown = sum(1 for p in polls if p.get("frame", -1) < 0)
+    if ppf:
+        vals = sorted(ppf.values())
+        print("polls per frame: min=%d median=%d max=%d  (%d of %d polls "
+              "straddled a batch boundary and are unstamped)"
+              % (vals[0], vals[len(vals) // 2], vals[-1], unknown, len(polls)))
+    # The pad is polled on a fixed cadence; a changing seq delta is the honest
+    # way to see irregular polling, since it needs no frame stamp at all.
+    deltas = sorted({polls[i + 1]["seq"] - polls[i]["seq"]
+                     for i in range(len(polls) - 1)})
+    print("poll seq deltas: %s" % (deltas if len(deltas) < 8
+                                   else "%d distinct" % len(deltas)))
+
+    runs, findings = analyze(polls)
+    for r in runs:
+        print("  %-8s %3d polls  seq %d..%d  frames %s..%s"
+              % (r["button"], r["polls"], r["seq0"], r["seq1"],
+                 r["frame0"], r["frame1"]))
+    print()
+    if findings:
+        for f in findings:
+            print("  [%s] %s: %s" % (f["kind"], f["button"], f["detail"]))
+    else:
+        print("Every press was delivered as one contiguous run.")
+        print("The doubling is not in pad delivery — look at the game's own "
+              "edge detection or its second input source.")
+
+    if args.json:
+        with open(args.json, "w") as fh:
+            json.dump({"polls": polls, "runs": runs, "findings": findings,
+                       "gaps": gaps}, fh, indent=2)
+        print("\nwrote %s" % args.json)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/pad_trace.py
+++ b/tools/pad_trace.py
@@ -76,12 +76,28 @@ def find_runs(samples, name):
     return runs
 
 
+def fold_skew(samples, run):
+    """Frames between the D-pad bit falling and the stick leaving centre.
+
+    Both are written by the same host frame, so 0 means the game sees one
+    event carrying two representations.  Non-zero means the two arrive on
+    different frames, and an edge-detecting menu fires twice.  None means the
+    stick never deflected.
+    """
+    i0, i1 = run
+    for i in range(i0, i1 + 1):
+        if stick_deflected(samples[i]["sticks"]):
+            return samples[i]["frame"] - samples[i0]["frame"]
+    return None
+
+
 def describe_run(samples, name, run):
     i0, i1 = run
     a, b = samples[i0], samples[i1]
     folded = any(stick_deflected(samples[i]["sticks"]) for i in range(i0, i1 + 1))
     analogs = {bool(samples[i]["analog"]) for i in range(i0, i1 + 1)}
     return {
+        "fold_skew_frames": fold_skew(samples, run),
         "button": name,
         "t0": a["t"], "t1": b["t"],
         "ms": round((b["t"] - a["t"]) * 1000.0, 1),
@@ -122,6 +138,14 @@ def analyze(samples, rebounce_ms=400.0, repeat_frames=16):
                     "kind": "analog_flip", "button": name,
                     "detail": "pad analog flag changed during the press",
                 })
+            if name in DPAD and d.get("fold_skew_frames"):
+                findings.append({
+                    "kind": "fold_skew", "button": name,
+                    "frames": d["fold_skew_frames"],
+                    "detail": "stick deflection arrived %d frame(s) after the "
+                              "D-pad bit; an edge-detecting menu fires twice"
+                              % d["fold_skew_frames"],
+                })
             if d["frames"] >= repeat_frames:
                 findings.append({
                     "kind": "long_hold", "button": name,
@@ -133,24 +157,82 @@ def analyze(samples, rebounce_ms=400.0, repeat_frames=16):
     return runs, findings
 
 
-def capture(host, port, seconds):
-    import debug_client
-    sock = debug_client.connect(host, port)
+class Link:
+    """A debug-server connection that survives builds which close after one
+    command.
+
+    The shipped build answers exactly one command per connection and then
+    hangs up; other builds keep the socket open.  Rather than assume either,
+    reuse the socket until it EOFs, then fall back to connect-per-command for
+    the rest of the run.
+    """
+
+    def __init__(self, host, port):
+        self.host, self.port = host, port
+        self.sock = None
+        self.persistent = True
+        self.reconnects = 0
+
+    def _connect(self):
+        import debug_client
+        self.sock = debug_client.connect(self.host, self.port)
+
+    def cmd(self, name):
+        return self.cmd_with({"cmd": name})
+
+    def cmd_with(self, obj):
+        import debug_client
+        for attempt in (0, 1):
+            try:
+                if self.sock is None:
+                    self._connect()
+                r = debug_client.send_cmd(self.sock, obj)
+                if not self.persistent:
+                    self.close()
+                return r
+            except Exception:
+                # EOF or parse failure => this build hung up on us.
+                self.close()
+                if attempt == 0:
+                    self.persistent = False
+                    self.reconnects += 1
+                    continue
+                raise
+        return None
+
+    def close(self):
+        if self.sock is not None:
+            try:
+                self.sock.close()
+            except Exception:
+                pass
+            self.sock = None
+
+
+def capture(host, port, seconds, min_interval=0.0):
+    """Sample pad_status (+ the frame counter) until `seconds` elapse."""
+    link = Link(host, port)
     samples, t_end = [], time.time() + seconds
     while time.time() < t_end:
-        st = debug_client.send_cmd(sock, {"cmd": "pad_status"})
-        pg = debug_client.send_cmd(sock, {"cmd": "ping"})
+        t0 = time.time()
+        st = link.cmd("pad_status")
         if not st or "slot0" not in st:
             continue
+        # `frame`, not `ping`: the shipped build's ping carries no frame number.
+        fr = link.cmd("frame")
         s0 = st["slot0"]
         samples.append({
             "t": time.time(),
-            "frame": int(pg.get("frame", -1)) if pg else -1,
+            "frame": int(fr.get("frame", -1)) if fr else -1,
             "buttons": int(s0["buttons"], 16),
             "sticks": [int(v) for v in s0.get("sticks", [128, 128, 128, 128])],
             "analog": bool(s0.get("analog", False)),
         })
-    return samples
+        spent = time.time() - t0
+        if min_interval > spent:
+            time.sleep(min_interval - spent)
+    link.close()
+    return samples, link
 
 
 def main():
@@ -160,11 +242,14 @@ def main():
     ap.add_argument("--port", type=int, default=4370)
     ap.add_argument("--seconds", type=float, default=8.0)
     ap.add_argument("--repeat-frames", type=int, default=16)
+    ap.add_argument("--hz", type=float, default=0.0,
+                    help="cap the sample rate (0 = as fast as possible)")
     ap.add_argument("--json", help="write raw samples + findings here")
     args = ap.parse_args()
 
     print("Capturing %.0fs — tap the D-pad ONCE, cleanly." % args.seconds)
-    samples = capture(args.host, args.port, args.seconds)
+    samples, link = capture(args.host, args.port, args.seconds,
+                            min_interval=1.0 / args.hz if args.hz else 0.0)
     if not samples:
         print("No samples. Is the runtime up on port %d?" % args.port)
         return 1
@@ -174,14 +259,23 @@ def main():
     frames = samples[-1]["frame"] - samples[0]["frame"]
     print("%d samples over %.1fs (%.0f Hz, %d emulated frames)"
           % (len(samples), span, rate, frames))
+    if not link.persistent:
+        print("note: this build closes the socket after each command; "
+              "reconnected per command.")
+    if frames <= 0:
+        print("WARNING: the frame counter never advanced — is the runtime "
+              "paused? Frame spans below are meaningless.")
+    if rate < 120.0:
+        print("WARNING: %.0f Hz is below 2x the emulated frame rate; a short "
+              "press may be missed." % rate)
 
     runs, findings = analyze(samples, repeat_frames=args.repeat_frames)
     if not runs:
         print("No button press seen — nothing to classify.")
     for r in runs:
-        print("  %-8s %6.1f ms  %3d frames  stick_folded=%s analog=%s"
+        print("  %-8s %6.1f ms  %3d frames  stick_folded=%s skew=%s analog=%s"
               % (r["button"], r["ms"], r["frames"],
-                 r["stick_folded"], r["analog"]))
+                 r["stick_folded"], r["fold_skew_frames"], r["analog"]))
 
     print()
     if not findings:

--- a/tools/tests/test_cursor_writers.py
+++ b/tools/tests/test_cursor_writers.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Unit tests for cursor_writers' attribution of cursor writes."""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import cursor_writers as cw
+
+
+def w(addr, old, new, pc, seq=0, width=1, frame=0, func="0x1000"):
+    return {"seq": seq, "addr": "0x%08X" % (addr & 0x1FFFFFFF),
+            "old": "0x%08X" % old, "new": "0x%08X" % new,
+            "pc": pc, "func": func, "ra": "0x2000", "w": width, "frame": frame}
+
+
+class PhysTest(unittest.TestCase):
+    def test_kseg0_maps_to_physical(self):
+        self.assertEqual(cw.phys(0x8004A5F5), 0x0004A5F5)
+
+    def test_physical_unchanged(self):
+        self.assertEqual(cw.phys(0x0004A5F5), 0x0004A5F5)
+
+
+class DeltaTest(unittest.TestCase):
+    def test_simple_decrement(self):
+        self.assertEqual(cw.delta(w(0x8004A5F5, 5, 4, "0x1")), -1)
+
+    def test_double_step(self):
+        self.assertEqual(cw.delta(w(0x8004A5F5, 5, 3, "0x1")), -2)
+
+    def test_byte_wrap_reads_as_small_negative(self):
+        """0 -> 255 at byte width is -1, not +255."""
+        self.assertEqual(cw.delta(w(0x8004A5F5, 0, 255, "0x1", width=1)), -1)
+
+    def test_word_width_increment(self):
+        self.assertEqual(cw.delta(w(0x8004A5F5, 7, 8, "0x1", width=4)), 1)
+
+
+class RangeTest(unittest.TestCase):
+    def test_filters_and_sorts(self):
+        entries = [w(0x8004A5F5, 5, 4, "0x1", seq=9),
+                   w(0x8004B000, 1, 2, "0x2", seq=8),
+                   w(0x8004A50D, 7, 6, "0x3", seq=7)]
+        got = cw.writes_in_range(entries, 0x8004A500, 0x8004A600)
+        self.assertEqual([e["seq"] for e in got], [7, 9])
+
+    def test_upper_bound_is_exclusive(self):
+        entries = [w(0x8004A600, 1, 2, "0x1")]
+        self.assertEqual(cw.writes_in_range(entries, 0x8004A500, 0x8004A600), [])
+
+
+class VerdictTest(unittest.TestCase):
+    def test_no_writes(self):
+        self.assertEqual(cw.verdict([])[0], "no_writes")
+
+    def test_single_write_double_step(self):
+        """One write of -2: the step calculation doubled, not the input."""
+        got = cw.verdict([w(0x8004A5F5, 5, 3, "0x800684C0")], 0x8004A5F5)
+        self.assertEqual(got[0], "single_write_double_step")
+
+    def test_single_write_single_step(self):
+        got = cw.verdict([w(0x8004A5F5, 5, 4, "0x800684C0")], 0x8004A5F5)
+        # Capture-level verdict: nothing doubled anywhere.
+        self.assertEqual(got[0], "no_double_step")
+        # The event itself is still classified as a clean single step.
+        ev = cw.describe_event([w(0x8004A5F5, 5, 4, "0x800684C0")], 0x8004A5F5)
+        self.assertEqual(ev["kind"], "single_write_single_step")
+        self.assertEqual(ev["total"], -1)
+
+    def test_two_distinct_pcs_is_two_paths(self):
+        got = cw.verdict([w(0x8004A5F5, 5, 4, "0x11110000", seq=1),
+                          w(0x8004A5F5, 4, 3, "0x22220000", seq=2)],
+                         0x8004A5F5)
+        self.assertEqual(got[0], "two_paths")
+
+    def test_same_pc_twice_is_one_path(self):
+        got = cw.verdict([w(0x8004A5F5, 5, 4, "0x11110000", seq=1),
+                          w(0x8004A5F5, 4, 3, "0x11110000", seq=2)],
+                         0x8004A5F5)
+        self.assertEqual(got[0], "one_path_twice")
+
+
+class SummarizeTest(unittest.TestCase):
+    def test_groups_by_address_and_collects_pcs(self):
+        writes = [w(0x8004A5F5, 5, 4, "0xA", seq=1),
+                  w(0x8004A5F5, 4, 3, "0xB", seq=2),
+                  w(0x8004A50D, 7, 6, "0xC", seq=3)]
+        by_addr, focus = cw.summarize(writes, 0x8004A5F5)
+        self.assertEqual(len(by_addr), 2)
+        self.assertEqual(by_addr[0x0004A5F5]["pcs"], ["0xA", "0xB"])
+        self.assertEqual(len(focus), 2)
+
+
+class WidthCoverageTest(unittest.TestCase):
+    """A wide store changes bytes that never appear as its address."""
+
+    def test_halfword_write_covers_high_byte(self):
+        e = w(0x8004A5F4, 0x05F9, 0x0366, "0x80024E3C", width=2)
+        self.assertTrue(cw.covers(e, 0x8004A5F5))
+
+    def test_write_does_not_cover_beyond_its_width(self):
+        e = w(0x8004A5F4, 0, 1, "0x1", width=2)
+        self.assertFalse(cw.covers(e, 0x8004A5F6))
+
+    def test_byte_value_extracts_the_right_lane(self):
+        e = w(0x8004A5F4, 0x05F9, 0x0366, "0x1", width=2)
+        self.assertEqual(cw.byte_value(e, "old", 0x8004A5F5), 5)
+        self.assertEqual(cw.byte_value(e, "new", 0x8004A5F5), 3)
+        self.assertEqual(cw.byte_value(e, "old", 0x8004A5F4), 0xF9)
+
+    def test_byte_delta_of_covered_byte(self):
+        e = w(0x8004A5F4, 0x05F9, 0x0366, "0x1", width=2)
+        self.assertEqual(cw.byte_delta(e, 0x8004A5F5), -2)
+
+    def test_wide_write_leaving_the_byte_alone_is_not_a_move(self):
+        """Covering the byte is not the same as changing it."""
+        e = w(0x8004A5F4, 0x0500, 0x05FF, "0x1", width=2)
+        self.assertEqual(cw.byte_delta(e, 0x8004A5F5), 0)
+        self.assertEqual(cw.touching_writes([e], 0x8004A5F5), [])
+
+    def test_touching_writes_finds_wide_stores(self):
+        es = [w(0x8004A5F4, 0x05F9, 0x0366, "0x1", width=2),
+              w(0x8004A5F4, 0x0366, 0x0823, "0x1", width=2)]
+        self.assertEqual(len(cw.touching_writes(es, 0x8004A5F5)), 2)
+
+    def test_verdict_uses_byte_delta_not_word_delta(self):
+        """-2 on the byte, though the halfword moved by -659."""
+        e = w(0x8004A5F4, 0x05F9, 0x0366, "0x1", width=2)
+        kind, _ = cw.verdict([e], 0x8004A5F5)
+        self.assertEqual(kind, "single_write_double_step")
+
+
+class GroupEventsTest(unittest.TestCase):
+    """Several presses in one capture must not be read as one event."""
+
+    def test_writes_in_the_same_frame_are_one_event(self):
+        ws = [w(0x8004A5F5, 5, 4, "0xA", seq=1, frame=100),
+              w(0x8004A5F5, 4, 3, "0xB", seq=2, frame=100)]
+        self.assertEqual(len(cw.group_events(ws, 0x8004A5F5)), 1)
+
+    def test_writes_seconds_apart_are_separate_events(self):
+        ws = [w(0x8004A5F5, 5, 4, "0xA", seq=1, frame=100),
+              w(0x8004A5F5, 4, 3, "0xA", seq=2, frame=250)]
+        self.assertEqual(len(cw.group_events(ws, 0x8004A5F5)), 2)
+
+    def test_adjacent_frames_stay_together(self):
+        ws = [w(0x8004A5F5, 5, 4, "0xA", seq=1, frame=100),
+              w(0x8004A5F5, 4, 3, "0xB", seq=2, frame=102)]
+        self.assertEqual(len(cw.group_events(ws, 0x8004A5F5)), 1)
+
+
+class PerPressVerdictTest(unittest.TestCase):
+    def test_two_paths_on_a_doubled_press(self):
+        ws = [w(0x8004A5F5, 5, 4, "0x11110000", seq=1, frame=100),
+              w(0x8004A5F5, 4, 3, "0x22220000", seq=2, frame=100)]
+        self.assertEqual(cw.verdict(ws, 0x8004A5F5)[0], "two_paths")
+
+    def test_one_path_twice_on_a_doubled_press(self):
+        ws = [w(0x8004A5F5, 5, 4, "0x11110000", seq=1, frame=100),
+              w(0x8004A5F5, 4, 3, "0x11110000", seq=2, frame=101)]
+        self.assertEqual(cw.verdict(ws, 0x8004A5F5)[0], "one_path_twice")
+
+    def test_single_write_of_two_steps(self):
+        ws = [w(0x8004A5F5, 5, 3, "0x11110000", seq=1, frame=100)]
+        self.assertEqual(cw.verdict(ws, 0x8004A5F5)[0],
+                         "single_write_double_step")
+
+    def test_clean_presses_report_no_doubling(self):
+        ws = [w(0x8004A5F5, 5, 4, "0xA", seq=1, frame=100),
+              w(0x8004A5F5, 4, 3, "0xA", seq=2, frame=300)]
+        self.assertEqual(cw.verdict(ws, 0x8004A5F5)[0], "no_double_step")
+
+    def test_mixed_capture_reports_the_doubled_presses(self):
+        """Single-step presses in the same capture must not mask the bug."""
+        ws = [w(0x8004A5F5, 9, 8, "0xA", seq=1, frame=100),
+              w(0x8004A5F5, 8, 7, "0xA", seq=2, frame=300),
+              w(0x8004A5F5, 7, 6, "0xB", seq=3, frame=500),
+              w(0x8004A5F5, 6, 5, "0xC", seq=4, frame=500)]
+        self.assertEqual(cw.verdict(ws, 0x8004A5F5)[0], "two_paths")

--- a/tools/tests/test_menu_scan.py
+++ b/tools/tests/test_menu_scan.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""Unit tests for menu_scan's cursor identification."""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import menu_scan as ms
+sys.path.insert(0, os.path.dirname(__file__))
+from test_pad_delivery import txn, hold, NONE
+
+
+class FindChangedOffsetsTest(unittest.TestCase):
+    def test_no_change(self):
+        a = bytes(4096)
+        self.assertEqual(ms.find_changed_offsets(a, a), [])
+
+    def test_single_byte_change(self):
+        a = bytearray(4096)
+        b = bytearray(4096)
+        b[1234] = 7
+        self.assertEqual(ms.find_changed_offsets(bytes(a), bytes(b)), [1234])
+
+    def test_changes_across_block_boundary(self):
+        a = bytearray(4096)
+        b = bytearray(4096)
+        b[1023] = 1
+        b[1024] = 1
+        self.assertEqual(ms.find_changed_offsets(bytes(a), bytes(b)),
+                         [1023, 1024])
+
+    def test_ragged_tail_shorter_than_block(self):
+        a = bytes(1500)
+        b = bytearray(1500)
+        b[1400] = 9
+        self.assertEqual(ms.find_changed_offsets(a, bytes(b)), [1400])
+
+
+class HeldSpansTest(unittest.TestCase):
+    """Holding a direction is input for its whole duration, not one edge."""
+
+    def build(self, words):
+        entries, seq = [], 0
+        for w in words:
+            entries.extend(txn(seq, w))
+            seq += 16
+        return entries
+
+    def test_single_tap_is_one_span(self):
+        e = self.build([NONE, hold("down"), hold("down"), NONE])
+        self.assertEqual(len(ms.held_spans(e, "down")), 1)
+
+    def test_long_hold_is_one_span_covering_it(self):
+        e = self.build([NONE] + [hold("down")] * 6 + [NONE])
+        spans = ms.held_spans(e, "down")
+        self.assertEqual(len(spans), 1)
+        self.assertGreater(spans[0][1] - spans[0][0], 60)
+
+    def test_two_taps_are_two_spans(self):
+        e = self.build([hold("down"), NONE, hold("down"), NONE])
+        self.assertEqual(len(ms.held_spans(e, "down")), 2)
+
+    def test_still_held_at_capture_end_is_closed(self):
+        e = self.build([NONE, hold("down"), hold("down")])
+        self.assertEqual(len(ms.held_spans(e, "down")), 1)
+
+    def test_other_button_ignored(self):
+        e = self.build([hold("up"), NONE])
+        self.assertEqual(ms.held_spans(e, "down"), [])
+
+
+class InputIntervalsTest(unittest.TestCase):
+    def test_press_marks_its_interval(self):
+        before, after = [0, 100, 200], [10, 110, 210]
+        allowed, presses = ms.input_intervals(before, after,
+                                              {"down": [(50, 55)]}, 0)
+        self.assertEqual(allowed, {0})
+        self.assertEqual(presses, [("down", 0, 0)])
+
+    def test_press_during_a_read_marks_both_neighbours(self):
+        before, after = [0, 100, 200], [10, 110, 210]
+        allowed, _ = ms.input_intervals(before, after,
+                                        {"down": [(105, 106)]}, 0)
+        self.assertEqual(allowed, {0, 1})
+
+    def test_every_direction_counts_as_input(self):
+        """A cursor moves on up as well as down; both must be allowed."""
+        before, after = [0, 100, 200, 300], [10, 110, 210, 310]
+        allowed, presses = ms.input_intervals(
+            before, after, {"up": [(50, 55)], "down": [(250, 255)]}, 0)
+        self.assertEqual(allowed, {0, 2})
+        self.assertEqual([p[0] for p in presses], ["up", "down"])
+
+    def test_presses_returned_in_capture_order(self):
+        before, after = [0, 100, 200, 300], [10, 110, 210, 310]
+        _, presses = ms.input_intervals(
+            before, after, {"up": [(250, 255)], "down": [(50, 55)]}, 0)
+        self.assertEqual([p[0] for p in presses], ["down", "up"])
+
+    def test_long_hold_marks_every_interval_it_spans(self):
+        before, after = [0, 100, 200, 300], [10, 110, 210, 310]
+        allowed, _ = ms.input_intervals(before, after,
+                                        {"down": [(50, 250)]}, 0)
+        self.assertEqual(allowed, {0, 1, 2})
+
+    def test_span_outside_capture_not_located(self):
+        before, after = [100, 200], [110, 210]
+        allowed, presses = ms.input_intervals(before, after,
+                                              {"down": [(500, 510)]}, 0)
+        self.assertEqual(allowed, set())
+        self.assertEqual(presses, [])
+
+
+class PressDeltasTest(unittest.TestCase):
+    """Measure the step settled-to-settled, so animation is not sampled."""
+
+    def test_single_step_per_press(self):
+        values = [10, 10, 9, 9, 8, 8]
+        presses = [("down", 1, 1), ("down", 3, 3)]
+        self.assertEqual(ms.press_deltas(values, presses, len(values)),
+                         [("down", -1), ("down", -1)])
+
+    def test_doubled_press_shows_double_step(self):
+        """The bug: one press moved two entries."""
+        values = [10, 10, 9, 9, 7, 7]
+        presses = [("down", 1, 1), ("down", 3, 3)]
+        self.assertEqual(ms.press_deltas(values, presses, len(values)),
+                         [("down", -1), ("down", -2)])
+
+    def test_opposite_directions_reported_separately(self):
+        values = [10, 10, 11, 11, 10, 10]
+        presses = [("down", 1, 1), ("up", 3, 3)]
+        self.assertEqual(ms.press_deltas(values, presses, len(values)),
+                         [("down", 1), ("up", -1)])
+
+    def test_animation_spanning_settle_is_measured_whole(self):
+        """Value slides 10 -> 8 across the settle window: one step of -2."""
+        values = [10, 10, 9, 8, 8]
+        presses = [("down", 1, 2)]
+        self.assertEqual(ms.press_deltas(values, presses, len(values)),
+                         [("down", -2)])
+
+    def test_press_at_the_very_end_does_not_overrun(self):
+        values = [10, 9]
+        presses = [("down", 0, 0)]
+        self.assertEqual(ms.press_deltas(values, presses, len(values)),
+                         [("down", -1)])
+
+
+class ByteDeltaTest(unittest.TestCase):
+    def test_plain_step(self):
+        self.assertEqual(ms.byte_delta(3, 4), 1)
+
+    def test_wrap_down(self):
+        """0 -> 255 is a step back, not a jump of 255."""
+        self.assertEqual(ms.byte_delta(0, 255), -1)
+
+    def test_wrap_up(self):
+        self.assertEqual(ms.byte_delta(255, 0), 1)
+
+
+class ClassifyOffsetTest(unittest.TestCase):
+    """values indices line up with snapshots; presses give (button, lo, hi)."""
+
+    def test_axis_moves_opposite_ways_and_is_strict(self):
+        """up and down move a cursor opposite ways -- not a disqualifier."""
+        values = [10, 10, 9, 9, 8, 8, 9, 9]
+        presses = [("down", 1, 1), ("down", 3, 3), ("up", 5, 5)]
+        allowed = {1, 2, 3, 4, 5, 6}
+        sc = ms.classify_offset(values, allowed, presses)
+        self.assertIsNotNone(sc)
+        self.assertTrue(sc["strict"])
+        self.assertTrue(sc["opposed"])
+
+    def test_movement_without_input_disqualifies(self):
+        values = [10, 11, 12, 13]
+        presses = [("down", 0, 0)]
+        self.assertIsNone(ms.classify_offset(values, {0}, presses))
+
+    def test_double_step_flagged(self):
+        """One press moved two strides: the bug, at whatever stride."""
+        values = [100, 100, 72, 72, 44, 44, 244, 244]
+        presses = [("right", 1, 1), ("right", 3, 3), ("right", 5, 5)]
+        allowed = {1, 2, 3, 4, 5, 6}
+        sc = ms.classify_offset(values, allowed, presses)
+        self.assertTrue(sc["strict"])
+        self.assertTrue(sc["doubled"])
+        self.assertEqual(sc["base"], 28)
+
+    def test_same_button_moving_both_ways_is_not_strict(self):
+        """`down` must not move a cursor up on one press and down the next."""
+        values = [10, 10, 9, 9, 10, 10, 9, 9]
+        presses = [("down", 1, 1), ("down", 3, 3), ("down", 5, 5)]
+        allowed = {1, 2, 3, 4, 5, 6}
+        sc = ms.classify_offset(values, allowed, presses)
+        self.assertFalse(sc["strict"])
+        self.assertFalse(sc["consistent"])
+
+    def test_too_few_responses_is_not_strict(self):
+        values = [10, 10, 9, 9, 9, 9]
+        presses = [("down", 1, 1), ("down", 3, 3)]
+        sc = ms.classify_offset(values, {1, 2, 3, 4}, presses, min_moves=3)
+        self.assertFalse(sc["strict"])
+
+    def test_irregular_stride_is_not_strict(self):
+        values = [0, 0, 3, 3, 13, 13, 20, 20]
+        presses = [("down", 1, 1), ("down", 3, 3), ("down", 5, 5)]
+        sc = ms.classify_offset(values, {1, 2, 3, 4, 5, 6}, presses)
+        self.assertFalse(sc["strict"])
+
+    def test_never_moving_is_not_a_candidate(self):
+        values = [7] * 6
+        presses = [("down", 1, 1)]
+        self.assertIsNone(ms.classify_offset(values, {1, 2}, presses))
+
+
+class DecodeTapsTest(unittest.TestCase):
+    def test_rising_edges_only(self):
+        entries = []
+        seq = 0
+        for w in [NONE, hold("down"), hold("down"), NONE, hold("down"), NONE]:
+            entries.extend(txn(seq, w))
+            seq += 16
+        taps = ms.decode_taps(entries, "down")
+        self.assertEqual(len(taps), 2)
+
+    def test_held_across_whole_capture_is_one_tap(self):
+        entries = []
+        seq = 0
+        for w in [hold("down")] * 5:
+            entries.extend(txn(seq, w))
+            seq += 16
+        self.assertEqual(len(ms.decode_taps(entries, "down")), 1)
+
+    def test_other_button_ignored(self):
+        entries = []
+        seq = 0
+        for w in [NONE, hold("up"), NONE]:
+            entries.extend(txn(seq, w))
+            seq += 16
+        self.assertEqual(ms.decode_taps(entries, "down"), [])
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class DirectionTest(unittest.TestCase):
+    """Per-button consistency replaces the old global sign test."""
+
+    def test_one_direction_moving_both_ways_rejected(self):
+        values = [10, 10, 13, 13, 10, 10]
+        presses = [("down", 1, 1), ("down", 3, 3)]
+        sc = ms.classify_offset(values, {1, 2, 3, 4}, presses, min_moves=2)
+        self.assertFalse(sc["strict"])
+
+    def test_opposite_buttons_moving_opposite_ways_accepted(self):
+        values = [10, 10, 11, 11, 10, 10, 11, 11]
+        presses = [("up", 1, 1), ("down", 3, 3), ("up", 5, 5)]
+        sc = ms.classify_offset(values, {1, 2, 3, 4, 5, 6}, presses)
+        self.assertTrue(sc["strict"])
+        self.assertTrue(sc["opposed"])

--- a/tools/tests/test_pad_delivery.py
+++ b/tools/tests/test_pad_delivery.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Unit tests for pad_delivery's SIO reconstruction."""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pad_delivery as pd
+
+
+NONE = 0xFFFF
+
+
+def txn(seq, buttons=NONE, pad_id=0x73, sticks=(0x80, 0x80, 0x80, 0x80),
+        addr=0x01, cmd=0x42, truncate=None, frame=0):
+    """Build the SIO byte entries for one controller transaction."""
+    lo, hi = buttons & 0xFF, (buttons >> 8) & 0xFF
+    lx, ly, rx, ry = sticks
+    pairs = [(addr, 0xFF), (cmd, pad_id), (0x00, 0x5A), (0x00, lo), (0x00, hi),
+             (0x00, rx), (0x00, ry), (0x00, lx), (0x00, ly)]
+    if truncate is not None:
+        pairs = pairs[:truncate]
+    return [{"seq": seq + i, "tx": "0x%02X" % t, "rx": "0x%02X" % r,
+             "frame": frame}
+            for i, (t, r) in enumerate(pairs)]
+
+
+def hold(name):
+    return NONE & ~pd.BUTTONS[name]
+
+
+def stream(words, start=0, frame_of=None):
+    out, seq = [], start
+    for i, w in enumerate(words):
+        f = frame_of(i) if frame_of else i
+        out.extend(txn(seq, w, frame=f))
+        seq += 16
+    return out
+
+
+class DecodeTest(unittest.TestCase):
+    def test_single_poll_decoded(self):
+        polls = pd.decode_polls(txn(100, hold("down")))
+        self.assertEqual(len(polls), 1)
+        self.assertEqual(polls[0]["buttons"], hold("down"))
+        self.assertEqual(polls[0]["id"], 0x73)
+
+    def test_sticks_decoded_in_lx_ly_order(self):
+        polls = pd.decode_polls(txn(0, NONE, sticks=(0x11, 0x22, 0x33, 0x44)))
+        self.assertEqual(polls[0]["sticks"], [0x11, 0x22, 0x33, 0x44])
+
+    def test_memory_card_traffic_ignored(self):
+        entries = txn(0, NONE, addr=0x81) + txn(50, hold("up"))
+        polls = pd.decode_polls(entries)
+        self.assertEqual(len(polls), 1)
+        self.assertEqual(polls[0]["buttons"], hold("up"))
+
+    def test_truncated_transaction_dropped(self):
+        """A transaction cut off before the button word carries no state."""
+        polls = pd.decode_polls(txn(0, hold("up"), truncate=3))
+        self.assertEqual(polls, [])
+
+    def test_non_poll_command_dropped(self):
+        """0x43 (config) is not a button poll."""
+        polls = pd.decode_polls(txn(0, hold("up"), cmd=0x43))
+        self.assertEqual(polls, [])
+
+    def test_multiple_polls_in_order(self):
+        polls = pd.decode_polls(stream([NONE, hold("up"), NONE]))
+        self.assertEqual([p["buttons"] for p in polls],
+                         [NONE, hold("up"), NONE])
+
+    def test_digital_pad_id(self):
+        polls = pd.decode_polls(txn(0, NONE, pad_id=0x41, truncate=5))
+        self.assertEqual(polls[0]["id"], 0x41)
+        self.assertIsNone(polls[0]["sticks"])
+
+
+class RunTest(unittest.TestCase):
+    def test_contiguous_press_is_one_run(self):
+        polls = pd.decode_polls(stream([NONE] + [hold("down")] * 4 + [NONE]))
+        self.assertEqual(pd.poll_runs(polls, "down"), [(1, 4)])
+
+    def test_split_press_is_two_runs(self):
+        polls = pd.decode_polls(
+            stream([NONE, hold("down"), hold("down"), NONE,
+                    hold("down"), hold("down"), NONE]))
+        self.assertEqual(pd.poll_runs(polls, "down"), [(1, 2), (4, 5)])
+
+
+class AnalyzeTest(unittest.TestCase):
+    def kinds(self, findings):
+        return {f["kind"] for f in findings}
+
+    def test_clean_press_reports_nothing(self):
+        polls = pd.decode_polls(stream([NONE] + [hold("down")] * 4 + [NONE]))
+        runs, findings = pd.analyze(polls)
+        self.assertEqual(len(runs), 1)
+        self.assertEqual(findings, [])
+
+    def test_mid_press_release_is_a_bounce(self):
+        """The smoking gun: one tap delivered as two rising edges."""
+        polls = pd.decode_polls(
+            stream([NONE, hold("down"), hold("down"), NONE,
+                    hold("down"), hold("down"), NONE]))
+        _, findings = pd.analyze(polls)
+        self.assertIn("delivered_bounce", self.kinds(findings))
+
+    def test_two_deliberate_taps_are_not_a_bounce(self):
+        words = ([NONE] + [hold("down")] * 3 + [NONE] * 40
+                 + [hold("down")] * 3 + [NONE])
+        polls = pd.decode_polls(stream(words))
+        _, findings = pd.analyze(polls)
+        self.assertNotIn("delivered_bounce", self.kinds(findings))
+
+    def test_polls_per_frame(self):
+        """Two polls landing in the same frame are counted together."""
+        polls = pd.decode_polls(stream([NONE] * 4, frame_of=lambda i: i // 2))
+        self.assertEqual(pd.polls_per_frame(polls), {0: 2, 1: 2})
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class ResolveFrameTest(unittest.TestCase):
+    """A batch may straddle a frame boundary; say -1 rather than guess."""
+
+    def test_stable_counter_gives_exact_frame(self):
+        self.assertEqual(pd.resolve_frame(1100, 1100), 1100)
+
+    def test_advanced_counter_is_unknowable(self):
+        self.assertEqual(pd.resolve_frame(1100, 1101), -1)
+
+    def test_first_batch_has_no_predecessor(self):
+        self.assertEqual(pd.resolve_frame(None, 1100), -1)
+
+    def test_missing_counter_is_unknowable(self):
+        self.assertEqual(pd.resolve_frame(1100, -1), -1)
+
+    def test_unstamped_polls_excluded_from_counts(self):
+        polls = [{"seq": 0, "frame": -1, "buttons": NONE},
+                 {"seq": 10, "frame": 5, "buttons": NONE},
+                 {"seq": 20, "frame": 5, "buttons": NONE}]
+        self.assertEqual(pd.polls_per_frame(polls), {5: 2})

--- a/tools/tests/test_pad_trace.py
+++ b/tools/tests/test_pad_trace.py
@@ -167,3 +167,30 @@ class AnalyzeTest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class FoldSkewTest(unittest.TestCase):
+    """The D-pad bit and its folded stick deflection should arrive together."""
+
+    def test_simultaneous_fold_has_zero_skew(self):
+        s = [sample(0.00, 10, NONE),
+             sample(0.01, 11, hold("up"), [0x80, 0x00, 0x80, 0x80], True),
+             sample(0.02, 12, NONE)]
+        runs, findings = pt.analyze(s)
+        self.assertEqual(runs[0]["fold_skew_frames"], 0)
+        self.assertNotIn("fold_skew", {f["kind"] for f in findings})
+
+    def test_late_stick_is_reported_as_skew(self):
+        s = [sample(0.00, 10, hold("up"), [0x80] * 4, True),
+             sample(0.01, 12, hold("up"), [0x80, 0x00, 0x80, 0x80], True),
+             sample(0.02, 13, NONE)]
+        runs, findings = pt.analyze(s)
+        self.assertEqual(runs[0]["fold_skew_frames"], 2)
+        self.assertIn("fold_skew", {f["kind"] for f in findings})
+
+    def test_no_stick_means_no_skew(self):
+        s = [sample(0.00, 10, hold("up"), [0x80] * 4, False),
+             sample(0.01, 11, NONE)]
+        runs, findings = pt.analyze(s)
+        self.assertIsNone(runs[0]["fold_skew_frames"])
+        self.assertNotIn("fold_skew", {f["kind"] for f in findings})


### PR DESCRIPTION
## Summary

In pinned-ANALOG mode the runtime presented a single D-pad press as **two
inputs at once**: `pad_sticks_for` slammed the left stick to full deflection
while `pad_buttons_for` went on reporting the D-pad bits. A real DualShock
holds both sticks at `0x80` while the D-pad is down, so this is a state no
hardware produces — and an analog-aware game that reads both sources acts on
one press twice.

Reported as: single D-pad taps registering as double inputs in Legend of Mana.

## Root cause

`runtime/src/main.cpp`, `pad_sticks_for`, reached because Player 1 defaults to
`PAD_MODE_ANALOG`:

```c
if (dpad_pressed("left"))  out[0] = 0x00;
if (dpad_pressed("right")) out[0] = 0xFF;
if (dpad_pressed("up"))    out[1] = 0x00;
if (dpad_pressed("down"))  out[1] = 0xFF;
```

The fold was deliberate — it let stick-only movement paths respond to the
D-pad — and its comment described it as "the faithful 'seamless' behaviour".
The sibling fold on the injection path went further and claimed it was "same
as a real DualShock seat". That claim is false, and it is what licensed the
controller-side fold.

## Evidence

Measured on Legend of Mana's land-placement screen, narrowing from the host
pad down to the write that moved the cursor:

| Probe | Finding |
|---|---|
| `pad_trace` | Host presents **one** press per tap — no bounce, no analog flip, steady 60 fps — but carrying **two representations**, D-pad bit plus full stick deflection, arriving in the same frame (`skew=0`) |
| `pad_delivery` | SIO delivers one contiguous 6-poll run per tap, polls exactly 10 bytes apart; `up`/`down` bit-for-bit mirrors (`0xFFEF`+`ly=0x00` vs `0xFFBF`+`ly=0xFF`). Delivery is clean |
| `menu_scan` | Cursor index at `0x800DCEEC` responded to 14 of 15 presses, stepping **two** entries on 6 of them. The double-buffered display copies at `0x8004C035`/`0x8004C14D` (0x118 apart) mirror it at 3x scale |
| `cursor_writers` | Doubled presses ran the **same handler twice** — `pc=0x8006583C` (decrement) / `0x800658C0` (increment), overlay `func=0x00000F40`, identical return address — on consecutive 30 Hz logic ticks. Frame gaps always even (2 or 4), never odd |

Everything upstream of the fold measured clean and is not implicated.

**Controlled test.** DIGITAL mode changes two variables at once (stick bytes
*and* pad ID `0x73`→`0x41`), so it only showed "not analog-with-fold" fixes it.
This change alters **only the stick bytes**, leaving the pad ID at `0x73`:

- Before, ANALOG: cursor stepped two entries on 6 of 14 presses
- After, ANALOG (`pad_status` → `analog=True`, `sticks=[128,128,128,128]`):
  **33 presses, 33 single steps, zero doubles**

That exonerates the pad type and confirms the fold specifically. Confirmed
visually by the reporter under deliberate stress testing.

## Compatibility

**Games whose movement reads only stick magnitude (e.g. Tomba) will no longer
respond to the D-pad in pinned-ANALOG.** The removed code named Tomba
explicitly. Such games are served by **HYBRID** mode, where pressing the D-pad
flips the pad to digital so the game runs its own d-pad path — without ever
presenting the impossible both-at-once state. This is a mode change for
affected users, not a silent equivalence, and `TombaRecomp` is worth a check
before this lands.

The keyboard path is unaffected: `psx_keybinds_sticks` maps that player's bound
stick-direction keys and is their only stick source.

## Scope

The injected-input fold in `apply_input_override_to_sio` is **retained**. It is
unreachable by a player, and injection has no physical stick to steer with, so
removing it would break tooling that drives stick-only games via `set_input`.
Its comment no longer claims to match hardware. Happy to remove it too if
preferred — two lines at each of two sites.

## Testing

- `ninja -C build-release Legend_of_Mana__Recompiled` — clean
- 177 tool unit tests passing
- Live capture above, in ANALOG mode, on the affected screen

## Also included

Four diagnostic probes with unit tests (`776ebc07`), each answering a question
the previous could not: `pad_trace` (what the runtime presents), `pad_delivery`
(what the game reads, via the always-on SIO ring), `menu_scan` (which RAM
location is the cursor), `cursor_writers` (who wrote it, grouped per press —
separating "two handlers ran" from "one handler ran twice" from "one write of
two steps"). They can be dropped from this PR if you'd rather keep the hotfix
minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
