### PR TITLE
runtime: build under MSVC — GNU-only constructs + C linkage (fixes #244)

### DIFF
--- a/runtime/include/psx_align.h
+++ b/runtime/include/psx_align.h
@@ -1,0 +1,25 @@
+/* psx_align.h — portable alignment attribute for SIMD scratch buffers.
+ *
+ * The SSE2/NEON kernels store to local scratch arrays with aligned stores
+ * (_mm_store_si128 and friends), so the alignment is load-bearing, not a
+ * hint: an under-aligned destination faults.
+ *
+ * GCC/Clang spell this __attribute__((aligned(n))); MSVC spells it
+ * __declspec(align(n)). Both are valid in prefix position on a declaration,
+ * which is the one placement the two spellings share -- hence the macro is
+ * written to be used as a prefix:
+ *
+ *     PSX_ALIGN(16) int32_t tmp[4];
+ */
+#ifndef PSXRECOMP_PSX_ALIGN_H
+#define PSXRECOMP_PSX_ALIGN_H
+
+#if defined(_MSC_VER) && !defined(__clang__)
+#define PSX_ALIGN(n) __declspec(align(n))
+#elif defined(__GNUC__) || defined(__clang__)
+#define PSX_ALIGN(n) __attribute__((aligned(n)))
+#else
+#define PSX_ALIGN(n) _Alignas(n)
+#endif
+
+#endif /* PSXRECOMP_PSX_ALIGN_H */

--- a/runtime/include/sio.h
+++ b/runtime/include/sio.h
@@ -17,6 +17,40 @@ extern "C" {
 #error "PSX_MAX_PLAYERS must be in 1..8"
 #endif
 
+/* Per-pad table initializer: repeat one element PSX_MAX_PLAYERS times.
+ *
+ *     static uint16_t pad_buttons[PSX_MAX_PLAYERS] = { PSX_PAD_INIT(0xFFFF) };
+ *
+ * GNU's [0 ... PSX_MAX_PLAYERS - 1] = x range designator says this in one
+ * token, but it is a GCC extension with no MSVC equivalent, so the element
+ * list is expanded by the preprocessor instead. Each PSX_PAD_REP_n is written
+ * flat rather than recursively so no nested macro call is involved and the
+ * expansion is identical under both the conforming and the traditional MSVC
+ * preprocessor. Variadic so a braced element ({ 0x80, 0x80, 0x80, 0x80 })
+ * survives argument splitting. The 1..8 bound above is what makes the ladder
+ * finite; a value outside it fails the #error before reaching an undefined
+ * PSX_PAD_REP_n. The count always matches the array extent because both are
+ * spelled PSX_MAX_PLAYERS. */
+#define PSX_PAD_REP_1(...) __VA_ARGS__
+#define PSX_PAD_REP_2(...) __VA_ARGS__, __VA_ARGS__
+#define PSX_PAD_REP_3(...) __VA_ARGS__, __VA_ARGS__, __VA_ARGS__
+#define PSX_PAD_REP_4(...) __VA_ARGS__, __VA_ARGS__, __VA_ARGS__, __VA_ARGS__
+#define PSX_PAD_REP_5(...) \
+    __VA_ARGS__, __VA_ARGS__, __VA_ARGS__, __VA_ARGS__, __VA_ARGS__
+#define PSX_PAD_REP_6(...) \
+    __VA_ARGS__, __VA_ARGS__, __VA_ARGS__, __VA_ARGS__, __VA_ARGS__, \
+    __VA_ARGS__
+#define PSX_PAD_REP_7(...) \
+    __VA_ARGS__, __VA_ARGS__, __VA_ARGS__, __VA_ARGS__, __VA_ARGS__, \
+    __VA_ARGS__, __VA_ARGS__
+#define PSX_PAD_REP_8(...) \
+    __VA_ARGS__, __VA_ARGS__, __VA_ARGS__, __VA_ARGS__, __VA_ARGS__, \
+    __VA_ARGS__, __VA_ARGS__, __VA_ARGS__
+/* Two layers so PSX_MAX_PLAYERS expands to its value before the ## paste. */
+#define PSX_PAD_REP_JOIN(n, ...) PSX_PAD_REP_##n(__VA_ARGS__)
+#define PSX_PAD_REP_EXPAND(n, ...) PSX_PAD_REP_JOIN(n, __VA_ARGS__)
+#define PSX_PAD_INIT(...) PSX_PAD_REP_EXPAND(PSX_MAX_PLAYERS, __VA_ARGS__)
+
 /* SIO0 register base: 0x1F801040 */
 #define SIO_BASE 0x1F801040
 

--- a/runtime/src/mdec.c
+++ b/runtime/src/mdec.c
@@ -1,4 +1,5 @@
 #include "mdec.h"
+#include "psx_align.h"
 #include "pst_wire.h"
 #include "psx_cycles.h"
 
@@ -327,7 +328,7 @@ static int idct_sse2_dot8(const int16_t *src8, const int16_t *scale8)
     __m128i c = _mm_loadu_si128((const __m128i *)src8);
     __m128i m = _mm_loadu_si128((const __m128i *)scale8);
     __m128i sum = _mm_madd_epi16(m, c);
-    int32_t tmp[4] __attribute__((aligned(16)));
+    PSX_ALIGN(16) int32_t tmp[4];
     sum = _mm_add_epi32(sum, _mm_shuffle_epi32(sum, _MM_SHUFFLE(0, 1, 2, 3)));
     sum = _mm_add_epi32(sum, _mm_shuffle_epi32(sum, _MM_SHUFFLE(0, 0, 0, 1)));
     _mm_store_si128((__m128i *)tmp, sum);
@@ -338,7 +339,7 @@ static void idct_block_sse2(int16_t *block)
 {
     int ac = 0;
     int i, col, x;
-    int16_t tmp[64] __attribute__((aligned(16)));
+    PSX_ALIGN(16) int16_t tmp[64];
 
     for (i = 1; i < 64; i++)
         ac |= block[i];

--- a/runtime/src/sio.c
+++ b/runtime/src/sio.c
@@ -45,13 +45,13 @@ static void sio_debug_poll_maybe(void) {
 
 /* Pad state: 0=pressed, 1=released (PS1 convention). Indexed by LOGICAL pad
  * 0 .. PSX_MAX_PLAYERS-1 (not physical SIO slot). */
-static uint16_t pad_buttons[PSX_MAX_PLAYERS] = { [0 ... PSX_MAX_PLAYERS - 1] = 0xFFFF };
+static uint16_t pad_buttons[PSX_MAX_PLAYERS] = { PSX_PAD_INIT(0xFFFF) };
 
 /* Per-logical-pad type + analog stick state. analog: 0=digital pad (poll id
  * 0x41), 1=DualShock/analog (poll id 0x73). Sticks are 0..255, 0x80 centred. */
 static PSX_BSS uint8_t pad_analog[PSX_MAX_PLAYERS];
 static uint8_t pad_stick[PSX_MAX_PLAYERS][4] = {
-    [0 ... PSX_MAX_PLAYERS - 1] = { 0x80, 0x80, 0x80, 0x80 }
+    PSX_PAD_INIT({ 0x80, 0x80, 0x80, 0x80 })
 }; /* lx,ly,rx,ry */
 
 /* DualShock command 0x4D maps the six writable bytes in a 0x42 poll onto the
@@ -59,7 +59,7 @@ static uint8_t pad_stick[PSX_MAX_PLAYERS][4] = {
  * 0xFF = unused. The map powers up unassigned and is echoed back while a new
  * map is latched, matching the physical pad/Mednafen protocol. */
 static uint8_t pad_rumble_map[PSX_MAX_PLAYERS][6] = {
-    [0 ... PSX_MAX_PLAYERS - 1] = { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF },
+    PSX_PAD_INIT({ 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF })
 };
 static PSX_BSS uint8_t pad_rumble_small[PSX_MAX_PLAYERS];
 static PSX_BSS uint8_t pad_rumble_large[PSX_MAX_PLAYERS];
@@ -134,7 +134,7 @@ static PSX_BSS uint8_t pad_in_config[PSX_MAX_PLAYERS];
  * phantom "all pressed" input. Default 1 keeps analog/hybrid pads unchanged;
  * main.cpp sets 0 for PAD_MODE_DIGITAL. */
 static uint8_t pad_supports_config[PSX_MAX_PLAYERS] = {
-    [0 ... PSX_MAX_PLAYERS - 1] = 1
+    PSX_PAD_INIT(1)
 };
 
 /* Coherent-DualShock model (Tomba phantom-input fix). A real controller never
@@ -149,7 +149,7 @@ static uint8_t pad_supports_config[PSX_MAX_PLAYERS] = {
  * only when the bus is idle (PAD_IDLE) and the pad is NOT in config mode. A
  * request raised during config is held until config exits. -1 = no request. */
 static int8_t pad_type_req[PSX_MAX_PLAYERS] = {
-    [0 ... PSX_MAX_PLAYERS - 1] = -1
+    PSX_PAD_INIT(-1)
 };
 
 /* ---- Logical pad ↔ physical SIO port mapping ----


### PR DESCRIPTION
Fixes #244 — both reports in it.

The tree already intends MSVC support and largely implements it: `runtime.cmake:1607` carries `/GS- /guard:cf-`, `/STACK:67108864`, `/SUBSYSTEM:WINDOWS` with `/ENTRY:mainCRTStartup`, and an `/experimental:c11atomics` scoped to `audio_trace.c`; `runtime.cmake:202` has an SDL2 MSVC dev-package lookup; `psx-oracle` and `psx-beetle` are skipped under MSVC as MinGW-only; `psx_cycles.c:644` picks `_BitScanReverse` over `__builtin_clz`; and the recompiler emits a `.CRT$XCU` static initializer rather than `__attribute__((constructor))`. Both reported problems are things that regressed past that work.

Everything here is in the runtime source list (`runtime.cmake:261,267`) or in `main.cpp`, so it blocked the framework runtime **and** every generated game project — the generated code being MSVC-clean doesn't help when the runtime it links against isn't.

---

## Commit 1 — two GNU-only constructs

**`runtime/src/sio.c`** — five GNU `[0 ... PSX_MAX_PLAYERS - 1]` range designators (the issue found line 48; there are also 54, 62, 137, 152). Replaced with a `PSX_PAD_INIT()` element-repeat macro added to `sio.h` beneath the `PSX_MAX_PLAYERS` 1..8 `#error` that bounds it. Each `PSX_PAD_REP_n` is flat rather than recursive, so no nested macro call is involved and the expansion is identical under the conforming and the traditional MSVC preprocessor; variadic so a braced element (`{ 0x80, 0x80, 0x80, 0x80 }`) survives argument splitting. Element count can't drift from the array extent — both are spelled `PSX_MAX_PLAYERS`.

**`runtime/src/mdec.c`** — `__attribute__((aligned(16)))` on the two SSE2 scratch locals. Load-bearing, not cosmetic: `idct_sse2_dot8` stores with `_mm_store_si128`, which faults on an under-aligned destination. `mdec.c:9-10` gates the SSE2 path on `_M_X64 || _M_AMD64` *specifically so MSVC x64 takes it*, so MSVC was guaranteed to reach a GCC-only attribute. Now `PSX_ALIGN(n)` from a new `runtime/include/psx_align.h` (`__declspec(align(n))` on MSVC — prefix position is the one placement both spellings share), written in the style of the neighbouring `psx_bss.h`.

## Commit 2 — C linkage for ten globals in `main.cpp`

MSVC mangles namespace-scope variables and the Itanium ABI does not, so a C++ reference to a C-defined global links on GCC/Clang and fails on MSVC. `main.cpp:180` already holds the file-scope `extern "C"` block from the earlier MSVC pass, with a comment describing precisely this. Ten globals added since then never got added to it:

| defined in | symbols |
|---|---|
| `memory.c` | `i_stat`, `i_mask`, `g_guest_store_count`, `g_vblank_ack_count` |
| `interrupts.c` | `g_vblank_raise_count`, `g_vblank_deliver_count` |
| `dirty_ram_interp.c` | `g_dirty_ram_blocks_run`, `g_dirty_pump_count` |
| `overlay_loader.c` | `g_call_unit_depth` |
| `psx_bios_backend.c` | `g_psx_dispatch_depth` |

Each was reached only through a block-scope `extern` inside a function; with no namespace-scope declaration in view, that gives the entity C++ linkage. Adding them to the block fixes it without touching any use site — the block-scope redeclarations inherit C linkage, exactly as the block's existing comment describes.

**Which ten was measured, not eyeballed.** All 31 distinct block-scope `extern`s in `main.cpp` were probed by appending `extern "C++" { extern T sym; }` to a copy of the file compiled with the target's real command line: a conflicting-linkage diagnostic means the symbol already has C linkage from an `extern "C"` header, silence means it does not. 21 came back already-C (`psx_cycles.h`, `cpu_state.h`, `debug_server.h`, or already in the block); these 10 came back C++. After the change all 31 probe as C linkage.

`main.cpp` is the only C++ TU in the runtime with this pattern — `beetle_libretro.cpp`'s `extern PS_GPU GPU` / `extern PS_CDC *PSX_CDC` are genuine Beetle C++ symbols, correctly left alone, and `psx-beetle` isn't built under MSVC anyway.

---

## Verification

Existing toolchains are provably unaffected — all three changed TUs compile to **byte-identical objects** against a clean `origin/master` worktree:

- `sio.o` — identical at every supported `PSX_MAX_PLAYERS` (1..8), under gcc and clang, and again under the `sio_card_protocol_test` target's own flags
- `mdec.o` — identical
- `main.cpp.o` — identical (539,200 bytes both sides)

Plus:
- `-Wpedantic` over `runtime/src` reported the five range designators before and reports none after
- `PSX_MAX_PLAYERS=9` still trips the `#error` first, before any undefined `PSX_PAD_REP_n`
- Clean-build full runtime suite: **47/48**, versus **43/44** at `origin/master` — same single failure both sides (see below), branch registers 4 extra netplay tests that also pass

What I could **not** test is `cl.exe` itself — no MSVC available here. The constructs are plain C99 variadic macros and `__declspec(align)`, and I deliberately avoided the nested-`__VA_ARGS__` forwarding that trips the legacy preprocessor, but someone on Windows should confirm the build before this merges.

## Two things this PR does not do

1. **`gte_register_access_test` fails to link** — pre-existing and unrelated, verified failing identically at `origin/master`. It links `gte.cpp` + `pgxp.cpp` but references `gpu_ws_precise_nclip_enabled`, defined in `gpu.c`, which isn't in that target's source list (`runtime/CMakeLists.txt:101-105`).
2. **Nothing in CI compiles `runtime/src` with `cl.exe`.** `cli-release.yml` has a `windows-latest` job, but it builds the CLI with the portable toolchain. That's why both of these landed unnoticed, and why they'll come back. A `windows-latest` MSVC configure+build job is the durable fix and deserves its own change.

Also worth knowing for anyone taking an MSVC build further: the per-block deferred cycle batching is `#if defined(PSX_ENABLE_BLOCK_CYCLES) && (defined(__GNUC__) || defined(__clang__))` (`code_generator.cpp:2628`, helpers at `psx_cyc.h:82`) with no MSVC fallback. Begin and end drop together, so charges publish eagerly instead of batched — a performance difference, not an accuracy one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014YD7rrVK63Kncki6prB65S