### PR TITLE
packaging: tolerate empty runtime dir lists

### DIFF
--- a/tools/package_setup_host.sh
+++ b/tools/package_setup_host.sh
@@ -263,12 +263,16 @@ copy_runtime_dir() {
   echo "staged runtime dir ${name}/"
 }
 
-for d in "${RUNTIME_DIRS[@]}"; do
-  copy_runtime_dir "${d}" 0
-done
-for d in "${RUNTIME_DIRS_OPTIONAL[@]}"; do
-  copy_runtime_dir "${d}" 1
-done
+if ((${#RUNTIME_DIRS[@]})); then
+  for d in "${RUNTIME_DIRS[@]}"; do
+    copy_runtime_dir "${d}" 0
+  done
+fi
+if ((${#RUNTIME_DIRS_OPTIONAL[@]})); then
+  for d in "${RUNTIME_DIRS_OPTIONAL[@]}"; do
+    copy_runtime_dir "${d}" 1
+  done
+fi
 
 copy_proj() {
   local rel="$1"


### PR DESCRIPTION
Fixes setup-host packaging on macOS when a title has no runtime directories to stage. Bash 3.2 with nounset treats expanding an empty array as an unbound variable, so guard the runtime-dir loops before expansion.\n\nContext: found while cutting the Tomba 0.12.1-alpha release after moving it to psxrecomp master.