### PR TITLE
tools: fix macOS CI packaging failure — empty-array expansion under set -u

### DIFF
--- a/tools/bios_emitter_fingerprint.sh
+++ b/tools/bios_emitter_fingerprint.sh
@@ -63,6 +63,6 @@ for f in "${FILES[@]}"; do [ -f "$f" ] && present+=("$f"); done
 # records with a relative path while runtime.cmake recomputes with an absolute
 # one, and every configure read as STALE with a byte-identical tree. The array
 # order is defined by this script alone, so it is stable across spellings.
-for f in "${present[@]}"; do
+for f in ${present[@]+"${present[@]}"}; do
     sha256sum < "$f"
 done | sha256sum | awk '{print $1}'

--- a/tools/bundle_mingw_dlls.sh
+++ b/tools/bundle_mingw_dlls.sh
@@ -327,7 +327,7 @@ for i in "${!EXE_PATHS[@]}"; do
   bundle_one "${EXE_PATHS[$i]}" "${DEST_DIRS[$i]}" "${LABELS[$i]}"
 done
 
-for dll in "${REQUIRE[@]}"; do
+for dll in ${REQUIRE[@]+"${REQUIRE[@]}"}; do
   [[ -n "${dll}" ]] || continue
   for i in "${!EXE_PATHS[@]}"; do
     exe="${EXE_PATHS[$i]}"

--- a/tools/package_release_macos.sh
+++ b/tools/package_release_macos.sh
@@ -286,7 +286,7 @@ note "bundled OpenBIOS (512 KiB) + MIT notice"
 
 # 4. Required mod packages. A silently mod-less launcher looks fine but has no
 #    Mods page at all, which is indistinguishable from the feature being cut.
-for m in "${REQUIRE_MODS[@]}"; do
+for m in ${REQUIRE_MODS[@]+"${REQUIRE_MODS[@]}"}; do
     [ -f "$APPDIR/Contents/Resources/mods/packages/$m" ] \
         || die "required mod package missing: mods/packages/$m"
 done

--- a/tools/package_setup_host.sh
+++ b/tools/package_setup_host.sh
@@ -263,10 +263,15 @@ copy_runtime_dir() {
   echo "staged runtime dir ${name}/"
 }
 
-for d in "${RUNTIME_DIRS[@]}"; do
+# Empty-array expansions below use ${arr[@]+"${arr[@]}"}: under `set -u`,
+# bash 3.2 (still /bin/bash on macOS runners) treats "${arr[@]}" on an EMPTY
+# array as an unbound variable and aborts. bash >= 4.4 does not, so this only
+# ever fails on macOS CI. A game packaged without --runtime-dir hit exactly
+# that.
+for d in ${RUNTIME_DIRS[@]+"${RUNTIME_DIRS[@]}"}; do
   copy_runtime_dir "${d}" 0
 done
-for d in "${RUNTIME_DIRS_OPTIONAL[@]}"; do
+for d in ${RUNTIME_DIRS_OPTIONAL[@]+"${RUNTIME_DIRS_OPTIONAL[@]}"}; do
   copy_runtime_dir "${d}" 1
 done
 
@@ -288,10 +293,10 @@ copy_proj() {
   fi
 }
 
-for f in "${PROJECT_FILES[@]}"; do
+for f in ${PROJECT_FILES[@]+"${PROJECT_FILES[@]}"}; do
   copy_proj "${f}"
 done
-for d in "${PROJECT_DIRS[@]}"; do
+for d in ${PROJECT_DIRS[@]+"${PROJECT_DIRS[@]}"}; do
   copy_proj "${d}"
 done
 

--- a/tools/tests/test_shell_nounset.py
+++ b/tools/tests/test_shell_nounset.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Guard against empty-array expansion under `set -u` in the shell tools.
+
+macOS runners still ship bash 3.2, where expanding "${arr[@]}" on an EMPTY
+array under `set -u` aborts with "unbound variable". bash >= 4.4 does not,
+so this class of bug is invisible on Linux and only ever breaks macOS CI --
+which is exactly how it reached us: a game packaged without --runtime-dir
+failed at `RUNTIME_DIRS[@]: unbound variable`.
+
+The safe idiom, used throughout these scripts, is:
+
+    for x in ${arr[@]+"${arr[@]}"}; do
+
+This test fails on any array that is declared empty and later expanded
+without that guard.
+"""
+
+import os
+import re
+import unittest
+
+TOOLS = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# Arrays that are declared empty but provably populated before every
+# expansion, so the guard would be noise. Keyed (script, array) -> why.
+ALLOWED = {
+    ("stage_setup_sdk.sh", "args"):
+        "unconditionally appended just above the loop",
+    ("package_setup_host.sh", "stage_args"):
+        "declared with contents, not empty",
+}
+
+DECL = re.compile(r"^\s*([A-Za-z_][A-Za-z0-9_]*)=\(\s*\)", re.M)
+GUARDED = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\[@\]\+")
+USE = re.compile(r'"\$\{([A-Za-z_][A-Za-z0-9_]*)\[@\]\}"')
+SET_U = re.compile(r"^set -[a-z]*u", re.M)
+# Lines of context in which a preceding size check still counts.
+LOOKBACK = 3
+COUNT = re.compile(r"\$\{#([A-Za-z_][A-Za-z0-9_]*)\[@\]\}")
+
+
+def shell_scripts():
+    for root, dirs, files in os.walk(TOOLS):
+        dirs[:] = [d for d in dirs if d not in (".git", "__pycache__")]
+        for f in files:
+            if f.endswith(".sh"):
+                yield os.path.join(root, f)
+
+
+class NounsetArrayTest(unittest.TestCase):
+    def test_no_unguarded_empty_array_expansion(self):
+        offenders = []
+        for path in shell_scripts():
+            with open(path, errors="replace") as fh:
+                text = fh.read()
+            if not SET_U.search(text):
+                continue
+            declared_empty = set(DECL.findall(text))
+            if not declared_empty:
+                continue
+            name = os.path.basename(path)
+            lines = text.split("\n")
+            for lineno, line in enumerate(lines, 1):
+                # A guarded expansion contains "${arr[@]+" on the same line.
+                guarded = set(GUARDED.findall(line))
+                # A ${#arr[@]} size check shortly before the expansion is a
+                # real guard too -- it is how vendor_deps.sh protects its
+                # loops -- and ${#arr[@]} itself is safe under bash 3.2.
+                window = "\n".join(lines[max(0, lineno - 1 - LOOKBACK):lineno])
+                counted = set(COUNT.findall(window))
+                for arr in USE.findall(line):
+                    if arr not in declared_empty:
+                        continue
+                    if arr in guarded or arr in counted:
+                        continue
+                    if (name, arr) in ALLOWED:
+                        continue
+                    offenders.append("%s:%d  %s -> %s"
+                                     % (name, lineno, arr, line.strip()[:60]))
+        self.assertEqual(
+            offenders, [],
+            "unguarded empty-array expansion under `set -u` "
+            "(breaks on bash 3.2 / macOS CI); use ${arr[@]+\"${arr[@]}\"}:\n  "
+            + "\n  ".join(offenders))
+
+    def test_the_detector_actually_fires(self):
+        """A detector that can never fail is not a guard."""
+        text = 'set -euo pipefail\nFOO=()\nfor x in "${FOO[@]}"; do :; done\n'
+        declared = set(DECL.findall(text))
+        self.assertIn("FOO", declared)
+        line = 'for x in "${FOO[@]}"; do :; done'
+        self.assertIn("FOO", USE.findall(line))
+        self.assertNotIn("FOO", set(GUARDED.findall(line)))
+
+    def test_guarded_form_is_recognised(self):
+        line = 'for x in ${FOO[@]+"${FOO[@]}"}; do :; done'
+        self.assertIn("FOO", set(GUARDED.findall(line)))
+
+    def test_size_check_counts_as_a_guard(self):
+        line = 'if [[ ${#FOO[@]} -gt 0 ]]; then for x in "${FOO[@]}"; do :; done'
+        self.assertIn("FOO", set(COUNT.findall(line)))
+
+    def test_size_check_on_an_earlier_line_counts(self):
+        """vendor_deps.sh guards one line above the loop."""
+        window = 'if [[ ${#FOO[@]} -gt 0 ]]; then\n  for x in "${FOO[@]}"; do'
+        self.assertIn("FOO", set(COUNT.findall(window)))
+
+    def test_size_check_on_a_different_array_does_not_count(self):
+        window = 'if [[ ${#BAR[@]} -gt 0 ]]; then\n  for x in "${FOO[@]}"; do'
+        self.assertNotIn("FOO", set(COUNT.findall(window)))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes the **macOS CI workflow failure** in the packaging step:

```
psxrecomp/tools/package_setup_host.sh: line 268:
  RUNTIME_DIRS[@]: unbound variable
Error: Process completed with exit code 1
```

(One accuracy note: the failure is in the setup-host packager shell script
invoked by the workflow, not in CMake itself — the CMake configure/build
completes before this point.)

## Root cause

macOS runners still ship **bash 3.2** as `/bin/bash`. Under `set -u`, bash 3.2
treats `"${arr[@]}"` on an **empty** array as an unbound variable and aborts.
bash >= 4.4 does not. The script runs `set -euo pipefail`, so this class of bug
is completely invisible on Linux and Windows and only ever breaks macOS CI.

`RUNTIME_DIRS` is populated solely from `--runtime-dir`, so **any game packaged
without one aborts**. Introduced in `05cd3625` ("tools: stage runtime dirs in
setup-host packages", 2026-08-24).

## Audit

Rather than patch the one reported line, every shell tool under `set -u` was
audited: 15 array expansions, of which **7** can legitimately be empty at the
point of expansion.

| Script | Array | Status |
|---|---|---|
| `package_setup_host.sh` | `RUNTIME_DIRS` | **the CI failure** |
| `package_setup_host.sh` | `RUNTIME_DIRS_OPTIONAL`, `PROJECT_FILES`, `PROJECT_DIRS` | same shape — the check at line 112 only rejects *both* project arrays being empty, so either alone can be |
| `package_release_macos.sh` | `REQUIRE_MODS` | latent, in a **macOS-only** script |
| `bundle_mingw_dlls.sh` | `REQUIRE` | latent |
| `bios_emitter_fingerprint.sh` | `present` | latent — empty when no listed file exists |

Left alone as already safe: five sites already using the guard; both
`vendor_deps.sh` loops, which are guarded by a `${#WANTED[@]}` check one to two
lines above; and `args` / `stage_args`, which are unconditionally populated
before use.

## Fix

All seven now use the `${arr[@]+"${arr[@]}"}` idiom **already used elsewhere in
these same scripts** (`bundle_mingw_dlls.sh`, `stage_setup_sdk.sh`), so this is
consistent with the existing style rather than a new convention. A comment at
the packager records why the quoting looks odd, so it does not get "cleaned up"
later.

## Regression guard

Adds `tools/tests/test_shell_nounset.py`, which scans every `set -u` shell
script for this pattern and fails on a new one — the rule lives in the artifact
instead of in review memory. A `${#arr[@]}` size check within three lines counts
as a guard, which is how `vendor_deps.sh` protects its loops. It includes a test
that the detector itself can fire, since a guard that cannot fail is not a
guard.

## Testing

- `bash -n` on all four modified scripts
- Full tool suite: 98 tests passing
- Idiom verified: empty and undeclared both expand to zero iterations; elements
  containing **spaces** survive intact (this repo's own checkout path has
  spaces); glob characters are not expanded; and guarded output is byte-identical
  to unguarded when the array is populated

**Limitation, stated plainly:** the bash 3.2 abort is **not reproducible on the
dev machine** — bash 5.3 tolerates both empty and undeclared arrays under `-u`.
The first version of the verification asserted that the unguarded form aborts,
and it did not; that test was wrong, not the code. So this fix rests on the
mechanism matching the CI error text exactly and on the idiom being provably
behaviour-preserving — **only the macOS runner can confirm it end to end.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
