### PR TITLE
input: add plugin controller presentation policies

### DIFF
--- a/recompiler/src/config_loader.cpp
+++ b/recompiler/src/config_loader.cpp
@@ -194,15 +194,13 @@ int pad_mode_from_string(const std::string& s, int fallback) {
     std::string l;
     l.reserve(s.size());
     for (char c : s) l.push_back((char)std::tolower((unsigned char)c));
-    /* "hybrid" is MOD-ONLY: reachable solely through
-     * psx_mod_set_controller_mode_override(). A game.toml that declares it is
-     * a configuration error, not something to silently coerce — coercion is
-     * how this mode kept reappearing in titles that never meant to ship it. */
+    /* "hybrid" used to be a framework mode. A game.toml that declares it is
+     * now a configuration error: game-specific auto-switching belongs in an
+     * enabled trusted plugin policy, not in the global launcher/config surface. */
     if (l == "hybrid")
         throw std::runtime_error(
             "[controller] pad mode \"hybrid\" is not selectable. Hybrid is a "
-            "mod-only mode, requested at runtime by a trusted game plugin via "
-            "psx_mod_set_controller_mode_override(). Use \"analog\" or "
+            "game-owned mod policy, not a game.toml value. Use \"analog\" or "
             "\"digital\" here.");
     if (l == "analog")  return PAD_MODE_ANALOG;
     if (l == "digital") return PAD_MODE_DIGITAL;

--- a/recompiler/src/config_loader.h
+++ b/recompiler/src/config_loader.h
@@ -30,21 +30,10 @@
 namespace PSXRecompV4 {
 
 // Pad input mode (per player). Replaces the old analog on/off boolean.
-//   hybrid  — MOD-ONLY. Not selectable in the launcher, not a valid game.toml
-//             value, never a default. It survives solely so a trusted game mod
-//             can request it via psx_mod_set_controller_mode_override() (Tomba's
-//             hybrid controller plugin). Auto-switches analog/digital per the
-//             most-recent input:
-//             nudge the stick -> report DualShock (0x73, variable sticks);
-//             press the D-pad -> report a digital pad (0x41) so the game runs
-//             its OWN d-pad path at true digital sensitivity. Mirrors a
-//             DualShock's analog LED toggling on/off (and Tomba Special
-//             Edition's auto-detect).
 //   analog  — always present a DualShock/analog pad (id 0x73). The D-pad is
-//             folded onto the stick at full deflection so it still moves you.
-//             Default.
+//             independent from both sticks, matching real hardware. Default.
 //   digital — always present a digital pad (id 0x41); sticks disabled.
-enum PadMode { PAD_MODE_HYBRID = 0, PAD_MODE_ANALOG = 1, PAD_MODE_DIGITAL = 2 };
+enum PadMode { PAD_MODE_ANALOG = 1, PAD_MODE_DIGITAL = 2 };
 
 // Renderer IDs shared by game.toml/settings parsing and runtime startup.
 // OpenGL is the default because the Windows software/SDL_Renderer path is slow
@@ -157,7 +146,7 @@ struct WidescreenAspectConeConfig {
 };
 // Parse/format a pad mode. Strict game.toml parsing accepts "analog" or
 // "digital" (case-insensitive), returns `fallback` for unknown values, and
-// THROWS on "hybrid" — the mode is mod-only and must not be declared by a game.
+// THROWS on "hybrid" — game-specific switching must not be declared globally.
 int         pad_mode_from_string(const std::string& s, int fallback);
 // Lenient: for a user's settings.toml, where a stale persisted "hybrid" must
 // migrate to analog rather than refuse to launch.
@@ -560,13 +549,11 @@ struct RuntimeConfig {
 
     // ---- [controller] block — game-declared input defaults ----
     // default_mode: the pad input mode this game ships with (see PadMode):
-    // "hybrid" (default) auto-switches DualShock/digital from the player's
-    // input, "analog" pins DualShock (0x73), "digital" pins a digital pad
-    // (0x41). A stick-capable title (e.g. Tomba) ships "hybrid" so the stick
-    // gives variable run speed yet the D-pad keeps its classic digital feel,
-    // with no launcher toggling. Per-install settings.toml [controller]
-    // p1_mode/p2_mode still override. `default_mode` sets both ports;
-    // `p1_mode`/`p2_mode` set one. Legacy `default_analog`/`p1_analog`/
+    // "analog" pins DualShock (0x73), "digital" pins a digital pad (0x41).
+    // Game-specific auto-switching belongs in an enabled trusted mod plugin,
+    // not in this global config surface. Per-install settings.toml
+    // [controller] p1_mode/p2_mode still override. `default_mode` sets both
+    // ports; `p1_mode`/`p2_mode` set one. Legacy `default_analog`/`p1_analog`/
     // `p2_analog` booleans are still accepted (true->analog, false->digital).
     bool                  has_default_mode = false;
     int                   default_p1_mode  = PAD_MODE_ANALOG;
@@ -582,7 +569,7 @@ struct RuntimeConfig {
     std::string           default_p2_device;
 
     // lock_mode: when true the launcher HIDES the whole pad-mode selector
-    // (Hybrid | Analog | D-Pad) and forces every port to default_p1_mode. For a
+    // (Analog | D-Pad) and forces every port to default_p1_mode. For a
     // game that supports exactly one pad type — e.g. Tomba 2, whose driver only
     // works as a plain digital pad because the DualShock config-mode handshake
     // is unhandled — so the player can't pick a broken mode. Supersedes

--- a/runtime/include/mod_plugins.h
+++ b/runtime/include/mod_plugins.h
@@ -171,19 +171,50 @@ int psx_mod_set_load_acceleration(uint32_t wall_clock_multiplier,
 int psx_mod_set_disc_speed(uint32_t divisor,
                            uint32_t instant_max_per_frame);
 
-/*
- * Override one player's resolved controller presentation mode for this launch.
- * This is intentionally a trusted-plugin API, not a generic launcher setting:
- * games may hide Hybrid from their normal selector while offering it as an
- * explicit game-owned mod.
- */
+/* Controller presentation values exposed to trusted game-owned plugins. */
 enum {
-    PSX_MOD_CONTROLLER_HYBRID = 0,
     PSX_MOD_CONTROLLER_ANALOG = 1,
     PSX_MOD_CONTROLLER_DIGITAL = 2
 };
+/*
+ * Per-sample input facts for an opt-in controller presentation policy. The
+ * runtime owns SDL sampling and SIO delivery; the game-owned plugin owns only
+ * the policy decision of whether this sample should present as DualShock
+ * analog or a digital pad.
+ */
+typedef struct PSXModControllerInput {
+    uint32_t struct_size;
+    uint32_t player;
+    uint32_t sio_slot;
+    uint32_t configured_mode;
+    uint32_t current_mode;
+    uint32_t stick_active;
+    uint32_t dpad_active;
+    uint32_t buttons;
+    uint32_t lx;
+    uint32_t ly;
+    uint32_t rx;
+    uint32_t ry;
+} PSXModControllerInput;
+typedef uint32_t (*PSXModControllerPresentationCallback)(
+    const PSXModControllerInput* input);
+/*
+ * Override one player's resolved controller presentation mode for this launch.
+ * This is intentionally a trusted-plugin API, not a generic launcher setting.
+ */
 int psx_mod_set_controller_mode_override(uint32_t player,
                                          uint32_t controller_mode);
+/*
+ * Let a game-owned plugin choose analog/digital presentation for one player on
+ * every input sample. The initial mode is used for boot/hotplug before the
+ * first sample. config_capable should be non-zero when the selected policy may
+ * present a DualShock, even if a later sample currently reports digital.
+ */
+int psx_mod_set_controller_presentation_policy(
+    uint32_t player,
+    PSXModControllerPresentationCallback callback,
+    uint32_t initial_mode,
+    int config_capable);
 
 /*
  * Register a C plugin before main() on the compilers supported by the runtime.

--- a/runtime/src/main.cpp
+++ b/runtime/src/main.cpp
@@ -345,13 +345,11 @@ static SDL_Texture*  sdl_texture;
 struct PlayerInput {
     int   kind = 0;            /* 0=none, 1=keyboard, 2=controller */
     char  guid[40] = {0};      /* SDL joystick GUID string when kind==controller */
-    /* Pad input mode (PSXRecompV4::PadMode): 1=analog (default), 0=hybrid
-     * (MOD-ONLY, requested via psx_mod_set_controller_mode_override),
-     * 2=digital. hybrid_analog is the per-frame auto-switch latch used only in
-     * hybrid mode: true => currently presenting DualShock (stick was the last
-     * input), false => currently presenting a digital pad (D-pad was last). */
+    /* Pad input mode (PSXRecompV4::PadMode): 1=analog (default), 2=digital.
+     * Game-owned plugins may register a trusted per-sample presentation policy
+     * for title-specific switching, but the global launcher/config surface only
+     * persists analog or digital. */
     int   mode = PSXRecompV4::PAD_MODE_ANALOG;
-    bool  hybrid_analog = false;
     int   deadzone = 3277;  /* raw SDL axis units, ~10% default */
     SDL_GameController* handle = nullptr;
     SDL_JoystickID      instance = -1;
@@ -1192,9 +1190,19 @@ static int           g_frame_interpolation_blend =
     PSX_MOD_FRAME_INTERPOLATION_LINEAR;
 static int           g_frame_interpolation_blend_default =
     PSX_MOD_FRAME_INTERPOLATION_LINEAR;
-static int           g_mod_controller_mode_override[2] = { -1, -1 };
-static_assert((int)PSX_MOD_CONTROLLER_HYBRID ==
-              (int)PSXRecompV4::PAD_MODE_HYBRID);
+static std::array<int, PSX_MAX_PLAYERS> g_mod_controller_mode_override =
+    [] {
+        std::array<int, PSX_MAX_PLAYERS> modes{};
+        modes.fill(-1);
+        return modes;
+    }();
+struct ModControllerPresentationPolicy {
+    PSXModControllerPresentationCallback callback = nullptr;
+    int initial_mode = PSXRecompV4::PAD_MODE_ANALOG;
+    int config_capable = 0;
+};
+static ModControllerPresentationPolicy
+    g_mod_controller_policy[PSX_MAX_PLAYERS];
 static_assert((int)PSX_MOD_CONTROLLER_ANALOG ==
               (int)PSXRecompV4::PAD_MODE_ANALOG);
 static_assert((int)PSX_MOD_CONTROLLER_DIGITAL ==
@@ -1457,8 +1465,9 @@ extern "C" int psx_mod_set_disc_speed(
 
 extern "C" int psx_mod_set_controller_mode_override(
     uint32_t player, uint32_t controller_mode) {
-    if (player >= 2 ||
-        controller_mode > (uint32_t)PSXRecompV4::PAD_MODE_DIGITAL) {
+    if (player >= PSX_MAX_PLAYERS ||
+        (controller_mode != (uint32_t)PSXRecompV4::PAD_MODE_ANALOG &&
+         controller_mode != (uint32_t)PSXRecompV4::PAD_MODE_DIGITAL)) {
         std::fprintf(stderr,
             "psxrecomp: mod rejected controller-mode override "
             "(player %u, mode %u)\n",
@@ -1466,6 +1475,26 @@ extern "C" int psx_mod_set_controller_mode_override(
         return 0;
     }
     g_mod_controller_mode_override[player] = (int)controller_mode;
+    return 1;
+}
+
+extern "C" int psx_mod_set_controller_presentation_policy(
+    uint32_t player,
+    PSXModControllerPresentationCallback callback,
+    uint32_t initial_mode,
+    int config_capable) {
+    if (player >= PSX_MAX_PLAYERS || !callback ||
+        (initial_mode != (uint32_t)PSXRecompV4::PAD_MODE_ANALOG &&
+         initial_mode != (uint32_t)PSXRecompV4::PAD_MODE_DIGITAL)) {
+        std::fprintf(stderr,
+            "psxrecomp: mod rejected controller-presentation policy "
+            "(player %u, initial mode %u)\n",
+            (unsigned)player, (unsigned)initial_mode);
+        return 0;
+    }
+    g_mod_controller_policy[player].callback = callback;
+    g_mod_controller_policy[player].initial_mode = (int)initial_mode;
+    g_mod_controller_policy[player].config_capable = config_capable ? 1 : 0;
     return 1;
 }
 
@@ -3963,18 +3992,13 @@ static void update_controller_rumble(void) {
 }
 
 /* The pad type a mode reports before any input has been sampled (boot /
- * hotplug). analog pins DualShock; digital and hybrid both start as a digital
- * pad (hybrid only flips to DualShock once the player nudges the stick). */
+ * hotplug). analog pins DualShock; digital starts as a plain digital pad. */
 static int pad_mode_boot_analog(int mode) {
-    /* Hybrid boots ANALOG-on (matches a DualShock powered up with the analog LED
-     * lit): the seamless auto-switch then drops to digital only if the player
-     * reaches for the d-pad. Pinned-analog also boots analog; digital boots off. */
-    return (mode == PSXRecompV4::PAD_MODE_ANALOG ||
-            mode == PSXRecompV4::PAD_MODE_HYBRID) ? 1 : 0;
+    return mode == PSXRecompV4::PAD_MODE_ANALOG ? 1 : 0;
 }
 
 /* Keyboard has no DualShock sticks/config handshake — always present as a
- * plain digital pad (SCPH-1080). Leaving keyboard slots in ANALOG/HYBRID made
+ * plain digital pad (SCPH-1080). Leaving keyboard slots in ANALOG/policy mode made
  * P2–P5 show as connected while games that expect digital multitap pads never
  * saw usable button input. */
 static int effective_player_mode(const PlayerInput& p) {
@@ -4002,14 +4026,21 @@ static void refresh_player_devices(void) {
         else open_player(p, s);
         if (netplay) continue;
         const int mode = effective_player_mode_for_sio(p, s);
+        const ModControllerPresentationPolicy& policy =
+            g_mod_controller_policy[s];
+        const int boot_mode = policy.callback ? policy.initial_mode : mode;
         sio_set_pad_connected(s, p.kind != 0 ? 1 : 0);
-        sio_set_pad_analog(s, pad_mode_boot_analog(mode), 0x80, 0x80, 0x80, 0x80);
+        sio_set_pad_analog(s, pad_mode_boot_analog(boot_mode),
+                           0x80, 0x80, 0x80, 0x80);
         /* DIGITAL mode == a plain digital controller that ignores the DualShock
-         * config-mode commands (real SCPH-1080 behaviour); ANALOG/HYBRID == a
-         * config-capable DualShock. A digital pad that wrongly answered 0x43
-         * sent Tomba 2's pad driver down the config path -> phantom 0x00 reads.
+         * config-mode commands (real SCPH-1080 behaviour); ANALOG or an
+         * explicitly config-capable mod policy == a config-capable DualShock.
+         * A digital pad that wrongly answered 0x43 sent Tomba 2's pad driver
+         * down the config path -> phantom 0x00 reads.
          * Multitap taps are always digital (see sio_pad_on_multitap). */
-        sio_set_pad_config_capable(s, mode != PSXRecompV4::PAD_MODE_DIGITAL);
+        sio_set_pad_config_capable(
+            s, policy.callback ? policy.config_capable
+                               : mode != PSXRecompV4::PAD_MODE_DIGITAL);
     }
 }
 
@@ -4017,9 +4048,6 @@ static void refresh_player_devices(void) {
  *   "none" -> no pad; "keyboard" -> keyboard map; otherwise an SDL GUID. */
 static void set_player_device(PlayerInput& p, const std::string& dev, int mode) {
     p.mode = mode;
-    /* Hybrid starts in ANALOG (analog LED on); the auto-switch drops to digital
-     * only when the player uses the d-pad. */
-    p.hybrid_analog = true;
     p.guid[0] = '\0';
     std::string d = lower_copy(trim_copy(dev));
     if (d.empty() || d == "none") { p.kind = 0; }
@@ -4147,18 +4175,23 @@ static uint16_t pad_buttons_for(const PlayerInput& p, int player, bool suppress_
 
 /* Analog stick bytes (lx,ly,rx,ry) for a player; centred if no live source.
  *
- * The host left stick maps to the LEFT analog axes (variable). When fold_dpad
- * is set, the physical D-pad (and, for a keyboard player, the arrow keys) is
- * ALSO folded onto the left axes at full deflection, so an analog-mode game
- * whose movement reads only the stick magnitude (e.g. Tomba) still responds to
- * the D-pad/keyboard — the faithful "seamless" behaviour: the stick gives
- * variable speed, the D-pad gives full speed, both at once. Only the PHYSICAL
- * D-pad is folded in (not the stick->d-pad button mapping), so the stick keeps
- * its true variable magnitude. fold_dpad is false in HYBRID mode (there the
- * D-pad instead flips the pad to digital, so the game runs its own d-pad path)
- * and true in pinned-ANALOG mode. The keyboard branch always folds the arrows
- * — they are that player's only stick source. */
-static void pad_sticks_for(const PlayerInput& p, int player, uint8_t out[4], bool fold_dpad) {
+ * The host left stick maps to the LEFT analog axes (variable). The physical
+ * D-pad is deliberately NOT folded onto those axes: a real DualShock holds
+ * both sticks at 0x80 while the D-pad is pressed, so presenting a direction
+ * as a button bit AND a full stick deflection at once is a state no hardware
+ * produces. An analog-aware game that reads both sources then acts on one
+ * press twice — measured on Legend of Mana's land-placement cursor, which
+ * stepped two entries per tap in pinned-ANALOG and exactly one in DIGITAL.
+ *
+ * A game whose movement reads only the stick magnitude (e.g. Tomba) can opt
+ * into a game-owned presentation policy. That policy may flip the pad to
+ * digital on D-pad input so the game runs its own D-pad path, without ever
+ * presenting the impossible both-at-once state.
+ *
+ * The keyboard branch is unaffected: psx_keybinds_sticks maps that player's
+ * bound stick-direction keys onto the axes, which is their only stick
+ * source. */
+static void pad_sticks_for(const PlayerInput& p, int player, uint8_t out[4]) {
     out[0] = out[1] = out[2] = out[3] = 0x80;
     if (p.kind == 1) {
         /* Keyboard analog: the configurable left/right stick-direction binds
@@ -4228,33 +4261,12 @@ static void pad_sticks_for(const PlayerInput& p, int player, uint8_t out[4], boo
             apply_discrete_stick("rs_up", "rs_down", "rs_left", "rs_right",
                                  &out[2], &out[3]);
         }
-        if (fold_dpad) {
-            /* Fold physical D-pad (mapped "up"/etc. button sources that are
-             * d-pad buttons) — prefer the mapped sources over hardcoded buttons
-             * so a remapped d-pad still folds onto the left stick. */
-            auto dpad_pressed = [&](const char* n) {
-                const PsxButtonMap* e = find_entry(n);
-                if (!e) return false;
-                for (const auto& s : e->sources) {
-                    if (source_is_stick_axis(s)) continue;
-                    if (controller_source_pressed_h(p.handle, s, p.deadzone))
-                        return true;
-                }
-                return false;
-            };
-            if (dpad_pressed("left"))  out[0] = 0x00;
-            if (dpad_pressed("right")) out[0] = 0xFF;
-            if (dpad_pressed("up"))    out[1] = 0x00;
-            if (dpad_pressed("down"))  out[1] = 0xFF;
-        }
     }
 }
 
-/* HYBRID-mode auto-switch detectors (mirror the DualShock analog LED toggling).
- * hybrid_stick_active: the LEFT stick is outside the radial deadzone — the
- * player has reached for analog. hybrid_dpad_active: any D-pad direction (or,
- * for the keyboard, an arrow key) is held — the player wants classic digital.
- * The keyboard has no analog stick, so a keyboard player stays digital. */
+/* Controller-policy facts exposed to trusted game-owned plugins. The runtime
+ * samples host devices and SIO delivery; the plugin decides only whether that
+ * sample should present as analog or digital. */
 static bool controller_stick_active(SDL_GameController* handle, int deadzone) {
     if (!handle) return false;
     const double lx =
@@ -4264,21 +4276,23 @@ static bool controller_stick_active(SDL_GameController* handle, int deadzone) {
     const double dz = (double)(deadzone > 0 ? deadzone : controller_deadzone);
     return std::sqrt(lx * lx + ly * ly) > dz;
 }
-static bool controller_dpad_active(SDL_GameController* handle) {
-    return handle &&
-        (SDL_GameControllerGetButton(handle, SDL_CONTROLLER_BUTTON_DPAD_LEFT) ||
-         SDL_GameControllerGetButton(handle, SDL_CONTROLLER_BUTTON_DPAD_RIGHT) ||
-         SDL_GameControllerGetButton(handle, SDL_CONTROLLER_BUTTON_DPAD_UP) ||
-         SDL_GameControllerGetButton(handle, SDL_CONTROLLER_BUTTON_DPAD_DOWN));
+static bool controller_mapped_dpad_active(const PlayerInput& p,
+                                          SDL_GameController* handle,
+                                          int deadzone) {
+    if (!handle) return false;
+    const uint16_t buttons =
+        controller_pad_buttons(controller_map_for(p), handle,
+                               true, deadzone);
+    return ((uint16_t)~buttons & 0x00F0u) != 0;
 }
 /* Which input sources may drive ONE pad slot this frame.
  *
  * This exists because the answer is consumed in three places — the button
- * merge, the HYBRID analog/digital auto-switch, and the analog stick fold —
+ * merge, the mod presentation policy, and the analog stick fold —
  * and those three used to compute it independently. Whenever they disagreed,
- * a source could assert a button without the hybrid state machine seeing it,
+ * a source could assert a button without the policy detector seeing it,
  * leaving the pad reporting D-pad presses while still presenting ANALOG: the
- * exact failure the hybrid logic exists to prevent, and silent when it
+ * exact failure a policy callback may exist to prevent, and silent when it
  * happens. Deriving all three from one predicate makes that desync
  * structurally impossible rather than merely fixed once.
  *
@@ -4300,11 +4314,11 @@ static PadSources pad_sources_for(const PlayerInput& p, bool dev_here) {
      * keybinds.ini/mouse bind silently.
      *
      * Widening this ONE line is safe precisely because every consumer reads
-     * it — the button merge, the HYBRID auto-switch detectors and the stick
+     * it — the button merge, mod policy detectors and the stick
      * fold all learn about the keyboard in the same instant. Widening the
      * button merge alone (the original shape of this change) let a keyboard
-     * D-pad press assert the D-pad bits while hybrid_dpad_active never saw
-     * them, leaving a mod-driven hybrid pad reporting D-pad input while still
+     * D-pad press assert the D-pad bits while policy detection never saw
+     * them, leaving a policy-driven pad reporting D-pad input while still
      * presenting ANALOG.
      *
      * The PSX pad word is active-low and the merge is an AND, so an unpressed
@@ -4317,7 +4331,8 @@ static PadSources pad_sources_for(const PlayerInput& p, bool dev_here) {
     return s;
 }
 
-static bool hybrid_stick_active(const PlayerInput& p, const PadSources& src) {
+static bool controller_policy_stick_active(const PlayerInput& p,
+                                           const PadSources& src) {
     if (src.device && p.kind == 2 &&
         controller_stick_active(p.handle, p.deadzone)) return true;
     if (src.all_pads) {
@@ -4333,9 +4348,10 @@ static bool hybrid_stick_active(const PlayerInput& p, const PadSources& src) {
     }
     return false;
 }
-static bool hybrid_dpad_active(const PlayerInput& p, int player,
-                               const PadSources& src) {
-    if (src.device && p.kind == 2 && controller_dpad_active(p.handle)) return true;
+static bool controller_policy_dpad_active(const PlayerInput& p, int player,
+                                          const PadSources& src) {
+    if (src.device && p.kind == 2 &&
+        controller_mapped_dpad_active(p, p.handle, p.deadzone)) return true;
     if (src.all_pads) {
         const int n = SDL_NumJoysticks();
         for (int i = 0; i < n; i++) {
@@ -4344,7 +4360,14 @@ static bool hybrid_dpad_active(const PlayerInput& p, int player,
             SDL_GameController* handle =
                 SDL_GameControllerFromInstanceID(inst);
             if (!handle) handle = SDL_GameControllerOpen(i);
-            if (controller_dpad_active(handle)) return true;
+            if (!handle) continue;
+            PlayerInput tmp;
+            tmp.kind = 2;
+            SDL_JoystickGUID g = SDL_JoystickGetDeviceGUID(i);
+            SDL_JoystickGetGUIDString(g, tmp.guid, (int)sizeof(tmp.guid));
+            if (controller_mapped_dpad_active(tmp, handle,
+                                              controller_deadzone))
+                return true;
         }
     }
     if (src.keybinds) {
@@ -4354,16 +4377,88 @@ static bool hybrid_dpad_active(const PlayerInput& p, int player,
     return false;
 }
 
+static int controller_policy_resolve_mode(
+    int slot, int player, int configured_mode, const PadSources& src,
+    const PlayerInput& p, uint16_t buttons, const uint8_t st[4]) {
+    ModControllerPresentationPolicy& policy = g_mod_controller_policy[slot];
+    if (!policy.callback)
+        return configured_mode;
+
+    const uint32_t current_mode =
+        configured_mode == PSXRecompV4::PAD_MODE_DIGITAL
+            ? (uint32_t)PSX_MOD_CONTROLLER_DIGITAL
+            : (uint32_t)PSX_MOD_CONTROLLER_ANALOG;
+    PSXModControllerInput input{};
+    input.struct_size = sizeof(input);
+    input.player = (uint32_t)player;
+    input.sio_slot = (uint32_t)slot;
+    input.configured_mode = current_mode;
+    input.current_mode = current_mode;
+    input.stick_active = controller_policy_stick_active(p, src) ? 1u : 0u;
+    input.dpad_active = controller_policy_dpad_active(p, player, src) ? 1u : 0u;
+    input.buttons = buttons;
+    input.lx = st[0];
+    input.ly = st[1];
+    input.rx = st[2];
+    input.ry = st[3];
+
+    const uint32_t requested = policy.callback(&input);
+    if (requested == (uint32_t)PSX_MOD_CONTROLLER_ANALOG)
+        return PSXRecompV4::PAD_MODE_ANALOG;
+    if (requested == (uint32_t)PSX_MOD_CONTROLLER_DIGITAL)
+        return PSXRecompV4::PAD_MODE_DIGITAL;
+    std::fprintf(stderr,
+        "psxrecomp: mod controller policy returned invalid mode %u "
+        "(player %u)\n",
+        (unsigned)requested, (unsigned)player);
+    return configured_mode;
+}
+
+static int controller_policy_resolve_override_mode(
+    int slot, int player, int configured_mode, uint16_t buttons,
+    const uint8_t st[4], bool stick_live, bool dpad_live) {
+    ModControllerPresentationPolicy& policy = g_mod_controller_policy[slot];
+    if (!policy.callback)
+        return configured_mode;
+
+    const uint32_t current_mode =
+        configured_mode == PSXRecompV4::PAD_MODE_DIGITAL
+            ? (uint32_t)PSX_MOD_CONTROLLER_DIGITAL
+            : (uint32_t)PSX_MOD_CONTROLLER_ANALOG;
+    PSXModControllerInput input{};
+    input.struct_size = sizeof(input);
+    input.player = (uint32_t)player;
+    input.sio_slot = (uint32_t)slot;
+    input.configured_mode = current_mode;
+    input.current_mode = current_mode;
+    input.stick_active = stick_live ? 1u : 0u;
+    input.dpad_active = dpad_live ? 1u : 0u;
+    input.buttons = buttons;
+    input.lx = st[0];
+    input.ly = st[1];
+    input.rx = st[2];
+    input.ry = st[3];
+
+    const uint32_t requested = policy.callback(&input);
+    if (requested == (uint32_t)PSX_MOD_CONTROLLER_ANALOG)
+        return PSXRecompV4::PAD_MODE_ANALOG;
+    if (requested == (uint32_t)PSX_MOD_CONTROLLER_DIGITAL)
+        return PSXRecompV4::PAD_MODE_DIGITAL;
+    std::fprintf(stderr,
+        "psxrecomp: mod controller policy returned invalid mode %u "
+        "(player %u)\n",
+        (unsigned)requested, (unsigned)player);
+    return configured_mode;
+}
+
 /* Sample each player's live device state into the matching SIO pad slot.
  * override >= 0 forces port-1 buttons (debug-server input injection). Called
  * once at cycle start (covers the turbo/FMV-skip paths that present nothing)
  * and, when g_low_latency_input is set, AGAIN after the pacer wait so the next
  * CPU frame reads near-fresh input instead of input ~one frame stale.
  *
- * HYBRID mode auto-switches DualShock<->digital from the most-recent input
- * (stick -> analog, D-pad -> digital) so the game runs its own analog or
- * digital input path exactly as on hardware (mirrors the inline block this
- * helper was extracted from for the low-latency re-sample). */
+ * A game-owned presentation policy may auto-switch DualShock<->digital from
+ * the most-recent input so the game runs its own analog or digital path. */
 /* Dev input mode: while enabled, Player 1 is driven by the keyboard AND EVERY
  * connected game controller, all merged together (active-low AND) onto the P1 pad
  * word — so a tester can navigate P1 from whatever is plugged in (keyboard, the
@@ -4491,12 +4586,12 @@ static int savestate_input_guard_active(void) {
 
 /* Debug-server input injection: drive the SAME pad model as a physical
  * device. The old path set only the button word and returned, which left the
- * pad type/sticks at whatever the real device last was — a hybrid P1 stayed
- * analog, so injected d-pad bits never moved games that read the stick in
- * analog mode (menus reacted, walking didn't). Injected d-pad reads as d-pad
- * activity (hybrid drops to digital), an injected stick override reads as
- * stick activity (hybrid rises to analog), and the resolved type goes through
- * the same coherent request channel as real sampling — never slammed mid-
+ * pad type/sticks at whatever the real device last was. A policy-driven P1
+ * could stay analog, so injected D-pad bits never moved games that read the
+ * stick in analog mode (menus reacted, walking didn't). Injected D-pad reads
+ * as D-pad activity, an injected stick override reads as stick activity, and
+ * the resolved type goes through the same coherent request channel as real
+ * sampling — never slammed mid-
  * handshake (the v0.5.0 phantom-input lesson). */
 static void apply_input_override_to_sio(int override_word) {
     PlayerInput& p = g_players[0];
@@ -4520,20 +4615,22 @@ static void apply_input_override_to_sio(int override_word) {
     else if (dev_any_input_enabled()) mode = (int)PSXRecompV4::PAD_MODE_ANALOG;
     else                              mode = p.mode;
 
-    int eff_analog;
-    if (mode == (int)PSXRecompV4::PAD_MODE_DIGITAL) {
-        eff_analog = 0;
-    } else if (mode == (int)PSXRecompV4::PAD_MODE_ANALOG) {
-        eff_analog = 1;
-    } else { /* HYBRID: most-recent input source wins, like the real sampler */
-        if (stick_live)     p.hybrid_analog = true;
-        else if (dpad_live) p.hybrid_analog = false;
-        eff_analog = p.hybrid_analog ? 1 : 0;
-    }
-    /* Pinned-ANALOG folds injected D-pad onto the left stick (same as a real
-     * DualShock seat). Without this, stick-only menu/move paths ignore
-     * button-bit injection even though pad_status shows the bits pressed. */
-    if (eff_analog && mode == (int)PSXRecompV4::PAD_MODE_ANALOG && !stick_live) {
+    const int effective_mode = controller_policy_resolve_override_mode(
+        0, 1, mode, w, st, stick_live, dpad_live);
+    const int eff_analog =
+        effective_mode == (int)PSXRecompV4::PAD_MODE_ANALOG ? 1 : 0;
+    /* Injected input only (set_input / dev routing): fold the injected D-pad
+     * word onto the left stick so stick-only menu/move paths respond to a
+     * button-bit injection that has no physical stick behind it.
+     *
+     * This is NOT hardware behaviour -- a real DualShock keeps its sticks at
+     * 0x80 while the D-pad is held -- and a game reading both sources will
+     * act on one injected press twice. It is kept only because injection has
+     * no other way to steer such a game; the equivalent fold for physical
+     * controllers was removed (see pad_sticks_for) after it was measured
+     * double-stepping Legend of Mana's land-placement cursor. */
+    if (eff_analog &&
+        effective_mode == (int)PSXRecompV4::PAD_MODE_ANALOG && !stick_live) {
         if ((uint16_t)(~w & 0x0010u)) st[1] = 0x00; /* Up */
         if ((uint16_t)(~w & 0x0040u)) st[1] = 0xFF; /* Down */
         if ((uint16_t)(~w & 0x0080u)) st[0] = 0x00; /* Left */
@@ -4569,21 +4666,22 @@ static int capture_pad_slot(int s, PsxNetPad* out) {
      * handshake cadence is preserved exactly). A P1 with no assigned device
      * keeps the game's resolved mode while dev-any-input merges the keyboard and
      * all connected controllers. */
-    /* One source set, consumed by the hybrid switch, the button merge and the
+    /* One source set, consumed by the presentation policy, the button merge and the
      * stick fold below — see pad_sources_for(). */
     const PadSources src = pad_sources_for(p, dev_here);
 
     const int mode = effective_player_mode_for_sio(p, s);
-    int eff_analog;
-    if (mode == PSXRecompV4::PAD_MODE_DIGITAL) {
-        eff_analog = 0;
-    } else if (mode == PSXRecompV4::PAD_MODE_ANALOG) {
-        eff_analog = 1;
-    } else { /* HYBRID */
-        if (hybrid_stick_active(p, src))             p.hybrid_analog = true;
-        else if (hybrid_dpad_active(p, player, src)) p.hybrid_analog = false;
-        eff_analog = p.hybrid_analog ? 1 : 0;
+    uint8_t st[4] = { 0x80, 0x80, 0x80, 0x80 };
+    if (mode == PSXRecompV4::PAD_MODE_ANALOG ||
+        g_mod_controller_policy[s].callback) {
+        pad_sticks_for(p, player, st);
     }
+    const uint16_t policy_buttons =
+        src.device ? pad_buttons_for(p, player, true) : (uint16_t)0xFFFF;
+    const int effective_mode = controller_policy_resolve_mode(
+        s, player, mode, src, p, policy_buttons, st);
+    const int eff_analog =
+        effective_mode == PSXRecompV4::PAD_MODE_ANALOG ? 1 : 0;
     if (savestate_input_guard_active()) {
         out->buttons = 0xFFFFu;
         out->lx = out->ly = out->rx = out->ry = 0x80u;
@@ -4611,16 +4709,10 @@ static int capture_pad_slot(int s, PsxNetPad* out) {
     if (src.all_pads)
         btn &= dev_all_controllers_buttons(suppress_stick);
 
-    /* Analog axes. Pinned-ANALOG folds the physical D-pad onto the left axes
-     * (fold_dpad) so the D-pad still moves stick-only games; HYBRID feeds the
-     * raw stick when currently analog (no fold — the D-pad drives its own
-     * digital path there); DIGITAL leaves the axes centred. */
-    uint8_t st[4] = { 0x80, 0x80, 0x80, 0x80 };
-    if (mode == PSXRecompV4::PAD_MODE_ANALOG) {
-        pad_sticks_for(p, player, st, /*fold_dpad=*/true);
-    } else if (eff_analog) {  /* HYBRID, currently presenting analog */
-        pad_sticks_for(p, player, st, /*fold_dpad=*/false);
-    }
+    /* Analog axes. ANALOG and plugin-selected analog feed the raw stick only;
+     * the D-pad is never folded in, matching a real DualShock, which keeps
+     * its sticks centred while the D-pad is held. DIGITAL leaves the axes
+     * centred. */
     /* Stick fold, driven by the SAME source set as the buttons above: whatever
      * may press a button may also steer. kind==1 already folded its binds
      * inside pad_sticks_for; psx_keybinds_sticks only widens a deflection, so
@@ -4632,6 +4724,9 @@ static int capture_pad_slot(int s, PsxNetPad* out) {
         }
         if (src.all_pads)
             dev_any_controller_sticks(st);
+    }
+    if (!eff_analog) {
+        st[0] = st[1] = st[2] = st[3] = 0x80;
     }
 
     out->buttons = btn;
@@ -4662,25 +4757,22 @@ static int capture_pad_slot_exclusive(int s, PsxNetPad* out, int present_sio_slo
     const PadSources src = pad_sources_for(p, dev_here);
     const int sio_slot = (present_sio_slot >= 0) ? present_sio_slot : s;
     int mode = effective_player_mode_for_sio(p, sio_slot);
-    int eff_analog;
-    if (mode == PSXRecompV4::PAD_MODE_DIGITAL) {
-        eff_analog = 0;
-    } else if (mode == PSXRecompV4::PAD_MODE_ANALOG) {
-        eff_analog = 1;
-    } else { /* HYBRID */
-        if (hybrid_stick_active(p, src))             p.hybrid_analog = true;
-        else if (hybrid_dpad_active(p, player, src)) p.hybrid_analog = false;
-        eff_analog = p.hybrid_analog ? 1 : 0;
+    uint8_t st[4] = { 0x80, 0x80, 0x80, 0x80 };
+    if (mode == PSXRecompV4::PAD_MODE_ANALOG ||
+        g_mod_controller_policy[s].callback) {
+        pad_sticks_for(p, player, st);
     }
+    const uint16_t policy_buttons = pad_buttons_for(p, player, true);
+    const int effective_mode = controller_policy_resolve_mode(
+        s, player, mode, src, p, policy_buttons, st);
+    const int eff_analog =
+        effective_mode == PSXRecompV4::PAD_MODE_ANALOG ? 1 : 0;
 
     const bool suppress_stick = (eff_analog != 0);
     uint16_t btn = pad_buttons_for(p, player, suppress_stick);
 
-    uint8_t st[4] = { 0x80, 0x80, 0x80, 0x80 };
-    if (mode == PSXRecompV4::PAD_MODE_ANALOG) {
-        pad_sticks_for(p, player, st, /*fold_dpad=*/true);
-    } else if (eff_analog) {  /* HYBRID, currently presenting analog */
-        pad_sticks_for(p, player, st, /*fold_dpad=*/false);
+    if (!eff_analog) {
+        st[0] = st[1] = st[2] = st[3] = 0x80;
     }
 
     out->buttons = btn;
@@ -4805,17 +4897,15 @@ static void capture_override_pad(int override_word, PsxNetPad* out) {
     else if (dev_any_input_enabled()) mode = (int)PSXRecompV4::PAD_MODE_ANALOG;
     else                              mode = p.mode;
 
-    int eff_analog;
-    if (mode == (int)PSXRecompV4::PAD_MODE_DIGITAL) {
-        eff_analog = 0;
-    } else if (mode == (int)PSXRecompV4::PAD_MODE_ANALOG) {
-        eff_analog = 1;
-    } else {
-        if (stick_live)     p.hybrid_analog = true;
-        else if (dpad_live) p.hybrid_analog = false;
-        eff_analog = p.hybrid_analog ? 1 : 0;
-    }
-    if (eff_analog && mode == (int)PSXRecompV4::PAD_MODE_ANALOG && !stick_live) {
+    const int effective_mode = controller_policy_resolve_override_mode(
+        0, 1, mode, w, st, stick_live, dpad_live);
+    const int eff_analog =
+        effective_mode == (int)PSXRecompV4::PAD_MODE_ANALOG ? 1 : 0;
+    /* Injected input only; see the note on the sibling fold above. Not
+     * hardware behaviour, retained solely so injection can steer stick-only
+     * games. */
+    if (eff_analog &&
+        effective_mode == (int)PSXRecompV4::PAD_MODE_ANALOG && !stick_live) {
         if ((uint16_t)(~w & 0x0010u)) st[1] = 0x00;
         if ((uint16_t)(~w & 0x0040u)) st[1] = 0xFF;
         if ((uint16_t)(~w & 0x0080u)) st[0] = 0x00;
@@ -5154,12 +5244,10 @@ static void sample_pad_into_sio(int override) {
         PsxNetPad pad;
         if (!capture_pad_slot(s, &pad)) continue;  /* no device in this port */
         /* Push sticks every frame; request the pad type (digital/analog) through
-         * the coherent channel so a hybrid stick<->d-pad flip is applied only at
-         * an idle, non-config bus boundary (never mid-poll / mid-handshake). This
-         * is the fix for the v0.5.0 phantom-input regression: slamming the type
-         * each frame raced Tomba's DualShock config handshake -> garbage button
-         * reads. eff_analog still reflects this frame's mode (digital / analog /
-         * hybrid auto-switch). */
+         * the coherent channel so a policy switch is applied only at an idle,
+         * non-config bus boundary (never mid-poll / mid-handshake). This is the
+         * fix for the v0.5.0 phantom-input regression: slamming the type each
+         * frame raced Tomba's DualShock config handshake -> garbage reads. */
         apply_pad_slot_to_sio(s, pad);
         if (psx_start_consumer_enabled())
             psx_start_consumer_note(s, consumer_sim, pad.buttons);
@@ -12297,10 +12385,11 @@ int main(int argc, char** argv) {
         }
     }
     /* Activation callbacks are re-run after every launcher session. Clear
-     * game-owned controller overrides first so disabling a package cannot
-     * leave its prior mode latched across a soft return to the launcher. */
-    g_mod_controller_mode_override[0] = -1;
-    g_mod_controller_mode_override[1] = -1;
+     * game-owned controller overrides/policies first so disabling a package
+     * cannot leave its prior state latched across a soft return. */
+    g_mod_controller_mode_override.fill(-1);
+    for (auto& policy : g_mod_controller_policy)
+        policy = ModControllerPresentationPolicy{};
     g_mod_load_wall_multiplier = -1;
     g_mod_load_release_frames = -1;
     g_mod_disc_speed_divisor = -1;
@@ -12313,10 +12402,10 @@ int main(int argc, char** argv) {
     g_frame_interpolation_blend = g_frame_interpolation_blend_default;
     mod_runtime_activate_plugins();
     apply_netplay_local_viewport_aspect(net_cfg.enabled);
-    if (g_mod_controller_mode_override[0] >= 0)
-        player_mode[0] = g_mod_controller_mode_override[0];
-    if (g_mod_controller_mode_override[1] >= 0)
-        player_mode[1] = g_mod_controller_mode_override[1];
+    for (int i = 0; i < PSX_MAX_PLAYERS; ++i) {
+        if (g_mod_controller_mode_override[i] >= 0)
+            player_mode[i] = g_mod_controller_mode_override[i];
+    }
     if (g_mod_load_wall_multiplier >= 0) {
         g_turbo_loads_enabled = 1;
         g_turbo_load_wall_multiplier = g_mod_load_wall_multiplier;

--- a/runtime/tests/test_hybrid_dev_any_input.py
+++ b/runtime/tests/test_hybrid_dev_any_input.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Guard Hybrid mode's explicitly opt-in dev-any routing."""
+"""Guard plugin controller policy's explicitly opt-in dev-any routing."""
 
 from pathlib import Path
 
@@ -14,27 +14,34 @@ assert "e && (e[0] == '0'" not in MAIN, (
     "PSX_DEV_INPUT must not use the old default-on/explicit-disable predicate"
 )
 
-assert "hybrid_stick_active(const PlayerInput& p, const PadSources& src)" in MAIN
-assert "hybrid_dpad_active(const PlayerInput& p, int player," in MAIN
-assert "hybrid_stick_active(p, src)" in MAIN
-assert "hybrid_dpad_active(p, player, src)" in MAIN
+assert "PAD_MODE_HYBRID" not in MAIN
+assert "PSX_MOD_CONTROLLER_HYBRID" not in MAIN
+assert "controller_policy_stick_active(const PlayerInput& p," in MAIN
+assert "controller_policy_dpad_active(const PlayerInput& p, int player," in MAIN
+assert "controller_policy_stick_active(p, src)" in MAIN
+assert "controller_policy_dpad_active(p, player, src)" in MAIN
 
 stick_body = MAIN.split(
-    "static bool hybrid_stick_active(const PlayerInput& p, const PadSources& src)", 1
-)[1].split("static bool hybrid_dpad_active", 1)[0]
+    "static bool controller_policy_stick_active(const PlayerInput& p,",
+    1,
+)[1].split("static bool controller_policy_dpad_active", 1)[0]
 dpad_body = MAIN.split(
-    "static bool hybrid_dpad_active(const PlayerInput& p, int player,",
+    "static bool controller_policy_dpad_active(const PlayerInput& p, int player,",
     1,
 )[1].split("/* Sample each player's live device state", 1)[0]
 
 for name, body, detector in (
     ("stick", stick_body, "controller_stick_active(handle, controller_deadzone)"),
-    ("D-pad", dpad_body, "controller_dpad_active(handle)"),
+    ("D-pad", dpad_body, "controller_mapped_dpad_active"),
 ):
     assert "SDL_NumJoysticks()" in body, (
-        f"Hybrid {name} detection must inspect all dev-any controllers"
+        f"Policy {name} detection must inspect all dev-any controllers"
     )
     assert "SDL_GameControllerFromInstanceID" in body
     assert detector in body
 
-print("Hybrid dev-any physical-controller guard passed")
+assert "controller_mapped_dpad_active" in dpad_body
+assert "controller_pad_buttons(controller_map_for(p), handle," in MAIN
+assert "true, deadzone" in MAIN
+
+print("controller policy dev-any physical-controller guard passed")

--- a/runtime/tests/test_mod_controller_override.py
+++ b/runtime/tests/test_mod_controller_override.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Guard the game-owned controller-mode override lifecycle."""
+"""Guard trusted-plugin controller presentation lifecycle."""
 
 from pathlib import Path
 
@@ -11,23 +11,30 @@ HEADER = (ROOT / "runtime" / "include" / "mod_plugins.h").read_text(
 )
 
 for symbol in (
-    "PSX_MOD_CONTROLLER_HYBRID",
     "PSX_MOD_CONTROLLER_ANALOG",
     "PSX_MOD_CONTROLLER_DIGITAL",
+    "PSXModControllerInput",
+    "PSXModControllerPresentationCallback",
     "psx_mod_set_controller_mode_override",
+    "psx_mod_set_controller_presentation_policy",
 ):
     assert symbol in HEADER, f"missing trusted-plugin controller API: {symbol}"
 
-reset0 = "g_mod_controller_mode_override[0] = -1;"
-reset1 = "g_mod_controller_mode_override[1] = -1;"
+assert "PSX_MOD_CONTROLLER_HYBRID" not in HEADER
+
+reset_override = "g_mod_controller_mode_override.fill(-1);"
+reset_policy = "policy = ModControllerPresentationPolicy{};"
 activate = "mod_runtime_activate_plugins();"
-apply0 = "player_mode[0] = g_mod_controller_mode_override[0];"
-apply1 = "player_mode[1] = g_mod_controller_mode_override[1];"
+apply = "player_mode[i] = g_mod_controller_mode_override[i];"
 
-for snippet in (reset0, reset1, activate, apply0, apply1):
-    assert snippet in MAIN, f"missing controller override lifecycle step: {snippet}"
+for snippet in (reset_override, reset_policy, activate, apply):
+    assert snippet in MAIN, (
+        f"missing controller presentation lifecycle step: {snippet}"
+    )
 
-assert MAIN.index(reset0) < MAIN.index(activate) < MAIN.index(apply0)
-assert MAIN.index(reset1) < MAIN.index(activate) < MAIN.index(apply1)
+assert MAIN.index(reset_override) < MAIN.index(activate) < MAIN.index(apply)
+assert MAIN.index(reset_policy) < MAIN.index(activate) < MAIN.index(apply)
+assert "controller_policy_resolve_mode(" in MAIN
+assert "controller_policy_resolve_override_mode(" in MAIN
 
-print("mod controller override lifecycle guard passed")
+print("mod controller presentation lifecycle guard passed")

--- a/tools/cursor_writers.py
+++ b/tools/cursor_writers.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""
+cursor_writers.py — Catch every write to the menu cursor and name the writer.
+
+menu_scan.py located a variable that moved two steps from one D-pad tap.
+This registers a write-trace range over it and records each write during a
+capture: the value before and after, the PC that made it, and the frame.
+
+That distinguishes the two ways one tap becomes two moves:
+
+  two writes, two PCs   two independent code paths each acted on the input.
+                        If one reads the button bits and the other the stick
+                        bytes, the D-pad/stick fold is implicated.
+  two writes, one PC    one path ran twice — the game polled or ticked twice.
+  one write of -2       one path computed a step of two; the doubling is in
+                        the step calculation, and input is not to blame.
+
+Usage:
+    python3 cursor_writers.py --seconds 12 --focus 0x8004A5F5
+
+Registers a trace range, captures, then always removes the range it added.
+"""
+
+import argparse
+import json
+import sys
+import time
+
+sys.path.insert(0, __file__.rsplit("/", 1)[0])
+
+PHYS_MASK = 0x1FFFFFFF
+
+
+def phys(addr):
+    """The trace ring records physical addresses; KSEG0/KSEG1 map down."""
+    return addr & PHYS_MASK
+
+
+def writes_in_range(entries, lo, hi):
+    """Trace entries whose address falls in [lo, hi), oldest first."""
+    out = []
+    for e in entries:
+        a = int(e["addr"], 16)
+        if phys(lo) <= a < phys(hi):
+            out.append(e)
+    out.sort(key=lambda e: e["seq"])
+    return out
+
+
+def covers(e, addr):
+    """Does this write touch `addr`?
+
+    The ring records a write at its base address and width, so a halfword
+    store to 0x...F4 changes the byte at 0x...F5 without ever appearing at
+    that address.  Matching on address equality misses those entirely.
+    """
+    a = int(e["addr"], 16)
+    return a <= phys(addr) < a + e.get("w", 4)
+
+
+def byte_value(e, key, addr):
+    """The byte this write put at `addr` ("old" or "new")."""
+    shift = (phys(addr) - int(e["addr"], 16)) * 8
+    return (int(e[key], 16) >> shift) & 0xFF
+
+
+def byte_delta(e, addr):
+    """Signed change this write made to the single byte at `addr`."""
+    d = byte_value(e, "new", addr) - byte_value(e, "old", addr)
+    if d > 128:
+        d -= 256
+    elif d < -128:
+        d += 256
+    return d
+
+
+def touching_writes(writes, addr):
+    """Writes that actually changed the byte at `addr`.
+
+    A wide store may cover the byte while leaving it alone; that is not a
+    cursor move and must not be counted as one.
+    """
+    return [e for e in writes if covers(e, addr) and byte_delta(e, addr) != 0]
+
+
+def delta(e):
+    """Signed change this write made, at the traced width."""
+    w = e.get("w", 4)
+    bits = w * 8
+    old = int(e["old"], 16) & ((1 << bits) - 1)
+    new = int(e["new"], 16) & ((1 << bits) - 1)
+    d = new - old
+    # Interpret a large jump as a small signed step (wrap at the width).
+    if d > (1 << (bits - 1)):
+        d -= (1 << bits)
+    elif d < -(1 << (bits - 1)):
+        d += (1 << bits)
+    return d
+
+
+def summarize(writes, focus):
+    """Per-address rollup, with the focus address reported in full."""
+    by_addr = {}
+    for e in writes:
+        a = int(e["addr"], 16)
+        s = by_addr.setdefault(a, {"addr": a, "writes": 0, "pcs": set(),
+                                   "funcs": set(), "deltas": []})
+        s["writes"] += 1
+        s["pcs"].add(e["pc"])
+        s["funcs"].add(e.get("func", "?"))
+        s["deltas"].append(delta(e))
+    for s in by_addr.values():
+        s["pcs"] = sorted(s["pcs"])
+        s["funcs"] = sorted(s["funcs"])
+    focus_writes = touching_writes(writes, focus)
+    return by_addr, focus_writes
+
+
+def group_events(writes, focus, gap_frames=8):
+    """Split writes into one group per press.
+
+    A press produces its writes within a frame or two; separate presses are
+    seconds apart.  Grouping keeps a capture containing several presses from
+    being read as one confused event.
+    """
+    events, cur = [], []
+    for e in sorted(writes, key=lambda x: x["seq"]):
+        if cur and (e.get("frame", 0) - cur[-1].get("frame", 0)) > gap_frames:
+            events.append(cur)
+            cur = []
+        cur.append(e)
+    if cur:
+        events.append(cur)
+    return events
+
+
+def describe_event(ev, focus):
+    total = sum(byte_delta(e, focus) for e in ev)
+    pcs = sorted({e["pc"] for e in ev})
+    if len(ev) == 1:
+        kind = ("single_write_double_step" if abs(total) >= 2
+                else "single_write_single_step")
+    elif len(pcs) > 1:
+        kind = "two_paths"
+    else:
+        kind = "one_path_twice"
+    return {"kind": kind, "writes": len(ev), "total": total, "pcs": pcs,
+            "frame0": ev[0].get("frame"), "frame1": ev[-1].get("frame"),
+            "funcs": sorted({e.get("func", "?") for e in ev})}
+
+
+def verdict(focus_writes, focus=None):
+    """Name the mechanism, per press and overall."""
+    if not focus_writes:
+        return ("no_writes",
+                "the focus byte was never changed during the capture")
+    events = [describe_event(ev, focus)
+              for ev in group_events(focus_writes, focus)]
+    doubled = [e for e in events if abs(e["total"]) >= 2]
+    if not doubled:
+        return ("no_double_step",
+                "%d press(es) seen, none moved the cursor more than one step"
+                % len(events))
+    kinds = {e["kind"] for e in doubled}
+    if kinds == {"single_write_double_step"}:
+        return ("single_write_double_step",
+                "%d of %d press(es) moved the cursor %s in ONE write — the "
+                "step size was computed wrong; the input path is not at fault"
+                % (len(doubled), len(events),
+                   "/".join(str(e["total"]) for e in doubled)))
+    if "two_paths" in kinds:
+        pcs = sorted({pc for e in doubled if e["kind"] == "two_paths"
+                      for pc in e["pcs"]})
+        return ("two_paths",
+                "%d of %d press(es) were acted on by MULTIPLE code paths "
+                "(PCs: %s) — two handlers consumed one press"
+                % (len(doubled), len(events), ", ".join(pcs)))
+    return ("one_path_twice",
+            "%d of %d press(es) ran the same handler twice"
+            % (len(doubled), len(events)))
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--host", default="127.0.0.1")
+    ap.add_argument("--port", type=int, default=4370)
+    ap.add_argument("--lo", default="0x8004A500")
+    ap.add_argument("--hi", default="0x8004A600")
+    ap.add_argument("--focus", default="0x8004A5F5")
+    ap.add_argument("--seconds", type=float, default=12.0)
+    ap.add_argument("--count", type=int, default=4096)
+    ap.add_argument("--json")
+    args = ap.parse_args()
+
+    lo, hi, focus = int(args.lo, 16), int(args.hi, 16), int(args.focus, 16)
+
+    import pad_trace
+    link = pad_trace.Link(args.host, args.port)
+    slot = None
+    try:
+        r = link.cmd_with({"cmd": "wtrace_add",
+                           "lo": "0x%08X" % lo, "hi": "0x%08X" % hi})
+        if not r or not r.get("ok"):
+            raise RuntimeError("wtrace_add failed: %r" % (r,))
+        slot = r["slot"]
+        print("tracing 0x%08X..0x%08X (slot %d) for %.0fs — tap the D-pad "
+              "ONCE, and note whether it doubles."
+              % (lo, hi, slot, args.seconds))
+        time.sleep(args.seconds)
+        d = link.cmd_with({"cmd": "wtrace_dump", "addr_lo": "0x%08X" % lo,
+                           "addr_hi": "0x%08X" % hi, "count": args.count,
+                           "newest": 1})
+        entries = (d or {}).get("entries", [])
+    finally:
+        if slot is not None:
+            link.cmd_with({"cmd": "wtrace_del", "slot": slot})
+        link.close()
+
+    writes = writes_in_range(entries, lo, hi)
+    print("\n%d write(s) in range during the capture" % len(writes))
+    by_addr, focus_writes = summarize(writes, focus)
+
+    for a in sorted(by_addr):
+        s = by_addr[a]
+        print("  0x%08X  writes=%-3d deltas=%-18s pc=%s"
+              % (0x80000000 | a, s["writes"],
+                 ",".join(str(x) for x in s["deltas"][:6]),
+                 ",".join(s["pcs"][:3])))
+
+    print("\nfocus 0x%08X:" % focus)
+    for e in focus_writes:
+        print("  frame=%-8s @0x%08X w=%s  %s -> %s   byte %d -> %d (%+d)"
+              "  pc=%s func=%s ra=%s"
+              % (e.get("frame"), int(e["addr"], 16), e.get("w"),
+                 e["old"], e["new"], byte_value(e, "old", focus),
+                 byte_value(e, "new", focus), byte_delta(e, focus),
+                 e["pc"], e.get("func"), e.get("ra")))
+
+    print("\nper-press breakdown:")
+    for ev in group_events(focus_writes, focus):
+        d = describe_event(ev, focus)
+        print("  frames %s..%s  writes=%d  step=%+d  %s  pc=%s"
+              % (d["frame0"], d["frame1"], d["writes"], d["total"],
+                 d["kind"], ",".join(d["pcs"])))
+
+    kind, text = verdict(focus_writes, focus)
+    print("\n[%s] %s" % (kind, text))
+
+    if args.json:
+        with open(args.json, "w") as fh:
+            json.dump({"writes": writes, "verdict": kind, "detail": text},
+                      fh, indent=2)
+        print("wrote %s" % args.json)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/menu_scan.py
+++ b/tools/menu_scan.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python3
+"""
+menu_scan.py — Find the menu cursor variable, then prove how far it moves.
+
+The reported bug is that one D-pad tap moves the menu cursor twice.  Both the
+host pad state and the delivered SIO polls have been measured clean, so the
+next question is what the *game* does with the input.  This finds the RAM
+location holding the cursor index by snapshotting main RAM while you tap, and
+keeping only the locations whose value changes when — and only when — a tap
+happened, by a small step.
+
+Taps are located exactly, using the SIO byte ring rather than the snapshot
+sampling rate: a 100 ms tap falls between two 250 ms snapshots and would be
+invisible otherwise.  Each snapshot records the ring's sequence counter, and
+the taps decoded from the ring afterwards are placed into the interval they
+fall in.
+
+Usage:
+    python3 menu_scan.py --snapshots 40 --interval 0.25 --json /tmp/menu.json
+
+Sit in the menu and tap the SAME direction several times, evenly spaced.
+"""
+
+import argparse
+import json
+import sys
+import time
+
+sys.path.insert(0, __file__.rsplit("/", 1)[0])
+
+RAM_BASE = 0x80000000
+RAM_SIZE = 0x200000
+CHUNK = 0x40000
+BLOCK = 1024
+
+
+def find_changed_offsets(a, b, block=BLOCK):
+    """Byte offsets where two snapshots differ.
+
+    Compares block-at-a-time first: in a static menu almost all of RAM is
+    unchanged, so this skips the vast majority at C speed and only walks
+    bytes inside blocks that actually moved.
+    """
+    out = []
+    n = min(len(a), len(b))
+    for base in range(0, n, block):
+        end = min(base + block, n)
+        if a[base:end] == b[base:end]:
+            continue
+        for i in range(base, end):
+            if a[i] != b[i]:
+                out.append(i)
+    return out
+
+
+def held_spans(entries, button):
+    """Ring-sequence spans during which `button` was held.
+
+    Rising edges alone are the wrong model: holding a direction makes the
+    game auto-repeat, so the cursor moves repeatedly with no new edge.
+    Treating those moves as "movement without input" disqualifies the very
+    variable being hunted, so the whole held period counts as input.
+    """
+    import pad_delivery
+    polls = pad_delivery.decode_polls(entries)
+    spans, start, last = [], None, None
+    for p in polls:
+        if p["buttons"] is None:
+            continue
+        down = pad_delivery.pressed(p["buttons"], button)
+        if down and start is None:
+            start = p["seq"]
+        elif not down and start is not None:
+            spans.append((start, last))
+            start = None
+        last = p["seq"]
+    if start is not None:
+        spans.append((start, last))
+    return spans
+
+
+def input_intervals(before, after, spans_by_button, settle=1):
+    """Intervals where movement is legitimate, and which press caused each.
+
+    Every direction must be supplied, not just the one under study: a cursor
+    moves on `up` as well as `down`, and treating an unmonitored direction as
+    "no input" disqualifies the cursor itself.
+
+    A change seen between snapshots i and i+1 was caused by input somewhere
+    between the start of snapshot i's read and the end of snapshot i+1's --
+    reads take real time, so that window is the honest bound.
+
+    Returns (allowed, presses) where presses is a list of
+    (button, first_interval, last_interval) in capture order.
+    """
+    allowed, presses = set(), []
+    n = len(before)
+    for button, spans in sorted(spans_by_button.items()):
+        for s0, s1 in spans:
+            touched = []
+            for i in range(n - 1):
+                if s0 < after[i + 1] and s1 >= before[i]:
+                    touched.append(i)
+            if not touched:
+                continue
+            lo, hi = touched[0], touched[-1]
+            for i in range(lo, min(hi + settle, n - 2) + 1):
+                allowed.add(i)
+            presses.append((button, lo, min(hi + settle, n - 2)))
+    presses.sort(key=lambda p: p[1])
+    return allowed, presses
+
+
+def press_deltas(values, presses, n):
+    """Net movement across each press, measured settled-to-settled.
+
+    An animated cursor slides into place over several frames, so a per-interval
+    delta samples the animation rather than the step.  Comparing the value
+    before the press with the value once it has settled measures the step the
+    game actually took.
+    """
+    out = []
+    for button, lo, hi in presses:
+        a = values[lo]
+        b = values[min(hi + 1, n - 1)]
+        out.append((button, byte_delta(a, b)))
+    return out
+
+
+def byte_delta(a, b):
+    """Signed step from byte value a to b, accounting for 8-bit wrap."""
+    d = b - a
+    if d > 128:
+        d -= 256
+    elif d < -128:
+        d += 256
+    return d
+
+
+def classify_offset(values, allowed, presses, max_multiple=2, min_moves=3):
+    """Does this location behave like a cursor?
+
+    Disqualified if it ever moves with no input.  Otherwise judged on the
+    net step per press, measured settled-to-settled:
+
+      * each direction must move it consistently one way -- `up` and `down`
+        move a cursor opposite ways, so a single global sign test would
+        reject the very thing we are looking for;
+      * every step must be one stride or exactly two, with the stride taken
+        from the data rather than assumed;
+      * it must respond to several presses, since one press cannot establish
+        a stride and coincidences are cheap.
+    """
+    n = len(values)
+    for i in range(n - 1):
+        if values[i] != values[i + 1] and i not in allowed:
+            return None                       # moved with no input
+
+    per = press_deltas(values, presses, n)
+    moves = [(b, d) for b, d in per if d != 0]
+    if not moves:
+        return None
+
+    by_button = {}
+    for b, d in moves:
+        by_button.setdefault(b, []).append(d)
+    consistent = all(all(x > 0 for x in v) or all(x < 0 for x in v)
+                     for v in by_button.values())
+
+    base = min(abs(d) for _, d in moves)
+    regular = base > 0 and all(abs(d) % base == 0 and abs(d) // base <= max_multiple
+                               for _, d in moves)
+    # Opposite directions moving opposite ways is the signature of an axis.
+    opposed = False
+    for a, b in (("up", "down"), ("left", "right")):
+        if a in by_button and b in by_button:
+            if by_button[a][0] * by_button[b][0] < 0:
+                opposed = True
+
+    strict = consistent and regular and len(moves) >= min_moves
+    return {"moves": len(moves), "per_press": per, "base": base,
+            "strict": strict, "values": list(values), "opposed": opposed,
+            "deltas": [d for _, d in moves], "consistent": consistent,
+            "doubled": strict and any(abs(d) // base == 2 for _, d in moves)}
+
+
+def decode_taps(entries, button):
+    """Ring sequence of each rising edge of `button` in the SIO stream."""
+    import pad_delivery
+    polls = pad_delivery.decode_polls(entries)
+    taps, held = [], False
+    for p in polls:
+        if p["buttons"] is None:
+            continue
+        now = pad_delivery.pressed(p["buttons"], button)
+        if now and not held:
+            taps.append(p["seq"])
+        held = now
+    return taps
+
+
+def read_ram(link, base, size):
+    out = bytearray()
+    for off in range(0, size, CHUNK):
+        n = min(CHUNK, size - off)
+        r = link.cmd_with({"cmd": "read_ram",
+                           "addr": "0x%08X" % (base + off), "len": n})
+        if not r or not r.get("ok"):
+            raise RuntimeError("read_ram failed at 0x%08X: %r" % (base + off, r))
+        out.extend(bytes.fromhex(r["hex"]))
+    return bytes(out)
+
+
+def capture(host, port, snapshots, interval, ring_count=512):
+    """Snapshot RAM repeatedly, stitching the SIO ring as we go.
+
+    The ring is pulled every round and merged by sequence number.  Pulling
+    once at the end instead would silently lose any tap that scrolled out of
+    the window, and a lost tap does not merely go unseen -- it disqualifies
+    the very variable we are looking for, because that variable then appears
+    to move with no input.
+    """
+    import pad_trace
+    link = pad_trace.Link(host, port)
+    snaps, before, after, ring, seen_max, gaps = [], [], [], [], -1, 0
+    for _ in range(snapshots):
+        t0 = time.time()
+        r = link.cmd_with({"cmd": "sio_trace", "count": ring_count})
+        before.append(int(r["total"]) if r and "total" in r else -1)
+        for e in (r or {}).get("entries", []):
+            if e["seq"] > seen_max:
+                if seen_max >= 0 and e["seq"] > seen_max + 1 and not ring:
+                    pass
+                ring.append(e)
+                seen_max = e["seq"]
+        snaps.append(read_ram(link, RAM_BASE, RAM_SIZE))
+        r2 = link.cmd_with({"cmd": "sio_trace", "count": ring_count})
+        after.append(int(r2["total"]) if r2 and "total" in r2 else -1)
+        for e in (r2 or {}).get("entries", []):
+            if e["seq"] > seen_max:
+                ring.append(e)
+                seen_max = e["seq"]
+        spent = time.time() - t0
+        if interval > spent:
+            time.sleep(interval - spent)
+    r = link.cmd_with({"cmd": "sio_trace", "count": ring_count})
+    for e in (r or {}).get("entries", []):
+        if e["seq"] > seen_max:
+            ring.append(e)
+            seen_max = e["seq"]
+    link.close()
+    ring.sort(key=lambda e: e["seq"])
+    for i in range(1, len(ring)):
+        if ring[i]["seq"] != ring[i - 1]["seq"] + 1:
+            gaps += ring[i]["seq"] - ring[i - 1]["seq"] - 1
+    return snaps, before, after, ring, gaps
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--host", default="127.0.0.1")
+    ap.add_argument("--port", type=int, default=4370)
+    ap.add_argument("--snapshots", type=int, default=40)
+    ap.add_argument("--interval", type=float, default=0.25)
+    ap.add_argument("--buttons", default="up,down,left,right",
+                    help="all directions that should count as input")
+    ap.add_argument("--max-report", type=int, default=40)
+    ap.add_argument("--min-moves", type=int, default=3,
+                    help="presses a location must respond to")
+    ap.add_argument("--settle", type=int, default=2,
+                    help="intervals after a tap in which movement is still "
+                         "allowed (animated cursors)")
+    ap.add_argument("--json")
+    args = ap.parse_args()
+
+    print("Capturing %d snapshots %.2fs apart (%.0fs) — sit in the menu and "
+          "tap %s several times."
+          % (args.snapshots, args.interval,
+             args.snapshots * args.interval, args.buttons))
+    snaps, before, after, ring, gaps = capture(
+        args.host, args.port, args.snapshots, args.interval)
+    if gaps:
+        print("WARNING: %d SIO bytes missed; a tap may be undetected." % gaps)
+    buttons = [b.strip() for b in args.buttons.split(",") if b.strip()]
+    spans_by_button = {b: held_spans(ring, b) for b in buttons}
+    tapped, presses = input_intervals(before, after, spans_by_button,
+                                      settle=args.settle)
+    counts = ", ".join("%s=%d" % (b, len(spans_by_button[b])) for b in buttons)
+    print("%d snapshots, presses in ring: %s -> %d located, %d interval(s) "
+          "where movement is allowed"
+          % (len(snaps), counts, len(presses), len(tapped)))
+    located = len(presses)
+    if not tapped:
+        print("No taps located inside the capture window — nothing to "
+              "correlate against. Tap during the capture and retry.")
+        return 1
+
+    # Union of everything that ever moved, then test each against the taps.
+    moved = set()
+    for i in range(len(snaps) - 1):
+        moved.update(find_changed_offsets(snaps[i], snaps[i + 1]))
+    print("%d bytes changed at least once" % len(moved))
+
+    strict, loose = [], []
+    for off in sorted(moved):
+        vals = [s_[off] for s_ in snaps]
+        sc = classify_offset(vals, tapped, presses,
+                             min_moves=args.min_moves)
+        if not sc:
+            continue
+        sc["addr"] = RAM_BASE + off
+        (strict if sc["strict"] else loose).append(sc)
+    strict.sort(key=lambda h: (-h["moves"], not h["opposed"]))
+    loose.sort(key=lambda h: -h["moves"])
+
+    def show(rows, label):
+        print("\n%d %s:" % (len(rows), label))
+        for h in rows[:args.max_report]:
+            flag = "  <-- DOUBLE STEP" if h.get("doubled") else ""
+            if h.get("opposed"):
+                flag += "  [axis]"
+            per = " ".join("%s:%+d" % (b, d)
+                           for b, d in h.get("per_press", []) if d)
+            print("  0x%08X  moves=%d/%d base=%d  [%s]%s"
+                  % (h["addr"], h["moves"], located, h["base"], per, flag))
+        if len(rows) > args.max_report:
+            print("  ... %d more (raise --max-report)"
+                  % (len(rows) - args.max_report))
+
+    show(strict, "location(s) stepping consistently on presses")
+    if not strict:
+        show(loose, "location(s) that moved only on taps, but irregularly")
+    hits = strict or loose
+
+    if args.json:
+        with open(args.json, "w") as fh:
+            json.dump({"presses": presses, "allowed": sorted(tapped),
+                       "strict": strict, "loose": loose}, fh, indent=2)
+        print("\nwrote %s" % args.json)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/pad_delivery.py
+++ b/tools/pad_delivery.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""
+pad_delivery.py — Decode the pad polls the game actually received over SIO.
+
+pad_trace.py measures what the runtime *presented*; this measures what the
+game *read*.  A single physical tap must appear as one contiguous run of
+polls with the button held.  If the delivered stream drops back to "released"
+in the middle of a press and then reports it held again, the game's edge
+detector fires twice and the menu moves twice — from one tap.
+
+Reads the always-on SIO byte ring (sio_trace) and reconstructs each pad
+transaction:
+
+    tx 0x01 -> rx 0xFF     address the controller
+    tx 0x42 -> rx id       0x41 digital, 0x73 analog, 0xF3 config
+    tx 0x00 -> rx 0x5A
+    tx 0x00 -> rx btn_lo   active low
+    tx 0x00 -> rx btn_hi
+    tx 0x00 -> rx rx,ry,lx,ly   (analog only)
+
+Usage:
+    python3 pad_delivery.py --seconds 8 --json /tmp/delivery.json
+
+Tap the D-pad once per press you want classified.
+"""
+
+import argparse
+import json
+import sys
+import time
+
+sys.path.insert(0, __file__.rsplit("/", 1)[0])
+
+PAD_ADDR = 0x01
+MC_ADDR = 0x81
+CMD_POLL = 0x42
+
+BUTTONS = {
+    "select": 0x0001, "l3": 0x0002, "r3": 0x0004, "start": 0x0008,
+    "up": 0x0010, "right": 0x0020, "down": 0x0040, "left": 0x0080,
+    "l2": 0x0100, "r2": 0x0200, "l1": 0x0400, "r1": 0x0800,
+    "triangle": 0x1000, "circle": 0x2000, "cross": 0x4000, "square": 0x8000,
+}
+DPAD = ("up", "right", "down", "left")
+
+
+def _b(v):
+    """sio_trace reports bytes as '0x41' strings."""
+    return int(v, 16) if isinstance(v, str) else int(v)
+
+
+def decode_polls(entries):
+    """Reconstruct pad polls from an ordered SIO byte stream.
+
+    `entries` must be ordered by seq and may contain memory-card traffic,
+    which is skipped.  Returns one dict per pad transaction that got far
+    enough to carry a button word.
+    """
+    polls = []
+    txn = None
+    for e in entries:
+        tx, rx = _b(e["tx"]), _b(e["rx"])
+        if tx in (PAD_ADDR, MC_ADDR):
+            # A new address byte always ends the previous transaction.
+            if txn is not None:
+                polls.append(txn) if txn["complete"] else None
+            txn = {"seq": e["seq"], "addr": tx, "bytes": [], "frame": e.get("frame", -1),
+                   "cmd": None, "id": None, "buttons": None, "sticks": None,
+                   "complete": False} if tx == PAD_ADDR else None
+            continue
+        if txn is None:
+            continue
+        txn["bytes"].append(rx)
+        n = len(txn["bytes"])
+        if n == 1:
+            txn["cmd"] = tx      # the command byte we clocked out
+            txn["id"] = rx
+        elif n == 4:
+            txn["buttons"] = txn["bytes"][2] | (txn["bytes"][3] << 8)
+            txn["complete"] = txn["cmd"] == CMD_POLL
+        elif n == 8:
+            txn["sticks"] = [txn["bytes"][6], txn["bytes"][7],
+                             txn["bytes"][4], txn["bytes"][5]]  # lx,ly,rx,ry
+    if txn is not None and txn["complete"]:
+        polls.append(txn)
+    return polls
+
+
+def pressed(word, name):
+    return (word & BUTTONS[name]) == 0
+
+
+def poll_runs(polls, name):
+    """Contiguous spans of polls where `name` is held. Returns (i0, i1) pairs."""
+    runs, start = [], None
+    for i, p in enumerate(polls):
+        if p["buttons"] is not None and pressed(p["buttons"], name):
+            if start is None:
+                start = i
+        elif start is not None:
+            runs.append((start, i - 1))
+            start = None
+    if start is not None:
+        runs.append((start, len(polls) - 1))
+    return runs
+
+
+def analyze(polls, bounce_polls=12):
+    """Classify delivered pad polls.
+
+    bounce_polls: two runs separated by fewer than this many polls came from
+    one physical tap (a tap is ~4 polls; a deliberate second tap is ~30+).
+    """
+    runs, findings = [], []
+    for name in BUTTONS:
+        spans = poll_runs(polls, name)
+        for i0, i1 in spans:
+            runs.append({
+                "button": name, "i0": i0, "i1": i1,
+                "polls": i1 - i0 + 1,
+                "seq0": polls[i0]["seq"], "seq1": polls[i1]["seq"],
+                "frame0": polls[i0].get("frame", -1),
+                "frame1": polls[i1].get("frame", -1),
+            })
+        for (a0, a1), (b0, _b1) in zip(spans, spans[1:]):
+            gap = b0 - a1 - 1
+            if gap <= bounce_polls:
+                findings.append({
+                    "kind": "delivered_bounce", "button": name,
+                    "gap_polls": gap,
+                    "detail": "the game read %s as released for %d poll(s) in "
+                              "the middle of one press, then held again — two "
+                              "rising edges, two menu moves" % (name, gap),
+                })
+    runs.sort(key=lambda r: r["i0"])
+    return runs, findings
+
+
+def polls_per_frame(polls):
+    """How many times the game read the pad in each frame it polled."""
+    counts = {}
+    for p in polls:
+        f = p.get("frame", -1)
+        if f >= 0:
+            counts[f] = counts.get(f, 0) + 1
+    return counts
+
+
+def resolve_frame(prev_frame, frame):
+    """Exact frame for entries seen between two reads, or -1 if unknowable.
+
+    Entries newly visible in this batch were generated between the previous
+    read and this one.  If the frame counter did not advance across that
+    interval, every one of them belongs to that frame.  If it did advance,
+    they straddle a boundary and this ring carries no per-entry stamp to
+    separate them — so say -1 rather than invent one.
+    """
+    if prev_frame is None or frame < 0 or prev_frame != frame:
+        return -1
+    return frame
+
+
+def capture(host, port, seconds, count):
+    import pad_trace
+    link = pad_trace.Link(host, port)
+    seen_max, entries, gaps = -1, [], 0
+    prev_frame = None
+    t_end = time.time() + seconds
+    while time.time() < t_end:
+        r = link.cmd_with({"cmd": "sio_trace", "count": count})
+        fr = link.cmd_with({"cmd": "frame"})
+        frame = int(fr.get("frame", -1)) if fr else -1
+        if not r or "entries" not in r:
+            raise RuntimeError("sio_trace failed: %r" % (r,))
+        batch = r["entries"]
+        if not batch:
+            continue
+        first = batch[0]["seq"]
+        if seen_max >= 0 and first > seen_max + 1:
+            gaps += first - seen_max - 1
+        stamp = resolve_frame(prev_frame, frame)
+        prev_frame = frame
+        for e in batch:
+            if e["seq"] > seen_max:
+                e["frame"] = stamp
+                entries.append(e)
+                seen_max = e["seq"]
+    link.close()
+    return entries, gaps, link
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--host", default="127.0.0.1")
+    ap.add_argument("--port", type=int, default=4370)
+    ap.add_argument("--seconds", type=float, default=8.0)
+    ap.add_argument("--count", type=int, default=192,
+                    help="sio_trace entries per poll; raise if gaps appear")
+    ap.add_argument("--json")
+    args = ap.parse_args()
+
+    print("Capturing %.0fs — tap the D-pad." % args.seconds)
+    entries, gaps, link = capture(args.host, args.port, args.seconds, args.count)
+    polls = decode_polls(entries)
+    print("%d SIO bytes, %d pad polls%s"
+          % (len(entries), len(polls),
+             "" if not link.persistent else ""))
+    if gaps:
+        print("WARNING: %d bytes missed between reads — raise --count." % gaps)
+
+    ppf = polls_per_frame(polls)
+    unknown = sum(1 for p in polls if p.get("frame", -1) < 0)
+    if ppf:
+        vals = sorted(ppf.values())
+        print("polls per frame: min=%d median=%d max=%d  (%d of %d polls "
+              "straddled a batch boundary and are unstamped)"
+              % (vals[0], vals[len(vals) // 2], vals[-1], unknown, len(polls)))
+    # The pad is polled on a fixed cadence; a changing seq delta is the honest
+    # way to see irregular polling, since it needs no frame stamp at all.
+    deltas = sorted({polls[i + 1]["seq"] - polls[i]["seq"]
+                     for i in range(len(polls) - 1)})
+    print("poll seq deltas: %s" % (deltas if len(deltas) < 8
+                                   else "%d distinct" % len(deltas)))
+
+    runs, findings = analyze(polls)
+    for r in runs:
+        print("  %-8s %3d polls  seq %d..%d  frames %s..%s"
+              % (r["button"], r["polls"], r["seq0"], r["seq1"],
+                 r["frame0"], r["frame1"]))
+    print()
+    if findings:
+        for f in findings:
+            print("  [%s] %s: %s" % (f["kind"], f["button"], f["detail"]))
+    else:
+        print("Every press was delivered as one contiguous run.")
+        print("The doubling is not in pad delivery — look at the game's own "
+              "edge detection or its second input source.")
+
+    if args.json:
+        with open(args.json, "w") as fh:
+            json.dump({"polls": polls, "runs": runs, "findings": findings,
+                       "gaps": gaps}, fh, indent=2)
+        print("\nwrote %s" % args.json)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/pad_trace.py
+++ b/tools/pad_trace.py
@@ -76,12 +76,28 @@ def find_runs(samples, name):
     return runs
 
 
+def fold_skew(samples, run):
+    """Frames between the D-pad bit falling and the stick leaving centre.
+
+    Both are written by the same host frame, so 0 means the game sees one
+    event carrying two representations.  Non-zero means the two arrive on
+    different frames, and an edge-detecting menu fires twice.  None means the
+    stick never deflected.
+    """
+    i0, i1 = run
+    for i in range(i0, i1 + 1):
+        if stick_deflected(samples[i]["sticks"]):
+            return samples[i]["frame"] - samples[i0]["frame"]
+    return None
+
+
 def describe_run(samples, name, run):
     i0, i1 = run
     a, b = samples[i0], samples[i1]
     folded = any(stick_deflected(samples[i]["sticks"]) for i in range(i0, i1 + 1))
     analogs = {bool(samples[i]["analog"]) for i in range(i0, i1 + 1)}
     return {
+        "fold_skew_frames": fold_skew(samples, run),
         "button": name,
         "t0": a["t"], "t1": b["t"],
         "ms": round((b["t"] - a["t"]) * 1000.0, 1),
@@ -122,6 +138,14 @@ def analyze(samples, rebounce_ms=400.0, repeat_frames=16):
                     "kind": "analog_flip", "button": name,
                     "detail": "pad analog flag changed during the press",
                 })
+            if name in DPAD and d.get("fold_skew_frames"):
+                findings.append({
+                    "kind": "fold_skew", "button": name,
+                    "frames": d["fold_skew_frames"],
+                    "detail": "stick deflection arrived %d frame(s) after the "
+                              "D-pad bit; an edge-detecting menu fires twice"
+                              % d["fold_skew_frames"],
+                })
             if d["frames"] >= repeat_frames:
                 findings.append({
                     "kind": "long_hold", "button": name,
@@ -133,24 +157,82 @@ def analyze(samples, rebounce_ms=400.0, repeat_frames=16):
     return runs, findings
 
 
-def capture(host, port, seconds):
-    import debug_client
-    sock = debug_client.connect(host, port)
+class Link:
+    """A debug-server connection that survives builds which close after one
+    command.
+
+    The shipped build answers exactly one command per connection and then
+    hangs up; other builds keep the socket open.  Rather than assume either,
+    reuse the socket until it EOFs, then fall back to connect-per-command for
+    the rest of the run.
+    """
+
+    def __init__(self, host, port):
+        self.host, self.port = host, port
+        self.sock = None
+        self.persistent = True
+        self.reconnects = 0
+
+    def _connect(self):
+        import debug_client
+        self.sock = debug_client.connect(self.host, self.port)
+
+    def cmd(self, name):
+        return self.cmd_with({"cmd": name})
+
+    def cmd_with(self, obj):
+        import debug_client
+        for attempt in (0, 1):
+            try:
+                if self.sock is None:
+                    self._connect()
+                r = debug_client.send_cmd(self.sock, obj)
+                if not self.persistent:
+                    self.close()
+                return r
+            except Exception:
+                # EOF or parse failure => this build hung up on us.
+                self.close()
+                if attempt == 0:
+                    self.persistent = False
+                    self.reconnects += 1
+                    continue
+                raise
+        return None
+
+    def close(self):
+        if self.sock is not None:
+            try:
+                self.sock.close()
+            except Exception:
+                pass
+            self.sock = None
+
+
+def capture(host, port, seconds, min_interval=0.0):
+    """Sample pad_status (+ the frame counter) until `seconds` elapse."""
+    link = Link(host, port)
     samples, t_end = [], time.time() + seconds
     while time.time() < t_end:
-        st = debug_client.send_cmd(sock, {"cmd": "pad_status"})
-        pg = debug_client.send_cmd(sock, {"cmd": "ping"})
+        t0 = time.time()
+        st = link.cmd("pad_status")
         if not st or "slot0" not in st:
             continue
+        # `frame`, not `ping`: the shipped build's ping carries no frame number.
+        fr = link.cmd("frame")
         s0 = st["slot0"]
         samples.append({
             "t": time.time(),
-            "frame": int(pg.get("frame", -1)) if pg else -1,
+            "frame": int(fr.get("frame", -1)) if fr else -1,
             "buttons": int(s0["buttons"], 16),
             "sticks": [int(v) for v in s0.get("sticks", [128, 128, 128, 128])],
             "analog": bool(s0.get("analog", False)),
         })
-    return samples
+        spent = time.time() - t0
+        if min_interval > spent:
+            time.sleep(min_interval - spent)
+    link.close()
+    return samples, link
 
 
 def main():
@@ -160,11 +242,14 @@ def main():
     ap.add_argument("--port", type=int, default=4370)
     ap.add_argument("--seconds", type=float, default=8.0)
     ap.add_argument("--repeat-frames", type=int, default=16)
+    ap.add_argument("--hz", type=float, default=0.0,
+                    help="cap the sample rate (0 = as fast as possible)")
     ap.add_argument("--json", help="write raw samples + findings here")
     args = ap.parse_args()
 
     print("Capturing %.0fs — tap the D-pad ONCE, cleanly." % args.seconds)
-    samples = capture(args.host, args.port, args.seconds)
+    samples, link = capture(args.host, args.port, args.seconds,
+                            min_interval=1.0 / args.hz if args.hz else 0.0)
     if not samples:
         print("No samples. Is the runtime up on port %d?" % args.port)
         return 1
@@ -174,14 +259,23 @@ def main():
     frames = samples[-1]["frame"] - samples[0]["frame"]
     print("%d samples over %.1fs (%.0f Hz, %d emulated frames)"
           % (len(samples), span, rate, frames))
+    if not link.persistent:
+        print("note: this build closes the socket after each command; "
+              "reconnected per command.")
+    if frames <= 0:
+        print("WARNING: the frame counter never advanced — is the runtime "
+              "paused? Frame spans below are meaningless.")
+    if rate < 120.0:
+        print("WARNING: %.0f Hz is below 2x the emulated frame rate; a short "
+              "press may be missed." % rate)
 
     runs, findings = analyze(samples, repeat_frames=args.repeat_frames)
     if not runs:
         print("No button press seen — nothing to classify.")
     for r in runs:
-        print("  %-8s %6.1f ms  %3d frames  stick_folded=%s analog=%s"
+        print("  %-8s %6.1f ms  %3d frames  stick_folded=%s skew=%s analog=%s"
               % (r["button"], r["ms"], r["frames"],
-                 r["stick_folded"], r["analog"]))
+                 r["stick_folded"], r["fold_skew_frames"], r["analog"]))
 
     print()
     if not findings:

--- a/tools/tests/test_cursor_writers.py
+++ b/tools/tests/test_cursor_writers.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Unit tests for cursor_writers' attribution of cursor writes."""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import cursor_writers as cw
+
+
+def w(addr, old, new, pc, seq=0, width=1, frame=0, func="0x1000"):
+    return {"seq": seq, "addr": "0x%08X" % (addr & 0x1FFFFFFF),
+            "old": "0x%08X" % old, "new": "0x%08X" % new,
+            "pc": pc, "func": func, "ra": "0x2000", "w": width, "frame": frame}
+
+
+class PhysTest(unittest.TestCase):
+    def test_kseg0_maps_to_physical(self):
+        self.assertEqual(cw.phys(0x8004A5F5), 0x0004A5F5)
+
+    def test_physical_unchanged(self):
+        self.assertEqual(cw.phys(0x0004A5F5), 0x0004A5F5)
+
+
+class DeltaTest(unittest.TestCase):
+    def test_simple_decrement(self):
+        self.assertEqual(cw.delta(w(0x8004A5F5, 5, 4, "0x1")), -1)
+
+    def test_double_step(self):
+        self.assertEqual(cw.delta(w(0x8004A5F5, 5, 3, "0x1")), -2)
+
+    def test_byte_wrap_reads_as_small_negative(self):
+        """0 -> 255 at byte width is -1, not +255."""
+        self.assertEqual(cw.delta(w(0x8004A5F5, 0, 255, "0x1", width=1)), -1)
+
+    def test_word_width_increment(self):
+        self.assertEqual(cw.delta(w(0x8004A5F5, 7, 8, "0x1", width=4)), 1)
+
+
+class RangeTest(unittest.TestCase):
+    def test_filters_and_sorts(self):
+        entries = [w(0x8004A5F5, 5, 4, "0x1", seq=9),
+                   w(0x8004B000, 1, 2, "0x2", seq=8),
+                   w(0x8004A50D, 7, 6, "0x3", seq=7)]
+        got = cw.writes_in_range(entries, 0x8004A500, 0x8004A600)
+        self.assertEqual([e["seq"] for e in got], [7, 9])
+
+    def test_upper_bound_is_exclusive(self):
+        entries = [w(0x8004A600, 1, 2, "0x1")]
+        self.assertEqual(cw.writes_in_range(entries, 0x8004A500, 0x8004A600), [])
+
+
+class VerdictTest(unittest.TestCase):
+    def test_no_writes(self):
+        self.assertEqual(cw.verdict([])[0], "no_writes")
+
+    def test_single_write_double_step(self):
+        """One write of -2: the step calculation doubled, not the input."""
+        got = cw.verdict([w(0x8004A5F5, 5, 3, "0x800684C0")], 0x8004A5F5)
+        self.assertEqual(got[0], "single_write_double_step")
+
+    def test_single_write_single_step(self):
+        got = cw.verdict([w(0x8004A5F5, 5, 4, "0x800684C0")], 0x8004A5F5)
+        # Capture-level verdict: nothing doubled anywhere.
+        self.assertEqual(got[0], "no_double_step")
+        # The event itself is still classified as a clean single step.
+        ev = cw.describe_event([w(0x8004A5F5, 5, 4, "0x800684C0")], 0x8004A5F5)
+        self.assertEqual(ev["kind"], "single_write_single_step")
+        self.assertEqual(ev["total"], -1)
+
+    def test_two_distinct_pcs_is_two_paths(self):
+        got = cw.verdict([w(0x8004A5F5, 5, 4, "0x11110000", seq=1),
+                          w(0x8004A5F5, 4, 3, "0x22220000", seq=2)],
+                         0x8004A5F5)
+        self.assertEqual(got[0], "two_paths")
+
+    def test_same_pc_twice_is_one_path(self):
+        got = cw.verdict([w(0x8004A5F5, 5, 4, "0x11110000", seq=1),
+                          w(0x8004A5F5, 4, 3, "0x11110000", seq=2)],
+                         0x8004A5F5)
+        self.assertEqual(got[0], "one_path_twice")
+
+
+class SummarizeTest(unittest.TestCase):
+    def test_groups_by_address_and_collects_pcs(self):
+        writes = [w(0x8004A5F5, 5, 4, "0xA", seq=1),
+                  w(0x8004A5F5, 4, 3, "0xB", seq=2),
+                  w(0x8004A50D, 7, 6, "0xC", seq=3)]
+        by_addr, focus = cw.summarize(writes, 0x8004A5F5)
+        self.assertEqual(len(by_addr), 2)
+        self.assertEqual(by_addr[0x0004A5F5]["pcs"], ["0xA", "0xB"])
+        self.assertEqual(len(focus), 2)
+
+
+class WidthCoverageTest(unittest.TestCase):
+    """A wide store changes bytes that never appear as its address."""
+
+    def test_halfword_write_covers_high_byte(self):
+        e = w(0x8004A5F4, 0x05F9, 0x0366, "0x80024E3C", width=2)
+        self.assertTrue(cw.covers(e, 0x8004A5F5))
+
+    def test_write_does_not_cover_beyond_its_width(self):
+        e = w(0x8004A5F4, 0, 1, "0x1", width=2)
+        self.assertFalse(cw.covers(e, 0x8004A5F6))
+
+    def test_byte_value_extracts_the_right_lane(self):
+        e = w(0x8004A5F4, 0x05F9, 0x0366, "0x1", width=2)
+        self.assertEqual(cw.byte_value(e, "old", 0x8004A5F5), 5)
+        self.assertEqual(cw.byte_value(e, "new", 0x8004A5F5), 3)
+        self.assertEqual(cw.byte_value(e, "old", 0x8004A5F4), 0xF9)
+
+    def test_byte_delta_of_covered_byte(self):
+        e = w(0x8004A5F4, 0x05F9, 0x0366, "0x1", width=2)
+        self.assertEqual(cw.byte_delta(e, 0x8004A5F5), -2)
+
+    def test_wide_write_leaving_the_byte_alone_is_not_a_move(self):
+        """Covering the byte is not the same as changing it."""
+        e = w(0x8004A5F4, 0x0500, 0x05FF, "0x1", width=2)
+        self.assertEqual(cw.byte_delta(e, 0x8004A5F5), 0)
+        self.assertEqual(cw.touching_writes([e], 0x8004A5F5), [])
+
+    def test_touching_writes_finds_wide_stores(self):
+        es = [w(0x8004A5F4, 0x05F9, 0x0366, "0x1", width=2),
+              w(0x8004A5F4, 0x0366, 0x0823, "0x1", width=2)]
+        self.assertEqual(len(cw.touching_writes(es, 0x8004A5F5)), 2)
+
+    def test_verdict_uses_byte_delta_not_word_delta(self):
+        """-2 on the byte, though the halfword moved by -659."""
+        e = w(0x8004A5F4, 0x05F9, 0x0366, "0x1", width=2)
+        kind, _ = cw.verdict([e], 0x8004A5F5)
+        self.assertEqual(kind, "single_write_double_step")
+
+
+class GroupEventsTest(unittest.TestCase):
+    """Several presses in one capture must not be read as one event."""
+
+    def test_writes_in_the_same_frame_are_one_event(self):
+        ws = [w(0x8004A5F5, 5, 4, "0xA", seq=1, frame=100),
+              w(0x8004A5F5, 4, 3, "0xB", seq=2, frame=100)]
+        self.assertEqual(len(cw.group_events(ws, 0x8004A5F5)), 1)
+
+    def test_writes_seconds_apart_are_separate_events(self):
+        ws = [w(0x8004A5F5, 5, 4, "0xA", seq=1, frame=100),
+              w(0x8004A5F5, 4, 3, "0xA", seq=2, frame=250)]
+        self.assertEqual(len(cw.group_events(ws, 0x8004A5F5)), 2)
+
+    def test_adjacent_frames_stay_together(self):
+        ws = [w(0x8004A5F5, 5, 4, "0xA", seq=1, frame=100),
+              w(0x8004A5F5, 4, 3, "0xB", seq=2, frame=102)]
+        self.assertEqual(len(cw.group_events(ws, 0x8004A5F5)), 1)
+
+
+class PerPressVerdictTest(unittest.TestCase):
+    def test_two_paths_on_a_doubled_press(self):
+        ws = [w(0x8004A5F5, 5, 4, "0x11110000", seq=1, frame=100),
+              w(0x8004A5F5, 4, 3, "0x22220000", seq=2, frame=100)]
+        self.assertEqual(cw.verdict(ws, 0x8004A5F5)[0], "two_paths")
+
+    def test_one_path_twice_on_a_doubled_press(self):
+        ws = [w(0x8004A5F5, 5, 4, "0x11110000", seq=1, frame=100),
+              w(0x8004A5F5, 4, 3, "0x11110000", seq=2, frame=101)]
+        self.assertEqual(cw.verdict(ws, 0x8004A5F5)[0], "one_path_twice")
+
+    def test_single_write_of_two_steps(self):
+        ws = [w(0x8004A5F5, 5, 3, "0x11110000", seq=1, frame=100)]
+        self.assertEqual(cw.verdict(ws, 0x8004A5F5)[0],
+                         "single_write_double_step")
+
+    def test_clean_presses_report_no_doubling(self):
+        ws = [w(0x8004A5F5, 5, 4, "0xA", seq=1, frame=100),
+              w(0x8004A5F5, 4, 3, "0xA", seq=2, frame=300)]
+        self.assertEqual(cw.verdict(ws, 0x8004A5F5)[0], "no_double_step")
+
+    def test_mixed_capture_reports_the_doubled_presses(self):
+        """Single-step presses in the same capture must not mask the bug."""
+        ws = [w(0x8004A5F5, 9, 8, "0xA", seq=1, frame=100),
+              w(0x8004A5F5, 8, 7, "0xA", seq=2, frame=300),
+              w(0x8004A5F5, 7, 6, "0xB", seq=3, frame=500),
+              w(0x8004A5F5, 6, 5, "0xC", seq=4, frame=500)]
+        self.assertEqual(cw.verdict(ws, 0x8004A5F5)[0], "two_paths")

--- a/tools/tests/test_menu_scan.py
+++ b/tools/tests/test_menu_scan.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""Unit tests for menu_scan's cursor identification."""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import menu_scan as ms
+sys.path.insert(0, os.path.dirname(__file__))
+from test_pad_delivery import txn, hold, NONE
+
+
+class FindChangedOffsetsTest(unittest.TestCase):
+    def test_no_change(self):
+        a = bytes(4096)
+        self.assertEqual(ms.find_changed_offsets(a, a), [])
+
+    def test_single_byte_change(self):
+        a = bytearray(4096)
+        b = bytearray(4096)
+        b[1234] = 7
+        self.assertEqual(ms.find_changed_offsets(bytes(a), bytes(b)), [1234])
+
+    def test_changes_across_block_boundary(self):
+        a = bytearray(4096)
+        b = bytearray(4096)
+        b[1023] = 1
+        b[1024] = 1
+        self.assertEqual(ms.find_changed_offsets(bytes(a), bytes(b)),
+                         [1023, 1024])
+
+    def test_ragged_tail_shorter_than_block(self):
+        a = bytes(1500)
+        b = bytearray(1500)
+        b[1400] = 9
+        self.assertEqual(ms.find_changed_offsets(a, bytes(b)), [1400])
+
+
+class HeldSpansTest(unittest.TestCase):
+    """Holding a direction is input for its whole duration, not one edge."""
+
+    def build(self, words):
+        entries, seq = [], 0
+        for w in words:
+            entries.extend(txn(seq, w))
+            seq += 16
+        return entries
+
+    def test_single_tap_is_one_span(self):
+        e = self.build([NONE, hold("down"), hold("down"), NONE])
+        self.assertEqual(len(ms.held_spans(e, "down")), 1)
+
+    def test_long_hold_is_one_span_covering_it(self):
+        e = self.build([NONE] + [hold("down")] * 6 + [NONE])
+        spans = ms.held_spans(e, "down")
+        self.assertEqual(len(spans), 1)
+        self.assertGreater(spans[0][1] - spans[0][0], 60)
+
+    def test_two_taps_are_two_spans(self):
+        e = self.build([hold("down"), NONE, hold("down"), NONE])
+        self.assertEqual(len(ms.held_spans(e, "down")), 2)
+
+    def test_still_held_at_capture_end_is_closed(self):
+        e = self.build([NONE, hold("down"), hold("down")])
+        self.assertEqual(len(ms.held_spans(e, "down")), 1)
+
+    def test_other_button_ignored(self):
+        e = self.build([hold("up"), NONE])
+        self.assertEqual(ms.held_spans(e, "down"), [])
+
+
+class InputIntervalsTest(unittest.TestCase):
+    def test_press_marks_its_interval(self):
+        before, after = [0, 100, 200], [10, 110, 210]
+        allowed, presses = ms.input_intervals(before, after,
+                                              {"down": [(50, 55)]}, 0)
+        self.assertEqual(allowed, {0})
+        self.assertEqual(presses, [("down", 0, 0)])
+
+    def test_press_during_a_read_marks_both_neighbours(self):
+        before, after = [0, 100, 200], [10, 110, 210]
+        allowed, _ = ms.input_intervals(before, after,
+                                        {"down": [(105, 106)]}, 0)
+        self.assertEqual(allowed, {0, 1})
+
+    def test_every_direction_counts_as_input(self):
+        """A cursor moves on up as well as down; both must be allowed."""
+        before, after = [0, 100, 200, 300], [10, 110, 210, 310]
+        allowed, presses = ms.input_intervals(
+            before, after, {"up": [(50, 55)], "down": [(250, 255)]}, 0)
+        self.assertEqual(allowed, {0, 2})
+        self.assertEqual([p[0] for p in presses], ["up", "down"])
+
+    def test_presses_returned_in_capture_order(self):
+        before, after = [0, 100, 200, 300], [10, 110, 210, 310]
+        _, presses = ms.input_intervals(
+            before, after, {"up": [(250, 255)], "down": [(50, 55)]}, 0)
+        self.assertEqual([p[0] for p in presses], ["down", "up"])
+
+    def test_long_hold_marks_every_interval_it_spans(self):
+        before, after = [0, 100, 200, 300], [10, 110, 210, 310]
+        allowed, _ = ms.input_intervals(before, after,
+                                        {"down": [(50, 250)]}, 0)
+        self.assertEqual(allowed, {0, 1, 2})
+
+    def test_span_outside_capture_not_located(self):
+        before, after = [100, 200], [110, 210]
+        allowed, presses = ms.input_intervals(before, after,
+                                              {"down": [(500, 510)]}, 0)
+        self.assertEqual(allowed, set())
+        self.assertEqual(presses, [])
+
+
+class PressDeltasTest(unittest.TestCase):
+    """Measure the step settled-to-settled, so animation is not sampled."""
+
+    def test_single_step_per_press(self):
+        values = [10, 10, 9, 9, 8, 8]
+        presses = [("down", 1, 1), ("down", 3, 3)]
+        self.assertEqual(ms.press_deltas(values, presses, len(values)),
+                         [("down", -1), ("down", -1)])
+
+    def test_doubled_press_shows_double_step(self):
+        """The bug: one press moved two entries."""
+        values = [10, 10, 9, 9, 7, 7]
+        presses = [("down", 1, 1), ("down", 3, 3)]
+        self.assertEqual(ms.press_deltas(values, presses, len(values)),
+                         [("down", -1), ("down", -2)])
+
+    def test_opposite_directions_reported_separately(self):
+        values = [10, 10, 11, 11, 10, 10]
+        presses = [("down", 1, 1), ("up", 3, 3)]
+        self.assertEqual(ms.press_deltas(values, presses, len(values)),
+                         [("down", 1), ("up", -1)])
+
+    def test_animation_spanning_settle_is_measured_whole(self):
+        """Value slides 10 -> 8 across the settle window: one step of -2."""
+        values = [10, 10, 9, 8, 8]
+        presses = [("down", 1, 2)]
+        self.assertEqual(ms.press_deltas(values, presses, len(values)),
+                         [("down", -2)])
+
+    def test_press_at_the_very_end_does_not_overrun(self):
+        values = [10, 9]
+        presses = [("down", 0, 0)]
+        self.assertEqual(ms.press_deltas(values, presses, len(values)),
+                         [("down", -1)])
+
+
+class ByteDeltaTest(unittest.TestCase):
+    def test_plain_step(self):
+        self.assertEqual(ms.byte_delta(3, 4), 1)
+
+    def test_wrap_down(self):
+        """0 -> 255 is a step back, not a jump of 255."""
+        self.assertEqual(ms.byte_delta(0, 255), -1)
+
+    def test_wrap_up(self):
+        self.assertEqual(ms.byte_delta(255, 0), 1)
+
+
+class ClassifyOffsetTest(unittest.TestCase):
+    """values indices line up with snapshots; presses give (button, lo, hi)."""
+
+    def test_axis_moves_opposite_ways_and_is_strict(self):
+        """up and down move a cursor opposite ways -- not a disqualifier."""
+        values = [10, 10, 9, 9, 8, 8, 9, 9]
+        presses = [("down", 1, 1), ("down", 3, 3), ("up", 5, 5)]
+        allowed = {1, 2, 3, 4, 5, 6}
+        sc = ms.classify_offset(values, allowed, presses)
+        self.assertIsNotNone(sc)
+        self.assertTrue(sc["strict"])
+        self.assertTrue(sc["opposed"])
+
+    def test_movement_without_input_disqualifies(self):
+        values = [10, 11, 12, 13]
+        presses = [("down", 0, 0)]
+        self.assertIsNone(ms.classify_offset(values, {0}, presses))
+
+    def test_double_step_flagged(self):
+        """One press moved two strides: the bug, at whatever stride."""
+        values = [100, 100, 72, 72, 44, 44, 244, 244]
+        presses = [("right", 1, 1), ("right", 3, 3), ("right", 5, 5)]
+        allowed = {1, 2, 3, 4, 5, 6}
+        sc = ms.classify_offset(values, allowed, presses)
+        self.assertTrue(sc["strict"])
+        self.assertTrue(sc["doubled"])
+        self.assertEqual(sc["base"], 28)
+
+    def test_same_button_moving_both_ways_is_not_strict(self):
+        """`down` must not move a cursor up on one press and down the next."""
+        values = [10, 10, 9, 9, 10, 10, 9, 9]
+        presses = [("down", 1, 1), ("down", 3, 3), ("down", 5, 5)]
+        allowed = {1, 2, 3, 4, 5, 6}
+        sc = ms.classify_offset(values, allowed, presses)
+        self.assertFalse(sc["strict"])
+        self.assertFalse(sc["consistent"])
+
+    def test_too_few_responses_is_not_strict(self):
+        values = [10, 10, 9, 9, 9, 9]
+        presses = [("down", 1, 1), ("down", 3, 3)]
+        sc = ms.classify_offset(values, {1, 2, 3, 4}, presses, min_moves=3)
+        self.assertFalse(sc["strict"])
+
+    def test_irregular_stride_is_not_strict(self):
+        values = [0, 0, 3, 3, 13, 13, 20, 20]
+        presses = [("down", 1, 1), ("down", 3, 3), ("down", 5, 5)]
+        sc = ms.classify_offset(values, {1, 2, 3, 4, 5, 6}, presses)
+        self.assertFalse(sc["strict"])
+
+    def test_never_moving_is_not_a_candidate(self):
+        values = [7] * 6
+        presses = [("down", 1, 1)]
+        self.assertIsNone(ms.classify_offset(values, {1, 2}, presses))
+
+
+class DecodeTapsTest(unittest.TestCase):
+    def test_rising_edges_only(self):
+        entries = []
+        seq = 0
+        for w in [NONE, hold("down"), hold("down"), NONE, hold("down"), NONE]:
+            entries.extend(txn(seq, w))
+            seq += 16
+        taps = ms.decode_taps(entries, "down")
+        self.assertEqual(len(taps), 2)
+
+    def test_held_across_whole_capture_is_one_tap(self):
+        entries = []
+        seq = 0
+        for w in [hold("down")] * 5:
+            entries.extend(txn(seq, w))
+            seq += 16
+        self.assertEqual(len(ms.decode_taps(entries, "down")), 1)
+
+    def test_other_button_ignored(self):
+        entries = []
+        seq = 0
+        for w in [NONE, hold("up"), NONE]:
+            entries.extend(txn(seq, w))
+            seq += 16
+        self.assertEqual(ms.decode_taps(entries, "down"), [])
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class DirectionTest(unittest.TestCase):
+    """Per-button consistency replaces the old global sign test."""
+
+    def test_one_direction_moving_both_ways_rejected(self):
+        values = [10, 10, 13, 13, 10, 10]
+        presses = [("down", 1, 1), ("down", 3, 3)]
+        sc = ms.classify_offset(values, {1, 2, 3, 4}, presses, min_moves=2)
+        self.assertFalse(sc["strict"])
+
+    def test_opposite_buttons_moving_opposite_ways_accepted(self):
+        values = [10, 10, 11, 11, 10, 10, 11, 11]
+        presses = [("up", 1, 1), ("down", 3, 3), ("up", 5, 5)]
+        sc = ms.classify_offset(values, {1, 2, 3, 4, 5, 6}, presses)
+        self.assertTrue(sc["strict"])
+        self.assertTrue(sc["opposed"])

--- a/tools/tests/test_pad_delivery.py
+++ b/tools/tests/test_pad_delivery.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Unit tests for pad_delivery's SIO reconstruction."""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pad_delivery as pd
+
+
+NONE = 0xFFFF
+
+
+def txn(seq, buttons=NONE, pad_id=0x73, sticks=(0x80, 0x80, 0x80, 0x80),
+        addr=0x01, cmd=0x42, truncate=None, frame=0):
+    """Build the SIO byte entries for one controller transaction."""
+    lo, hi = buttons & 0xFF, (buttons >> 8) & 0xFF
+    lx, ly, rx, ry = sticks
+    pairs = [(addr, 0xFF), (cmd, pad_id), (0x00, 0x5A), (0x00, lo), (0x00, hi),
+             (0x00, rx), (0x00, ry), (0x00, lx), (0x00, ly)]
+    if truncate is not None:
+        pairs = pairs[:truncate]
+    return [{"seq": seq + i, "tx": "0x%02X" % t, "rx": "0x%02X" % r,
+             "frame": frame}
+            for i, (t, r) in enumerate(pairs)]
+
+
+def hold(name):
+    return NONE & ~pd.BUTTONS[name]
+
+
+def stream(words, start=0, frame_of=None):
+    out, seq = [], start
+    for i, w in enumerate(words):
+        f = frame_of(i) if frame_of else i
+        out.extend(txn(seq, w, frame=f))
+        seq += 16
+    return out
+
+
+class DecodeTest(unittest.TestCase):
+    def test_single_poll_decoded(self):
+        polls = pd.decode_polls(txn(100, hold("down")))
+        self.assertEqual(len(polls), 1)
+        self.assertEqual(polls[0]["buttons"], hold("down"))
+        self.assertEqual(polls[0]["id"], 0x73)
+
+    def test_sticks_decoded_in_lx_ly_order(self):
+        polls = pd.decode_polls(txn(0, NONE, sticks=(0x11, 0x22, 0x33, 0x44)))
+        self.assertEqual(polls[0]["sticks"], [0x11, 0x22, 0x33, 0x44])
+
+    def test_memory_card_traffic_ignored(self):
+        entries = txn(0, NONE, addr=0x81) + txn(50, hold("up"))
+        polls = pd.decode_polls(entries)
+        self.assertEqual(len(polls), 1)
+        self.assertEqual(polls[0]["buttons"], hold("up"))
+
+    def test_truncated_transaction_dropped(self):
+        """A transaction cut off before the button word carries no state."""
+        polls = pd.decode_polls(txn(0, hold("up"), truncate=3))
+        self.assertEqual(polls, [])
+
+    def test_non_poll_command_dropped(self):
+        """0x43 (config) is not a button poll."""
+        polls = pd.decode_polls(txn(0, hold("up"), cmd=0x43))
+        self.assertEqual(polls, [])
+
+    def test_multiple_polls_in_order(self):
+        polls = pd.decode_polls(stream([NONE, hold("up"), NONE]))
+        self.assertEqual([p["buttons"] for p in polls],
+                         [NONE, hold("up"), NONE])
+
+    def test_digital_pad_id(self):
+        polls = pd.decode_polls(txn(0, NONE, pad_id=0x41, truncate=5))
+        self.assertEqual(polls[0]["id"], 0x41)
+        self.assertIsNone(polls[0]["sticks"])
+
+
+class RunTest(unittest.TestCase):
+    def test_contiguous_press_is_one_run(self):
+        polls = pd.decode_polls(stream([NONE] + [hold("down")] * 4 + [NONE]))
+        self.assertEqual(pd.poll_runs(polls, "down"), [(1, 4)])
+
+    def test_split_press_is_two_runs(self):
+        polls = pd.decode_polls(
+            stream([NONE, hold("down"), hold("down"), NONE,
+                    hold("down"), hold("down"), NONE]))
+        self.assertEqual(pd.poll_runs(polls, "down"), [(1, 2), (4, 5)])
+
+
+class AnalyzeTest(unittest.TestCase):
+    def kinds(self, findings):
+        return {f["kind"] for f in findings}
+
+    def test_clean_press_reports_nothing(self):
+        polls = pd.decode_polls(stream([NONE] + [hold("down")] * 4 + [NONE]))
+        runs, findings = pd.analyze(polls)
+        self.assertEqual(len(runs), 1)
+        self.assertEqual(findings, [])
+
+    def test_mid_press_release_is_a_bounce(self):
+        """The smoking gun: one tap delivered as two rising edges."""
+        polls = pd.decode_polls(
+            stream([NONE, hold("down"), hold("down"), NONE,
+                    hold("down"), hold("down"), NONE]))
+        _, findings = pd.analyze(polls)
+        self.assertIn("delivered_bounce", self.kinds(findings))
+
+    def test_two_deliberate_taps_are_not_a_bounce(self):
+        words = ([NONE] + [hold("down")] * 3 + [NONE] * 40
+                 + [hold("down")] * 3 + [NONE])
+        polls = pd.decode_polls(stream(words))
+        _, findings = pd.analyze(polls)
+        self.assertNotIn("delivered_bounce", self.kinds(findings))
+
+    def test_polls_per_frame(self):
+        """Two polls landing in the same frame are counted together."""
+        polls = pd.decode_polls(stream([NONE] * 4, frame_of=lambda i: i // 2))
+        self.assertEqual(pd.polls_per_frame(polls), {0: 2, 1: 2})
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class ResolveFrameTest(unittest.TestCase):
+    """A batch may straddle a frame boundary; say -1 rather than guess."""
+
+    def test_stable_counter_gives_exact_frame(self):
+        self.assertEqual(pd.resolve_frame(1100, 1100), 1100)
+
+    def test_advanced_counter_is_unknowable(self):
+        self.assertEqual(pd.resolve_frame(1100, 1101), -1)
+
+    def test_first_batch_has_no_predecessor(self):
+        self.assertEqual(pd.resolve_frame(None, 1100), -1)
+
+    def test_missing_counter_is_unknowable(self):
+        self.assertEqual(pd.resolve_frame(1100, -1), -1)
+
+    def test_unstamped_polls_excluded_from_counts(self):
+        polls = [{"seq": 0, "frame": -1, "buttons": NONE},
+                 {"seq": 10, "frame": 5, "buttons": NONE},
+                 {"seq": 20, "frame": 5, "buttons": NONE}]
+        self.assertEqual(pd.polls_per_frame(polls), {5: 2})

--- a/tools/tests/test_pad_trace.py
+++ b/tools/tests/test_pad_trace.py
@@ -167,3 +167,30 @@ class AnalyzeTest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class FoldSkewTest(unittest.TestCase):
+    """The D-pad bit and its folded stick deflection should arrive together."""
+
+    def test_simultaneous_fold_has_zero_skew(self):
+        s = [sample(0.00, 10, NONE),
+             sample(0.01, 11, hold("up"), [0x80, 0x00, 0x80, 0x80], True),
+             sample(0.02, 12, NONE)]
+        runs, findings = pt.analyze(s)
+        self.assertEqual(runs[0]["fold_skew_frames"], 0)
+        self.assertNotIn("fold_skew", {f["kind"] for f in findings})
+
+    def test_late_stick_is_reported_as_skew(self):
+        s = [sample(0.00, 10, hold("up"), [0x80] * 4, True),
+             sample(0.01, 12, hold("up"), [0x80, 0x00, 0x80, 0x80], True),
+             sample(0.02, 13, NONE)]
+        runs, findings = pt.analyze(s)
+        self.assertEqual(runs[0]["fold_skew_frames"], 2)
+        self.assertIn("fold_skew", {f["kind"] for f in findings})
+
+    def test_no_stick_means_no_skew(self):
+        s = [sample(0.00, 10, hold("up"), [0x80] * 4, False),
+             sample(0.01, 11, NONE)]
+        runs, findings = pt.analyze(s)
+        self.assertIsNone(runs[0]["fold_skew_frames"])
+        self.assertNotIn("fold_skew", {f["kind"] for f in findings})


### PR DESCRIPTION
Supersedes #233 with the validated callback-based architecture.

Changes:
- removes global/public Hybrid controller mode from game config and launcher-facing enum use
- keeps physical analog mode hardware-faithful by no longer folding D-pad onto the left stick
- adds a trusted plugin controller presentation policy callback so game-owned mods can choose analog/digital per sample
- preserves injected-input steering for debug/dev paths where no physical stick exists
- carries over the #233 pad/cursor diagnostic tools and tests

Validation:
- py -3 runtime\tests\test_mod_controller_override.py
- py -3 runtime\tests\test_hybrid_dev_any_input.py
- py -3 -m unittest tools.tests.test_pad_trace tools.tests.test_pad_delivery tools.tests.test_menu_scan tools.tests.test_cursor_writers
- Tomba regenerated successfully against rbengine main; generated output unchanged
- Tomba fresh rbengine-main build passed manual Hybrid Controller validation with slot-2 100% save