### PR TITLE
Port rbengine wrong-base PR subset to master

### DIFF
--- a/TCP_COMMANDS.md
+++ b/TCP_COMMANDS.md
@@ -50,7 +50,9 @@ Columns: **N** = native, **D** = DuckStation oracle.
 | `read_scratch` |   | ✓ | `addr`, `len` | Read PS1 scratchpad (0x1F800000 region) |
 | `read_vram` / `vram_peek` | ✓¹ | ✓ | `x`, `y`, `w`, `h` | Read 16-bit VRAM pixels (max 128×128) |
 | `gpu_state` | ✓ | ✓ | — | Display area, display depth, draw offset, GPUSTAT, clip rect, xfer state |
-| `screenshot_hires` |   | ✓ | `path` | PNG of the **supersampled** surface (the present path the window uses), at `display × gr_scale()`. ⚠ `screenshot`/`screenshot_file` capture native 15-bit VRAM and are **blind to anything that only exists in the hi-res mirror** — geometry correction, SSAA edges, perspective UVs — so they show a clean frame while the player sees a broken one. Use this one to verify those. Falls back to the native resolve (and reports `scale: 1`) when no hi-res surface exists |
+| `screenshot_hires` | ✓ | ✓ | `path` | PNG of the **supersampled** surface (the present path the window uses), at `display × gr_scale()`. ⚠ `screenshot`/`screenshot_file` capture native 15-bit VRAM and are **blind to anything that only exists in the hi-res mirror** — geometry correction, SSAA edges, perspective UVs — so they show a clean frame while the player sees a broken one. Use this one to verify those. Falls back to the native resolve (and reports `scale: 1`) when no hi-res surface exists |
+| `present_shot` | ✓ |   | `path` | PNG of the **composed present surface** — the frame after the backend fits the display buffer to the window, so it carries the presented aspect. ⚠ every other capture resolves the display buffer *before* that fit: on a 508×256 display in a 4:3 window they answer 508×256 while the player sees 640×480. Use this one for anything aspect-shaped (widescreen, letterbox), where a pre-fit buffer would hide the very stage the change touches. Staged and fulfilled on the next present, so the ack means *queued* — poll `present_shot_seq`. Unavailable headless and on the Vulkan backend (its swapchain has no readback hook) |
+| `present_shot_seq` | ✓ |   | — | Completion counter for `present_shot`, plus `wrote` (1 = that completion produced a PNG). Sample before staging, poll until `seq` moves. Advances on success *and* failure, so the poll always terminates |
 | `geom_correction` |   | ✓ | — | `[video] geometry_correction` / `perspective_texturing` engagement: enable flag plus free-running `geometry_vertex_hits` and `perspective_triangles` totals. Both enhancements silently fall back to the faithful path on anything they cannot prove is projected geometry, so a zero counter with the flag on means the title never qualifies — sample twice and diff for a rate |
 | `sio_state` | ✓ | ✓ | — | SIO registers + (native only) pad/memcard protocol + TX/RX history |
 | `irq_state` | ✓ | ✓ | — | `I_STAT`, `I_MASK` (both), plus chain state on native |
@@ -214,16 +216,7 @@ ring names the return path that let it come back.
   `sp_b`/`ra_b`/`s0_b`/`s3_b`, post-call `pc_a`/`ra_a`/`sp_a`/`s0_a`/
   `s3_a`/`v0_a`, `bail`/`rfe`/`esc`/`in_exc` flags, `dstatic`/`dblocks`/
   `dexc` engine-attribution deltas across the call, `last_func`.
-- `{"cmd":"callret_watch","disarm":true}` — disarm. The legacy
-  `{"lo":"0"}` spelling (no `hi`) still disarms and says so in the reply.
-
-The ring is armed iff the window is NON-EMPTY (`hi > lo`), so `lo` may be
-`0` — `{"lo":"0","hi":"0x200000"}` really does watch the whole address
-space. Every reply carries `armed`, and the dump carries `armed` plus the
-active window, because an unarmed ring reports `total: 0` — which otherwise
-reads exactly like a genuine "those calls never happened" answer. Passing
-`lo` with no `hi` is refused rather than silently inheriting the previous
-ceiling (usually `0`, i.e. an empty window).
+- `{"cmd":"callret_watch","lo":"0"}` — disarm.
 
 ## `hle_dump` — BIOS-HLE tier call ring (native only)
 
@@ -272,9 +265,9 @@ The TCP server is the canonical instrumentation surface. Rule 3 in `CLAUDE.md` i
 
 ## Complete command index (generated)
 
-**305 commands registered** — 292 on the native server (`runtime/src/debug_server.c`), 61 on the Beetle server (`runtime/src/beetle_debug_server.c`).
+**306 commands registered** — 293 on the native server (`runtime/src/debug_server.c`), 61 on the Beetle server (`runtime/src/beetle_debug_server.c`).
 
-49 of 305 have prose above; **256 are index-only**. An index-only command still works — it just has no description here yet. Send it `{"cmd":"<name>"}` and read the reply, or find its `handle_*` function in the server source.
+51 of 306 have prose above; **255 are index-only**. An index-only command still works — it just has no description here yet. Send it `{"cmd":"<name>"}` and read the reply, or find its `handle_*` function in the server source.
 
 Regenerate with `python tools/gen_tcp_commands.py`; `--check` fails if this block has drifted from the code.
 
@@ -471,6 +464,8 @@ Regenerate with `python tools/gen_tcp_commands.py`; `--check` fails if this bloc
 | `phase_profile` | ✓ |  |  |
 | `ping` | ✓ | ✓ | ✓ |
 | `present_ring` | ✓ |  |  |
+| `present_shot` | ✓ |  | ✓ |
+| `present_shot_seq` | ✓ |  | ✓ |
 | `press` | ✓ | ✓ |  |
 | `probe_clear` | ✓ |  |  |
 | `probe_trace` | ✓ |  |  |
@@ -584,6 +579,5 @@ Regenerate with `python tools/gen_tcp_commands.py`; `--check` fails if this bloc
 | `xlate` | ✓ |  |  |
 | `xprobe` | ✓ |  |  |
 | `xprobe_arm` | ✓ |  |  |
-| `xprobe_watch` | ✓ |  |  |
 
 <!-- END AUTOGENERATED COMMAND INDEX -->

--- a/runtime/include/gpu.h
+++ b/runtime/include/gpu.h
@@ -383,6 +383,12 @@ void psx_ws_backdrop_ring_note(uint32_t pc, int kind, int wcols, uint32_t orig,
                                uint32_t base, uint32_t dl);
 int  psx_ws_backdrop_ring_json(char *buf, int cap);
 
+/* auto_ui_squash partition dump (`ws_ui_groups`). Reports, for the last UI
+ * prepass, each primitive's raw key inputs (CLUT/texpage band/family via op,
+ * y, h) alongside its union-find root and final anchor — enough to tell whether
+ * two HUD primitives shared a run, and which key component split them if not. */
+int  psx_ws_ui_groups_json(char *buf, int cap);
+
 /* Live-tunable backdrop widen amount (ws_backdrop_margin command): <0 whole-row,
  * 0 off, >0 N-column widen. g_ws_bd_from_interp is the interp's one-shot
  * "I will record the rich entry myself" flag (see gpu.c / dirty_ram_interp.c). */

--- a/runtime/include/gpu.h
+++ b/runtime/include/gpu.h
@@ -39,6 +39,14 @@ typedef struct {
 } GpuDisplayInfo;
 
 void gpu_get_display_info(GpuDisplayInfo* out);
+
+/* Perspective-correct UV arming rate, per condition. armed/attempts is the
+ * real perspective coverage: attempts counts only textured triangles, so it is
+ * the denominator that gp0_draw (which includes untextured primitives that are
+ * correctly never armed) cannot provide. Diagnostic; any pointer may be NULL. */
+void gpu_texture_correction_stats(uint64_t *attempts, uint64_t *armed,
+                                  uint64_t *no_correction,
+                                  uint64_t *no_source, uint64_t *no_depth);
 /* GP1(08h) bit4 — 24-bit display. Renderers skip FBO upload queues while set:
  * packed RGB888 lives in the CPU mirror; treating A0 rects as 1555 FBO uploads
  * both wastes bandwidth and force-flushes when UP_RECTS_MAX is hit (MotK FMV). */

--- a/runtime/include/mod_packages.h
+++ b/runtime/include/mod_packages.h
@@ -46,6 +46,7 @@ struct ModFeature {
     std::string description;
     std::string group = "General";
     bool default_enabled = false;
+    bool hidden = false;
     bool legacy = false;
 };
 

--- a/runtime/include/ws_ui_group.h
+++ b/runtime/include/ws_ui_group.h
@@ -10,10 +10,22 @@ extern "C" {
 
 #define WS_UI_GROUP_JOIN_GAP 24
 
+/* Vertical slack, in scanlines, still counted as "stacked on" rather than
+ * "somewhere else on screen". A readout drawn as a label directly above its
+ * box leaves a one-pixel seam; the nearest thing that must NOT join is the
+ * other end of the screen, ~200 scanlines away. */
+#define WS_UI_GROUP_STACK_GAP 4
+
 typedef struct {
     uint32_t key;
     int32_t x;
     int32_t width;
+    /* Vertical extent, needed to tell "drawn on top of each other" (one visual
+     * element) from "happens to share screen columns" (the top-left lap counter
+     * and the bottom-left lap timer). Grouping only ever produces a HORIZONTAL
+     * anchor, but deciding the grouping is a 2-D question. */
+    int32_t y;
+    int32_t height;
     int32_t anchor;
     /* Diagnostic only: index of the union-find representative this item
      * merged into, so an observer can tell "these two share an anchor because

--- a/runtime/include/ws_ui_group.h
+++ b/runtime/include/ws_ui_group.h
@@ -15,6 +15,14 @@ typedef struct {
     int32_t x;
     int32_t width;
     int32_t anchor;
+    /* Diagnostic only: index of the union-find representative this item
+     * merged into, so an observer can tell "these two share an anchor because
+     * they are one run" from "these two happen to land on the same third".
+     * Anchor equality cannot distinguish those — there are only three anchor
+     * values — and that distinction is the whole question when a HUD element
+     * splits apart under the squash. Written by ws_ui_group_assign; never read
+     * by the transform path. */
+    uint32_t root;
 } WsUiGroupItem;
 
 /* Assign one thirds anchor to each complete spatial run. Items with the same

--- a/runtime/runtime.cmake
+++ b/runtime/runtime.cmake
@@ -771,7 +771,10 @@ function(psxrecomp_add_runtime_target target)
     # and stamp the pgxp overlay flavor so the shard cache and the ABI gate
     # keep pgxp and base DLLs fully separate. The base target is untouched —
     # the macros preprocess away without the define.
-    set(options ORACLE COSIM PGXP)
+    # PGXP_CLONE is internal: set only by the PSX_PGXP_VARIANT auto-clone at the
+    # end of this function, to mark the sibling that needs a distinguishing exe
+    # name. Callers pass PGXP alone.
+    set(options ORACLE COSIM PGXP PGXP_CLONE)
     set(oneValueArgs
         GAME_GENERATED_DISPATCH_C
         GAME_OVERLAY_STATIC_C
@@ -936,10 +939,22 @@ function(psxrecomp_add_runtime_target target)
         set(_psxrt_exe_name "${_psxrt_exe_name}_oracle")
     endif()
     if(PSXRT_PGXP)
-        # Distinct binary beside the base one; the launcher (or the player)
-        # picks the variant. Same debug port as the base build — run one at a
-        # time (the A/B protocol is one-toggle-per-run anyway).
-        set(_psxrt_exe_name "${_psxrt_exe_name}_pgxp")
+        # The _pgxp suffix exists only to keep the auto-cloned A/B sibling
+        # distinct from the base binary it sits beside (PSX_PGXP_VARIANT); the
+        # launcher or the player picks between them. Same debug port as the
+        # base build — run one at a time (the A/B protocol is
+        # one-toggle-per-run anyway).
+        #
+        # A title that builds PGXP into its ONE runtime target has no base
+        # binary beside it, so suffixing there would ship a single product
+        # under an odd name and, worse, leave a second look-alike executable in
+        # the build tree for someone to launch by mistake. That is not
+        # hypothetical: a non-PGXP binary got played and reported as "textures
+        # still wobble" while the PGXP one measured 99% precise-vertex
+        # coverage. Suffix the clone, never the primary.
+        if(PSXRT_PGXP_CLONE)
+            set(_psxrt_exe_name "${_psxrt_exe_name}_pgxp")
+        endif()
         target_compile_definitions(${target} PRIVATE
             PSX_PGXP=1
             PSX_OVERLAY_FLAVOR=2)   # PSX_OVERLAY_FLAVOR_PGXP (overlay_api.h)
@@ -1657,7 +1672,7 @@ function(psxrecomp_add_runtime_target target)
         option(PSX_PGXP_VARIANT
             "Also build the <exe>_pgxp PGXP precision-shadowing variant" OFF)
         if(PSX_PGXP_VARIANT)
-            psxrecomp_add_runtime_target(${target}-pgxp PGXP ${ARGN})
+            psxrecomp_add_runtime_target(${target}-pgxp PGXP PGXP_CLONE ${ARGN})
         endif()
     endif()
 endfunction()

--- a/runtime/src/cdrom.c
+++ b/runtime/src/cdrom.c
@@ -578,11 +578,12 @@ static int apply_speed(int delay) {
 
 static int apply_read_speed(int delay) {
     /* A route is an explicit DATA-read allowlist, never a blanket drive-speed
-     * change. Keep FMV/STR authentic: XA-ADPCM (0x40), filter (0x08), and
-     * Form2/0x924 (0x20) — MotK sets mode 0xa2 (Form2+2×) before the XA bit,
-     * and disc_speed=4x was compressing that preamble into a one-sector race
-     * (soak §93 P1 sim 184: rd≈112896 vs delivered). */
-    if (xa_stream_active || (mode_reg & 0x68u)) return delay;
+     * change. Keep FMV/STR authentic once the drive is explicitly in XA/filter
+     * mode (0x40/0x08) or an XA stream is already active. Do not treat the
+     * whole-sector/Form2 bit (0x20) alone as realtime media: Tomba's normal
+     * asset loads use mode 0xA0, so including 0x20 here made the CD Speed mod
+     * configure divisor=32 while every actual data-read deadline stayed 1x/2x. */
+    if (xa_stream_active || (mode_reg & 0x48u)) return delay;
     if (s_warm_route_active) return warm_route_period();
     return apply_speed(delay);
 }

--- a/runtime/src/debug_server.c
+++ b/runtime/src/debug_server.c
@@ -5204,10 +5204,19 @@ static void handle_geom_correction(int id, const char *json)
      * but described a different word (stale = provenance hole to hunt). */
     PGXPStats ps;
     pgxp_get_stats(&ps);
+    /* Perspective arming, with its real denominator. perspective_triangles on
+     * its own could only be compared against gp0_draw, which counts untextured
+     * primitives that are correctly never armed — so it read as a coverage
+     * figure without being one. texcorr.attempts counts exactly the textured
+     * triangles that reach the predicate. */
+    uint64_t tc_att = 0, tc_arm = 0, tc_off = 0, tc_nosrc = 0, tc_noz = 0;
+    gpu_texture_correction_stats(&tc_att, &tc_arm, &tc_off, &tc_nosrc, &tc_noz);
     send_fmt("{\"id\":%d,\"ok\":true,"
              "\"geometry_correction\":%d,"
              "\"geometry_vertex_hits\":%u,"
              "\"perspective_triangles\":%u,"
+             "\"texcorr\":{\"attempts\":%llu,\"armed\":%llu,"
+             "\"no_correction\":%llu,\"no_source\":%llu,\"no_depth\":%llu},"
              "\"lookups\":%u,\"miss_unrecorded\":%u,\"miss_ambiguous\":%u,"
              "\"pgxp\":{\"enabled\":%d,\"cpu_mode\":%d,\"tolerance\":%.3f,"
              "\"lookups\":%llu,\"dataflow_hit\":%llu,\"fallback_hit\":%llu,"
@@ -5218,6 +5227,9 @@ static void handle_geom_correction(int id, const char *json)
              gte_geometry_correction_enabled(),
              (unsigned)hits,
              (unsigned)gpu_texture_correction_hits(),
+             (unsigned long long)tc_att, (unsigned long long)tc_arm,
+             (unsigned long long)tc_off, (unsigned long long)tc_nosrc,
+             (unsigned long long)tc_noz,
              (unsigned)lookups, (unsigned)unrec, (unsigned)ambig,
              pgxp_enabled(), pgxp_cpu_mode(), (double)pgxp_tolerance(),
              (unsigned long long)ps.lookups,

--- a/runtime/src/debug_server.c
+++ b/runtime/src/debug_server.c
@@ -8701,7 +8701,9 @@ static void handle_screenshot_hires(int id, const char *json)
         strncpy(path, "psx_screenshot_hires.png", sizeof(path) - 1);
     path[sizeof(path) - 1] = '\0';
 
-    uint32_t *argb = (uint32_t *)malloc((size_t)ow * oh * sizeof(uint32_t));
+    /* calloc, not malloc: any pixel a resolve declines to touch must be a
+     * deterministic black, never whatever the allocator handed back. */
+    uint32_t *argb = (uint32_t *)calloc((size_t)ow * oh, sizeof(uint32_t));
     if (!argb) { send_err(id, "alloc failed"); return; }
     /* Renderer pitches are byte strides (the live SDL presentation path uses
      * the same contract). Passing `ow` here advanced each row by only one
@@ -8711,15 +8713,25 @@ static void handle_screenshot_hires(int id, const char *json)
                                       (int)(ow * sizeof(*argb)),
                                       (int)di.display_x,
                                       (int)di.display_y, (int)w, (int)h);
-    if (!got) {
-        /* No hi-res surface (scale 1, or a backend without one): resolve the
-         * native display instead and say so, rather than emitting a blank. */
+    /* The resolves return the pixel COUNT they wrote, and a partial cover is a
+     * real case: gr_scale() reports the GL backend's internal scale, but
+     * sw_render_display_hires falls back to the native resolve when the CPU
+     * hi-res mirror does not exist (gpu_sw_renderer.c: !g_hr || g_scale <= 1).
+     * That fills w*h of an ow*oh buffer and still returns non-zero, so testing
+     * `!got` alone would emit a PNG that is mostly untouched allocation. Demand
+     * full cover, else redo it honestly at native size. */
+    if (got < (int)((size_t)ow * oh)) {
+        /* No hi-res surface (scale 1, a backend without one, or a partial
+         * cover): resolve the native display instead and say so, rather than
+         * emitting a blank. */
         scale = 1; ow = w; oh = h;
         got = gr_render_display(argb,
                                 (int)(ow * sizeof(*argb)),
                                 (int)di.display_x,
                                 (int)di.display_y, (int)w, (int)h);
-        if (!got) { free(argb); send_err(id, "no display surface"); return; }
+        if (got < (int)((size_t)ow * oh)) {
+            free(argb); send_err(id, "no display surface"); return;
+        }
     }
 
     uint8_t *rgb = (uint8_t *)malloc((size_t)ow * oh * 3);
@@ -8741,6 +8753,56 @@ static void handle_screenshot_hires(int id, const char *json)
 
     send_fmt("{\"id\":%d,\"ok\":true,\"path\":\"%s\",\"width\":%u,"
              "\"height\":%u,\"scale\":%d}", id, path, ow, oh, scale);
+}
+
+/* present_shot — PNG of the COMPOSED renderer output: the frame after SDL fits
+ * the display buffer into the logical surface, i.e. at the aspect the player is
+ * actually looking at.
+ *
+ * The three buffer-level captures above (screenshot / screenshot_file /
+ * screenshot_hires) all resolve the display buffer BEFORE that fit. On a 508x256
+ * display in a 4:3 window they answer 508x256 while the window shows 640x480 —
+ * the same pixels at a different shape. That is correct for faithfulness work
+ * and WRONG for anything aspect-shaped: a widescreen change alters the GTE
+ * squash and the present fit, so validating it against a pre-fit buffer measures
+ * the one stage the change does not touch.
+ *
+ * Staged and fulfilled in the present path (see present_shot_request in
+ * main.cpp), so the ack means "queued", not "written" — the PNG lands on the
+ * next present. Sample `present_shot_seq` before staging and poll it until the
+ * counter moves; `wrote` in that reply says whether a file actually landed.
+ *
+ * Refused up front on headless (no present surface) and on the Vulkan backend,
+ * which presents through its own swapchain and has no readback hook — accepting
+ * there would leave a request nothing can ever fulfil. */
+static void handle_present_shot(int id, const char *json)
+{
+    extern int present_shot_request(const char *path);
+    extern int present_shot_seq(void);
+    char path[512];
+    if (!json_get_str(json, "path", path, sizeof(path)))
+        strncpy(path, "psx_present_shot.png", sizeof(path) - 1);
+    path[sizeof(path) - 1] = '\0';
+    if (!present_shot_request(path)) {
+        send_err(id, "present_shot unavailable (headless, or the Vulkan backend "
+                     "which has no present readback)");
+        return;
+    }
+    send_fmt("{\"id\":%d,\"ok\":true,\"path\":\"%s\",\"staged\":true,\"seq\":%d}",
+             id, path, present_shot_seq());
+}
+
+/* present_shot_seq — completion counter for the staged capture above. Sample it
+ * before present_shot and poll until it changes; the counter advances on every
+ * completion, success or not, so the poll always terminates. `wrote` reports
+ * whether that completion actually produced a PNG. */
+static void handle_present_shot_seq(int id, const char *json)
+{
+    extern int present_shot_seq(void);
+    extern int present_shot_ok(void);
+    (void)json;
+    send_fmt("{\"id\":%d,\"ok\":true,\"seq\":%d,\"wrote\":%d}",
+             id, present_shot_seq(), present_shot_ok());
 }
 
 /* dump_buffer: dump a raw 512x240 VRAM region starting at display Y = `y` to a
@@ -13619,6 +13681,8 @@ static const CmdEntry s_commands[] = {
     { "screenshot",        handle_present_screenshot },
     { "screenshot_file",   handle_screenshot_file },
     { "screenshot_hires",  handle_screenshot_hires },
+    { "present_shot",      handle_present_shot },
+    { "present_shot_seq",  handle_present_shot_seq },
     { "display_ring_get",  handle_display_ring_get },
     { "display_ring_aux",  handle_display_ring_aux },
     { "display_ring_stats", handle_display_ring_stats },

--- a/runtime/src/debug_server.c
+++ b/runtime/src/debug_server.c
@@ -7848,6 +7848,31 @@ static void handle_ws_backdrop_ring(int id, const char *json)
     free(buf);
 }
 
+/* ws_ui_groups: dump the auto_ui_squash partition for the last UI prepass —
+ * per primitive its op / key / raw key inputs (y, h, derived band and family) /
+ * union-find root / final anchor.
+ *
+ * auto_ui_squash squashes each spatial run about its own anchor, so a HUD
+ * element split across two runs gets two anchors and comes apart as the frame
+ * widens (elements drifting to opposite edges, glyphs sliding off their
+ * background box). Diagnosing that needed to know which run each primitive
+ * landed in, and nothing exposed it: `key` is a hash, so unequal keys do not
+ * say WHICH of CLUT/texpage/band/family differed, and `anchor` takes only three
+ * values, so equal anchors do not prove two prims actually co-grouped.
+ * Read-only; sized for the 2048-entry prepass cap. */
+static void handle_ws_ui_groups(int id, const char *json)
+{
+    (void)json;
+    size_t cap = 1u << 19;                 /* 512 KB: 2048 items * ~180 chars */
+    char *buf = (char *)malloc(cap);
+    if (!buf) { send_err(id, "alloc failed"); return; }
+    int hdr  = snprintf(buf, cap, "{\"id\":%d,\"ok\":true,", id);
+    int body = psx_ws_ui_groups_json(buf + hdr, (int)cap - hdr - 4);
+    snprintf(buf + hdr + body, cap - (size_t)(hdr + body), "}");
+    debug_server_send_line(buf);
+    free(buf);
+}
+
 /* ws_backdrop_margin [m=<N>]: live-tune the far-backdrop widen strategy without
  * a rebuild. m<0 = whole-row preload, m=0 = off, m>0 = widen N columns each side.
  * No m= just reports the current value. */
@@ -13493,6 +13518,7 @@ static const CmdEntry s_commands[] = {
     { "ws_aspect",         handle_ws_aspect },
     { "ws_nw",             handle_ws_nw },
     { "ws_backdrop_ring",  handle_ws_backdrop_ring },
+    { "ws_ui_groups",      handle_ws_ui_groups },
     { "ws_backdrop_margin", handle_ws_backdrop_margin },
     { "ws_backdrop_stretch", handle_ws_backdrop_stretch },
     { "ws_dbg_stretch",    handle_ws_dbg_stretch },

--- a/runtime/src/dirty_ram_interp.c
+++ b/runtime/src/dirty_ram_interp.c
@@ -2867,6 +2867,16 @@ static int dirty_ram_dispatch_inner(CPUState* cpu, uint32_t addr, uint32_t stop_
      * pages overwritten by a runtime overlay (Tomba 2), not just [FLOOR, RAM). */
     int allow_local_dirty_flow = phys_is_overlay_flow_region(phys);
 
+    /* Backend-invariant mod_function_entry hooks: generated code fires
+     * psx_mod_function_entry at listed function entries, but a mod-patched
+     * page runs here instead and would silently skip them. Fire the same hook
+     * on interp dispatch so the contract does not depend on which backend
+     * executes the page. */
+    {
+        extern void psx_mod_function_entry(CPUState *cpu, uint32_t address);
+        psx_mod_function_entry(cpu, addr);
+    }
+
     /* Per-PC entry counter (visible via dirty_ram_stats). */
     DirtyRamPcEntry *pc_entry = pc_table_get_or_insert(phys);
     if (pc_entry) pc_entry->hits++;

--- a/runtime/src/fntrace.c
+++ b/runtime/src/fntrace.c
@@ -71,7 +71,19 @@ void fntrace_mark_game_started(CPUState* cpu) {
 void fntrace_maybe_mark_game_started(CPUState* cpu, uint32_t addr) {
     if (s_game_started) return;
     if (s_game_entry_phys == 0) return;   /* no game range armed */
-    if ((addr & 0x1FFFFFFFu) == s_game_entry_phys)
+    /* The dirty-RAM interpreter path may miss the exact PS-X EXE entry when
+     * the BIOS or loader enters game text through already-interpreted flow.
+     * Mirror fntrace_record's safe fallback: only latch on other game-text
+     * addresses when a reference image exists and live RAM already matches it.
+     * Without that guard, relocated BIOS shell RAM can look like game RAM and
+     * a premature handoff corrupts boot. */
+    extern int psx_game_address_in_text(uint32_t addr);
+    extern int psx_game_text_native_ok(uint32_t addr);
+    extern int dirty_ram_text_image_registered(void);
+    uint32_t phys = addr & 0x1FFFFFFFu;
+    if (phys == s_game_entry_phys ||
+        (dirty_ram_text_image_registered() &&
+         psx_game_address_in_text(addr) && psx_game_text_native_ok(addr)))
         fntrace_mark_game_started(cpu);
 }
 
@@ -208,15 +220,7 @@ void fntrace_record(CPUState* cpu, uint32_t target) {
          * latching game-start before the EXE has loaded and clearing the dirty
          * baseline mid-load (the v0.0.2/v0.0.3 release-install boot crash).
          * Without an image, only the exact entry_pc dispatch may latch. */
-        extern int psx_game_address_in_text(uint32_t addr);
-        extern int psx_game_text_native_ok(uint32_t addr);
-        extern int dirty_ram_text_image_registered(void);
-        uint32_t _tphys = target & 0x1FFFFFFFu;
-        if (_tphys == s_game_entry_phys ||
-            (dirty_ram_text_image_registered() &&
-             psx_game_address_in_text(target) && psx_game_text_native_ok(target))) {
-            fntrace_mark_game_started(cpu);
-        }
+        fntrace_maybe_mark_game_started(cpu, target);
     }
     /* Honor the one-shot capture freeze (insn_freeze): once latched, the ring
      * preserves the pre-divergence window instead of evicting it. */

--- a/runtime/src/gpu.c
+++ b/runtime/src/gpu.c
@@ -125,6 +125,16 @@ static struct {
     uint32_t rank;        /* admitted, then dropped by the max_rank filter */
 } ws_ui_reject;
 
+/* Geometry of the primitives the max_rank filter discarded. A count alone
+ * cannot say whether those are stray world geometry (fine to drop) or HUD
+ * marks belonging to a cluster that IS being squashed (not fine -- they are
+ * left behind at their 4:3 X). Small fixed ring; the filter typically drops a
+ * handful. */
+#define WS_UI_RANKDROP_MAX 8
+static struct { int32_t x, y, w, h; uint16_t rank; uint8_t op; }
+    ws_ui_rankdrop[WS_UI_RANKDROP_MAX];
+static uint32_t ws_ui_rankdrop_count;
+
 /* Wide-aspect mode: 0 = off (4:3 identity), 1 = squash (legacy hack — compress
  * a wider FOV into the 320 frame, present stretched), 2 = native-wide (render
  * the wider FOV into an actually wider frame and present 1:1; the GTE is NOT
@@ -1630,13 +1640,22 @@ int psx_ws_ui_groups_json(char *buf, int cap) {
         "\"disp_x\":%d,\"disp_w\":%d,\"join_gap\":%d,"
         "\"rejected\":{\"opcode\":%u,\"not_axis\":%u,\"degenerate\":%u,"
         "\"too_big\":%u,\"cap\":%u,\"rank\":%u},"
-        "\"n\":%u,\"items\":[",
+        "\"n\":%u,",
         ws_active(), ws_auto_ui_squash, ws_auto_ui_dense,
         ws_ui_prepass_rank != 0xFFFFu ? (int)ws_ui_prepass_rank : -1,
         ws_disp_x(), ws_disp_w(), WS_UI_GROUP_JOIN_GAP,
         ws_ui_reject.opcode, ws_ui_reject.not_axis, ws_ui_reject.degenerate,
         ws_ui_reject.too_big, ws_ui_reject.cap, ws_ui_reject.rank,
         ws_ui_prepass_count);
+    off += snprintf(buf + off, (size_t)(cap - off), "\"rank_dropped\":[");
+    for (uint32_t i = 0; i < ws_ui_rankdrop_count && off < cap - 120; i++) {
+        off += snprintf(buf + off, (size_t)(cap - off),
+            "%s{\"op\":\"%02x\",\"rank\":%u,\"x\":%d,\"w\":%d,\"y\":%d,\"h\":%d}",
+            i ? "," : "", ws_ui_rankdrop[i].op, ws_ui_rankdrop[i].rank,
+            ws_ui_rankdrop[i].x, ws_ui_rankdrop[i].w,
+            ws_ui_rankdrop[i].y, ws_ui_rankdrop[i].h);
+    }
+    off += snprintf(buf + off, (size_t)(cap - off), "],\"items\":[");
     for (uint32_t i = 0; i < ws_ui_prepass_count && off < cap - 220; i++) {
         const WsUiPrepassItem *it = &ws_ui_prepass[i];
         /* Recover the key components so a split is attributable. Mirrors
@@ -4043,6 +4062,16 @@ static void gp0_exec_mono_rect(void) {
     if (w > 1023) w = 1023;
     if (h > 511)  h = 511;
     ws_expand_fullscreen_rect(&x0, y0, &w, h);
+    /* Same auto_ui squash the textured rect path gets. Without it a flat
+     * -coloured HUD mark keeps its 4:3 X while the textured primitives of the
+     * same widget move toward their anchor, so at a wide aspect it is left
+     * behind in open screen. Untouched when the prepass did not admit this
+     * primitive, and rects never carry GTE output. */
+    if (ws_active() && w > 0) {
+        int corrected_w = w;
+        if (ws_auto_ui_transform_rect(&x0, y0, &corrected_w, h))
+            w = corrected_w;
+    }
     x0 += ws_nw_hud_shift(x0, w);   /* native-wide HUD corner re-anchor (no-op else) */
     x0 += draw_offset_x; y0 += draw_offset_y;
     if (draw_area_out_rect(x0, y0, w, h)) return;
@@ -4107,6 +4136,7 @@ static void gp0_exec_mono_dot(void) {
     uint16_t color = rgb888_to_rgb555(gp0_cmd_buf[0] & 0xFFFFFFu);
     int32_t x, y;
     parse_vertex(gp0_cmd_buf[1], &x, &y);
+    ws_sprt_fixed_transform(&x, y, 1);   /* auto_ui squash; no-op when unadmitted */
     x += ws_nw_hud_shift(x, 1);
     x += draw_offset_x; y += draw_offset_y;
     if (draw_area_out_point(x, y)) return;
@@ -4148,11 +4178,15 @@ static void gp0_exec_mono_8x8(void) {
     uint16_t color = rgb888_to_rgb555(gp0_cmd_buf[0] & 0xFFFFFFu);
     int32_t x0, y0;
     parse_vertex(gp0_cmd_buf[1], &x0, &y0);
+    int ws_w = ws_sprt_fixed_transform(&x0, y0, 8);
     x0 += ws_nw_hud_shift(x0, 8);
     x0 += draw_offset_x; y0 += draw_offset_y;
-    if (draw_area_out_rect(x0, y0, 8, 8)) return;
-    gr_set_semi_transparency(semi_trans, (int)semi_transparency);
-    gr_draw_flat_rect(x0, y0, 8, 8, color);
+    {
+        int dw = (ws_w && ws_w != 8) ? ws_w : 8;
+        if (draw_area_out_rect(x0, y0, dw, 8)) return;
+        gr_set_semi_transparency(semi_trans, (int)semi_transparency);
+        gr_draw_flat_rect(x0, y0, dw, 8, color);
+    }
 }
 
 /* Execute 16x16 textured sprite (GP0 0x7C-0x7F) */
@@ -4589,16 +4623,35 @@ static void ws_ui_prepass_add(const uint32_t *words, uint32_t source_addr,
             if (vy[i] < min_y) min_y = vy[i];
             if (vy[i] > max_y) max_y = vy[i];
         }
-    } else if ((op >= 0x64u && op <= 0x67u) ||
-               (op >= 0x74u && op <= 0x77u) ||
-               (op >= 0x7Cu && op <= 0x7Fu)) {
+    } else if (op >= 0x60u && op <= 0x7Fu) {
+        /* GP0 rectangle / sprite. Bits 4-3 select the size (00 variable,
+         * 01 1x1, 10 8x8, 11 16x16) and bit 2 whether it is textured.
+         *
+         * Only the TEXTURED families used to be admitted here, which silently
+         * dropped every flat-coloured HUD mark. Those then kept their raw 4:3
+         * X while the textured primitives beside them were squashed toward an
+         * anchor -- so at a wide aspect they were left stranded in open screen,
+         * to the left of the cluster they belong to. A GP0 rectangle is always
+         * screen-space and never carries GTE output, so admitting the whole
+         * range cannot reach world geometry. */
+        const unsigned size_sel = (op >> 3) & 3u;
+        const int textured = (op >> 2) & 1;
         parse_vertex(words[1], &min_x, &min_y);
         int32_t width, height;
-        if (op >= 0x64u && op <= 0x67u) {
-            width = (int32_t)(words[3] & 0x3FFu);
-            height = (int32_t)((words[3] >> 16) & 0x1FFu);
+        if (size_sel == 0u) {
+            if (textured) {
+                width  = (int32_t)(words[3] & 0x3FFu);
+                height = (int32_t)((words[3] >> 16) & 0x1FFu);
+            } else {
+                /* Mirrors gp0_exec_mono_rect: the full 16-bit field, then
+                 * clamped to the hardware maximum. */
+                width  = (int32_t)(words[2] & 0xFFFFu);
+                height = (int32_t)((words[2] >> 16) & 0xFFFFu);
+                if (width > 1023) width = 1023;
+                if (height > 511)  height = 511;
+            }
         } else {
-            width = height = op >= 0x7Cu ? 16 : 8;
+            width = height = size_sel == 1u ? 1 : (size_sel == 2u ? 8 : 16);
         }
         if (width <= 0 || height <= 0) { ws_ui_reject.degenerate++; return; }
         max_x = min_x + width;
@@ -4638,6 +4691,7 @@ void gpu_ws_prepass_linked_list(uint32_t start_addr) {
     ws_auto_ui_dense = 0;
     ws_ui_reject.opcode = ws_ui_reject.not_axis = ws_ui_reject.degenerate =
         ws_ui_reject.too_big = ws_ui_reject.cap = ws_ui_reject.rank = 0;
+    ws_ui_rankdrop_count = 0;
     if (!ws_auto_ui_squash || !ws_active()) return;
 
     uint32_t addr = psx_mod_gpu_dma_resolve_address(start_addr);
@@ -4704,8 +4758,18 @@ void gpu_ws_prepass_linked_list(uint32_t start_addr) {
 
     uint32_t out = 0;
     for (uint32_t i = 0; i < ws_ui_prepass_count; i++) {
-        if (ws_ui_prepass[i].ot_rank == max_rank)
+        if (ws_ui_prepass[i].ot_rank == max_rank) {
             ws_ui_prepass[out++] = ws_ui_prepass[i];
+        } else if (ws_ui_rankdrop_count < WS_UI_RANKDROP_MAX) {
+            const WsUiPrepassItem *it = &ws_ui_prepass[i];
+            ws_ui_rankdrop[ws_ui_rankdrop_count].x    = it->group.x;
+            ws_ui_rankdrop[ws_ui_rankdrop_count].w    = it->group.width;
+            ws_ui_rankdrop[ws_ui_rankdrop_count].y    = it->y;
+            ws_ui_rankdrop[ws_ui_rankdrop_count].h    = it->h;
+            ws_ui_rankdrop[ws_ui_rankdrop_count].rank = it->ot_rank;
+            ws_ui_rankdrop[ws_ui_rankdrop_count].op   = it->op;
+            ws_ui_rankdrop_count++;
+        }
     }
     ws_ui_reject.rank = ws_ui_prepass_count - out;
     ws_ui_prepass_count = out;
@@ -5116,9 +5180,12 @@ static void gp0_execute_command(void) {
             uint16_t color = rgb888_to_rgb555(gp0_cmd_buf[0] & 0xFFFFFFu);
             int32_t x0, y0;
             parse_vertex(gp0_cmd_buf[1], &x0, &y0);
+            int ws_w = ws_sprt_fixed_transform(&x0, y0, 16);
+            x0 += ws_nw_hud_shift(x0, 16);
             x0 += draw_offset_x; y0 += draw_offset_y;
             gr_set_semi_transparency(semi_trans, (int)semi_transparency);
-            gr_draw_flat_rect(x0, y0, 16, 16, color);
+            gr_draw_flat_rect(x0, y0, (ws_w && ws_w != 16) ? ws_w : 16, 16,
+                              color);
             break;
         }
         case 0x7C: case 0x7D: case 0x7E: case 0x7F:

--- a/runtime/src/gpu.c
+++ b/runtime/src/gpu.c
@@ -107,6 +107,24 @@ static WsUiPrepassItem ws_ui_prepass[WS_UI_PREPASS_MAX];
 static uint32_t ws_ui_prepass_count;
 static uint16_t ws_ui_prepass_rank = 0xFFFFu;
 
+/* Why a UI-looking primitive did NOT reach the squash partition.
+ *
+ * Every rejection here leaves a primitive at its raw 4:3 X while the cluster
+ * around it is squashed toward an anchor -- which is precisely how a HUD mark
+ * ends up stranded in open screen at a wide aspect. The gates are silent
+ * `return`s, so a stranded primitive is indistinguishable from one that was
+ * never drawn at all. These counters let ws_ui_groups name the responsible gate
+ * from a capture instead of it being guessed at. Diagnostic only; nothing in
+ * the transform path reads them. */
+static struct {
+    uint32_t opcode;      /* not in the textured quad / rect families      */
+    uint32_t not_axis;    /* textured quad, but not axis-aligned           */
+    uint32_t degenerate;  /* zero or negative extent                       */
+    uint32_t too_big;     /* full-screen or large-primitive reject         */
+    uint32_t cap;         /* WS_UI_PREPASS_MAX reached                     */
+    uint32_t rank;        /* admitted, then dropped by the max_rank filter */
+} ws_ui_reject;
+
 /* Wide-aspect mode: 0 = off (4:3 identity), 1 = squash (legacy hack — compress
  * a wider FOV into the 320 frame, present stretched), 2 = native-wide (render
  * the wider FOV into an actually wider frame and present 1:1; the GTE is NOT
@@ -1609,10 +1627,16 @@ int psx_ws_backdrop_ring_json(char *buf, int cap) {
 int psx_ws_ui_groups_json(char *buf, int cap) {
     int off = snprintf(buf, (size_t)cap,
         "\"active\":%d,\"squash\":%d,\"dense\":%d,\"rank\":%d,"
-        "\"disp_x\":%d,\"disp_w\":%d,\"join_gap\":%d,\"n\":%u,\"items\":[",
+        "\"disp_x\":%d,\"disp_w\":%d,\"join_gap\":%d,"
+        "\"rejected\":{\"opcode\":%u,\"not_axis\":%u,\"degenerate\":%u,"
+        "\"too_big\":%u,\"cap\":%u,\"rank\":%u},"
+        "\"n\":%u,\"items\":[",
         ws_active(), ws_auto_ui_squash, ws_auto_ui_dense,
         ws_ui_prepass_rank != 0xFFFFu ? (int)ws_ui_prepass_rank : -1,
-        ws_disp_x(), ws_disp_w(), WS_UI_GROUP_JOIN_GAP, ws_ui_prepass_count);
+        ws_disp_x(), ws_disp_w(), WS_UI_GROUP_JOIN_GAP,
+        ws_ui_reject.opcode, ws_ui_reject.not_axis, ws_ui_reject.degenerate,
+        ws_ui_reject.too_big, ws_ui_reject.cap, ws_ui_reject.rank,
+        ws_ui_prepass_count);
     for (uint32_t i = 0; i < ws_ui_prepass_count && off < cap - 220; i++) {
         const WsUiPrepassItem *it = &ws_ui_prepass[i];
         /* Recover the key components so a split is attributable. Mirrors
@@ -3299,26 +3323,57 @@ static void prepare_precise_triangle(int i0, int i1, int i2,
     gr_set_precise_triangle(1, fx[0],fy[0], fx[1],fy[1], fx[2],fy[2]);
 }
 
+/* Arming rate for perspective-correct UVs, per condition.
+ *
+ * perspective_triangles alone cannot answer "how much texture warp is left",
+ * because it has no denominator: comparing it to gp0_draw mixes in untextured
+ * mono and gouraud primitives that are correctly never armed, and comparing it
+ * to a vertex-lookup count divided by three is the same error. `attempts`
+ * counts exactly the textured triangles that reach this predicate, so
+ * armed/attempts IS the perspective coverage, and the three reject counters
+ * say which condition is spending it. Diagnostic only. */
+static struct {
+    uint64_t attempts;      /* textured triangles submitted                 */
+    uint64_t armed;         /* got perspective-correct UVs                  */
+    uint64_t no_correction; /* texture correction off                       */
+    uint64_t no_source;     /* CPU-built primitive, no packet address       */
+    uint64_t no_depth;      /* a vertex had no recorded Z, or Z == 0        */
+} s_texcorr;
+
+void gpu_texture_correction_stats(uint64_t *attempts, uint64_t *armed,
+                                  uint64_t *no_correction,
+                                  uint64_t *no_source, uint64_t *no_depth) {
+    if (attempts)      *attempts      = s_texcorr.attempts;
+    if (armed)         *armed         = s_texcorr.armed;
+    if (no_correction) *no_correction = s_texcorr.no_correction;
+    if (no_source)     *no_source     = s_texcorr.no_source;
+    if (no_depth)      *no_depth      = s_texcorr.no_depth;
+}
+
 /* Enable perspective UVs only when every position word came from an exact
  * SWC2 projection store at that same DMA packet address. This preserves the
  * association through ordering-table reordering and rejects CPU-built UI. */
 static void prepare_texture_triangle(int i0, int i1, int i2) {
     gr_set_perspective_triangle(0, 0.0f, 0.0f, 0.0f);
-    if (!s_texture_correction_enabled || gp0_cmd_source_addr == 0xFFFFFFFFu)
-        return;
+    s_texcorr.attempts++;
+    if (!s_texture_correction_enabled) { s_texcorr.no_correction++; return; }
+    if (gp0_cmd_source_addr == 0xFFFFFFFFu) { s_texcorr.no_source++; return; }
     int indices[3] = { i0, i1, i2 };
     uint16_t z[3];
     for (int i = 0; i < 3; i++) {
         uint32_t addr = (gp0_cmd_source_addr + (uint32_t)indices[i] * 4u) & 0x1FFFFCu;
         if (!gte_precision_load_word(addr, gp0_cmd_buf[indices[i]], NULL, NULL, &z[i]) ||
-            z[i] == 0)
+            z[i] == 0) {
+            s_texcorr.no_depth++;
             return;
+        }
     }
     float q[3] = { 1.0f / (float)z[0], 1.0f / (float)z[1], 1.0f / (float)z[2] };
     float qmax = q[0];
     if (q[1] > qmax) qmax = q[1];
     if (q[2] > qmax) qmax = q[2];
-    if (qmax <= 0.0f) return;
+    if (qmax <= 0.0f) { s_texcorr.no_depth++; return; }
+    s_texcorr.armed++;
     gr_set_perspective_triangle(1, q[0] / qmax, q[1] / qmax, q[2] / qmax);
 }
 
@@ -4508,8 +4563,8 @@ static int gp0_command_word_count(uint8_t opcode) {
 
 static void ws_ui_prepass_add(const uint32_t *words, uint32_t source_addr,
                               uint16_t rank) {
-    if (ws_ui_prepass_count >= WS_UI_PREPASS_MAX || rank == 0xFFFFu)
-        return;
+    if (rank == 0xFFFFu) return;
+    if (ws_ui_prepass_count >= WS_UI_PREPASS_MAX) { ws_ui_reject.cap++; return; }
     uint32_t op = words[0] >> 24;
     int32_t min_x, max_x, min_y, max_y;
 
@@ -4526,7 +4581,7 @@ static void ws_ui_prepass_add(const uint32_t *words, uint32_t source_addr,
         int32_t vx[4], vy[4];
         for (int i = 0; i < 4; i++)
             parse_vertex(words[indices[i]], &vx[i], &vy[i]);
-        if (!ws_axis_aligned_quad(vx, vy)) return;
+        if (!ws_axis_aligned_quad(vx, vy)) { ws_ui_reject.not_axis++; return; }
         min_x = max_x = vx[0]; min_y = max_y = vy[0];
         for (int i = 1; i < 4; i++) {
             if (vx[i] < min_x) min_x = vx[i];
@@ -4545,18 +4600,21 @@ static void ws_ui_prepass_add(const uint32_t *words, uint32_t source_addr,
         } else {
             width = height = op >= 0x7Cu ? 16 : 8;
         }
-        if (width <= 0 || height <= 0) return;
+        if (width <= 0 || height <= 0) { ws_ui_reject.degenerate++; return; }
         max_x = min_x + width;
         max_y = min_y + height;
     } else {
+        ws_ui_reject.opcode++;
         return;
     }
 
     int32_t width = max_x - min_x, height = max_y - min_y;
     int32_t X = ws_disp_x(), W = ws_disp_w(), H = ws_disp_h();
     if ((min_x <= X && max_x >= X + W && min_y <= 0 && max_y >= H) ||
-        (width > W / 2 && height > H / 4))
+        (width > W / 2 && height > H / 4)) {
+        ws_ui_reject.too_big++;
         return;
+    }
 
     WsUiPrepassItem *item = &ws_ui_prepass[ws_ui_prepass_count++];
     item->group.key =
@@ -4578,6 +4636,8 @@ void gpu_ws_prepass_linked_list(uint32_t start_addr) {
     ws_ui_prepass_count = 0;
     ws_ui_prepass_rank = 0xFFFFu;
     ws_auto_ui_dense = 0;
+    ws_ui_reject.opcode = ws_ui_reject.not_axis = ws_ui_reject.degenerate =
+        ws_ui_reject.too_big = ws_ui_reject.cap = ws_ui_reject.rank = 0;
     if (!ws_auto_ui_squash || !ws_active()) return;
 
     uint32_t addr = psx_mod_gpu_dma_resolve_address(start_addr);
@@ -4647,6 +4707,7 @@ void gpu_ws_prepass_linked_list(uint32_t start_addr) {
         if (ws_ui_prepass[i].ot_rank == max_rank)
             ws_ui_prepass[out++] = ws_ui_prepass[i];
     }
+    ws_ui_reject.rank = ws_ui_prepass_count - out;
     ws_ui_prepass_count = out;
     /*
      * A high final-layer primitive count is a good "dense 2D menu" signal for

--- a/runtime/src/gpu.c
+++ b/runtime/src/gpu.c
@@ -4563,6 +4563,8 @@ static void ws_ui_prepass_add(const uint32_t *words, uint32_t source_addr,
         ws_auto_ui_group_key_words(words, op, min_y, height);
     item->group.x = min_x - X;
     item->group.width = width;
+    item->group.y = min_y;
+    item->group.height = height;
     item->group.anchor = 0;
     item->group.root = ws_ui_prepass_count - 1u;
     item->src_addr = source_addr & 0x1FFFFCu;

--- a/runtime/src/gpu.c
+++ b/runtime/src/gpu.c
@@ -95,6 +95,13 @@ typedef struct {
     WsUiGroupItem group;
     uint32_t src_addr;
     uint16_t ot_rank;
+    /* Diagnostic only (ws_ui_groups): the key is a hash, so a dump of keys
+     * alone says two prims differ without saying WHICH component differed.
+     * Keep the raw inputs so an observer can attribute a split to the CLUT,
+     * the texpage, the 24px Y band, or the poly-vs-rect family. */
+    int32_t  y;
+    int32_t  h;
+    uint8_t  op;
 } WsUiPrepassItem;
 static WsUiPrepassItem ws_ui_prepass[WS_UI_PREPASS_MAX];
 static uint32_t ws_ui_prepass_count;
@@ -1583,6 +1590,43 @@ int psx_ws_backdrop_ring_json(char *buf, int cap) {
             i ? "," : "", e->frame, e->pc, e->kind, e->wcols,
             (int)(int16_t)e->orig, (int)(int16_t)e->finalv, e->extent, e->camx, e->count,
             e->base, e->dl);
+    }
+    off += snprintf(buf + off, (size_t)(cap - off), "]");
+    return off;
+}
+
+/* ws_ui_groups — dump the auto_ui_squash partition for the LAST prepass.
+ *
+ * auto_ui_squash squashes each spatial run about its own anchor, so a HUD
+ * element that lands in two runs gets two anchors and comes apart as the frame
+ * widens. Nothing exposed which run a primitive ended up in, which made that
+ * failure mode guesswork: the key is a hash of CLUT/texpage/Y-band/family, so
+ * comparing keys tells you two prims differ without telling you why, and the
+ * anchor takes only three values so anchor equality cannot prove co-grouping.
+ *
+ * This reports both the raw key inputs and the union-find root, which together
+ * answer "did these two merge, and if not, which component split them". */
+int psx_ws_ui_groups_json(char *buf, int cap) {
+    int off = snprintf(buf, (size_t)cap,
+        "\"active\":%d,\"squash\":%d,\"dense\":%d,\"rank\":%d,"
+        "\"disp_x\":%d,\"disp_w\":%d,\"join_gap\":%d,\"n\":%u,\"items\":[",
+        ws_active(), ws_auto_ui_squash, ws_auto_ui_dense,
+        ws_ui_prepass_rank != 0xFFFFu ? (int)ws_ui_prepass_rank : -1,
+        ws_disp_x(), ws_disp_w(), WS_UI_GROUP_JOIN_GAP, ws_ui_prepass_count);
+    for (uint32_t i = 0; i < ws_ui_prepass_count && off < cap - 220; i++) {
+        const WsUiPrepassItem *it = &ws_ui_prepass[i];
+        /* Recover the key components so a split is attributable. Mirrors
+         * ws_auto_ui_group_key_words; kept in step with it by construction. */
+        int32_t centre_y = it->y + it->h / 2;
+        unsigned band = (unsigned)((centre_y < 0 ? 0 : centre_y / 24) & 0x1F);
+        unsigned family = it->op < 0x60u ? 1u : 2u;
+        off += snprintf(buf + off, (size_t)(cap - off),
+            "%s{\"i\":%u,\"op\":\"%02x\",\"key\":\"%08x\",\"root\":%u,"
+            "\"x\":%d,\"w\":%d,\"y\":%d,\"h\":%d,"
+            "\"band\":%u,\"family\":%u,\"anchor\":%d,\"src\":\"%08x\"}",
+            i ? "," : "", i, it->op, it->group.key, it->group.root,
+            it->group.x, it->group.width, it->y, it->h,
+            band, family, it->group.anchor, it->src_addr);
     }
     off += snprintf(buf + off, (size_t)(cap - off), "]");
     return off;
@@ -4520,8 +4564,12 @@ static void ws_ui_prepass_add(const uint32_t *words, uint32_t source_addr,
     item->group.x = min_x - X;
     item->group.width = width;
     item->group.anchor = 0;
+    item->group.root = ws_ui_prepass_count - 1u;
     item->src_addr = source_addr & 0x1FFFFCu;
     item->ot_rank = rank;
+    item->y  = min_y;
+    item->h  = height;
+    item->op = (uint8_t)op;
 }
 
 void gpu_ws_prepass_linked_list(uint32_t start_addr) {

--- a/runtime/src/gpu_gl_renderer.c
+++ b/runtime/src/gpu_gl_renderer.c
@@ -85,6 +85,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include "png_write.h"   /* png_write_rgb — present_shot readback */
 
 #ifndef GL_BGRA
 #define GL_BGRA 0x80E1
@@ -3981,6 +3982,42 @@ static void gl_swap_with_osd(void) {
         }
     }
     host_osd_present_done();
+    /* present_shot (GL backend): the default framebuffer now holds the composed
+     * frame — display quad fitted to the window, plus OSD — so this is the only
+     * capture that carries the presented aspect. Buffer-level captures resolve
+     * before the fit and answer the raw display size instead. Read back before
+     * the swap; GL rows come out bottom-up, so flip into the PNG. */
+    {
+        extern int  present_shot_take(char *out, int n);
+        extern void present_shot_done(int ok);
+        char shot_path[512];
+        if (present_shot_take(shot_path, (int)sizeof(shot_path))) {
+            int ww = 0, wh = 0;
+            int wrote = 0;
+            SDL_GL_GetDrawableSize(s_win, &ww, &wh);
+            if (ww > 0 && wh > 0) {
+                uint8_t *rows = (uint8_t *)malloc((size_t)ww * wh * 3);
+                uint8_t *flip = rows ? (uint8_t *)malloc((size_t)ww * wh * 3) : NULL;
+                if (rows && flip) {
+                    glPixelStorei(GL_PACK_ALIGNMENT, 1);
+                    glReadPixels(0, 0, ww, wh, GL_RGB, GL_UNSIGNED_BYTE, rows);
+                    for (int y = 0; y < wh; y++)
+                        memcpy(flip + (size_t)y * ww * 3,
+                               rows + (size_t)(wh - 1 - y) * ww * 3,
+                               (size_t)ww * 3);
+                    FILE *pf = fopen(shot_path, "wb");
+                    if (pf) {
+                        wrote = png_write_rgb(pf, flip, (uint32_t)ww, (uint32_t)wh);
+                        fclose(pf);
+                    }
+                }
+                /* free() tolerates NULL, so both exits are covered. */
+                free(flip);
+                free(rows);
+            }
+            present_shot_done(wrote);
+        }
+    }
     SDL_GL_SwapWindow(s_win);
 }
 

--- a/runtime/src/main.cpp
+++ b/runtime/src/main.cpp
@@ -25,6 +25,7 @@
 #include "psx_savestate_menu.h"
 #include "host_osd.h"
 #include "host_keymap.h"
+#include "png_write.h"       /* png_write_rgb — present_shot readback */
 #include "overlay_capture.h"
 #include "overlay_loader.h"
 #include "autocompile.h"
@@ -114,6 +115,7 @@ extern "C" void psx_game_codegen_forward_if_built(int argc, char** argv);
 #endif
 #include <algorithm>
 #include <atomic>
+#include <mutex>
 #include <thread>
 #include <cctype>
 #include <cmath>
@@ -438,6 +440,7 @@ static bool     s_force_present_after_load = false;
 static int s_sw_hold_valid = 0;
 static SDL_Rect s_sw_hold_src;
 static SDL_Rect s_sw_hold_dst;
+
 /* After LOADED: optional freeze probe (PSX_POST_LOAD_PROBE=1). Off by default. */
 static int      s_post_load_probe_enabled = -1; /* -1 = unread env */
 static int      s_post_load_probe_left = 0;
@@ -1167,6 +1170,7 @@ static int           g_hotkey_pad_save_state_menu = 2040;/* select + r1 */
 static uint32_t      g_savestate_input_guard_min_until = 0;
 static uint32_t      g_savestate_input_guard_max_until = 0;
 static int           g_headless       = 0;   /* debug/CI frontend: no SDL window/audio */
+
 /* FMV instant-skip via the game's OWN end-of-movie path. Tomba's MDEC player
  * (FUN_8001efe8) tears a movie down when the streamed frame number reaches that
  * movie's per-movie total minus 3; writing the current movie's total down to
@@ -1708,6 +1712,77 @@ extern "C" int psx_ws_get_native_wide(void) { return g_ws_native_wide; }
 
 static bool          g_gl_active = false;    /* GL context live -> GL present path */
 static bool          g_vk_active = false;    /* Vulkan context live -> VK present path */
+
+/* present_shot — capture the COMPOSED present surface, i.e. the frame after the
+ * backend has fitted the display buffer to the window, so the PNG carries the
+ * aspect the player is actually looking at.
+ *
+ * screenshot / screenshot_file / screenshot_hires all resolve the display
+ * buffer BEFORE that fit: on a 508x256 display in a 4:3 window they answer
+ * 508x256 while the window shows 640x480. Correct for faithfulness work, wrong
+ * for anything aspect-shaped — a widescreen change moves the GTE squash and the
+ * present fit, which is exactly the stage those captures skip.
+ *
+ * Staged here and fulfilled by whichever backend owns the present: the SDL
+ * software path reads back via SDL_RenderReadPixels, the GL path via
+ * glReadPixels before SwapWindow (gpu_gl_renderer.c).
+ *
+ * THREADING: the request is written from a debug-server command handler on the
+ * emu thread (debug_server_poll safe point), but GL fulfilment can run on the
+ * frame-interpolation thread (gpu_gl_renderer.c interp_present -> gl_swap_with_osd),
+ * so the path buffer and the pending flag are mutex-guarded and the counters are
+ * atomic. present_shot_take() CLAIMS the request under the lock, so two present
+ * paths can never fulfil the same shot.
+ *
+ * A staged shot is OVERWRITTEN by a later request rather than refused (the same
+ * choice savestate's request_save_inner makes). A present that never arrives —
+ * a static frame, a backend that stops presenting — therefore cannot wedge the
+ * command: the next request simply replaces it. */
+static std::mutex       s_present_shot_mtx;
+static char             s_present_shot_path[512];
+static bool             s_present_shot_pending = false;
+static std::atomic<int> s_present_shot_seq{0};   /* bumps on every completion */
+static std::atomic<int> s_present_shot_ok{0};    /* 1 = last completion wrote a PNG */
+
+extern "C" int present_shot_request(const char *path)
+{
+    if (!path || !*path) return 0;
+    if (g_headless)  return 0;   /* no present surface to read back */
+    /* Vulkan owns its own swapchain present (see the g_vk_active branch in
+     * sdl_vblank_present_body) and has no readback hook, so nothing would ever
+     * fulfil the request. Refuse honestly instead of accepting a shot that can
+     * never complete — CLAUDE.md rule 15. */
+    if (g_vk_active) return 0;
+    {
+        std::lock_guard<std::mutex> lk(s_present_shot_mtx);
+        std::snprintf(s_present_shot_path, sizeof(s_present_shot_path), "%s", path);
+        s_present_shot_pending = true;
+    }
+    return 1;
+}
+
+/* Backend hook: atomically claim a staged shot (returns 1 and fills `out`),
+ * then call present_shot_done(ok) once the PNG is written — or not written. */
+extern "C" int present_shot_take(char *out, int n)
+{
+    if (!out || n <= 0) return 0;
+    std::lock_guard<std::mutex> lk(s_present_shot_mtx);
+    if (!s_present_shot_pending) return 0;
+    std::snprintf(out, (size_t)n, "%s", s_present_shot_path);
+    s_present_shot_pending = false;   /* claimed */
+    return 1;
+}
+
+/* ok = 1 only when a PNG actually landed on disk. seq advances either way so a
+ * client polling it always terminates; ok tells it whether the file exists. */
+extern "C" void present_shot_done(int ok)
+{
+    s_present_shot_ok.store(ok ? 1 : 0, std::memory_order_release);
+    s_present_shot_seq.fetch_add(1, std::memory_order_release);
+}
+
+extern "C" int present_shot_seq(void) { return s_present_shot_seq.load(std::memory_order_acquire); }
+extern "C" int present_shot_ok(void)  { return s_present_shot_ok.load(std::memory_order_acquire); }
 /* Present straight from the FBO (fast, no readback). Set PSX_GL_FORCE_CPU_PRESENT=1
  * to force the software readout path instead — a diagnostic/fallback that also
  * keeps CPU VRAM current every frame (so screenshots reflect the screen). */
@@ -7072,6 +7147,66 @@ static NetplayVblankEpilogue sdl_vblank_present_body(void) {
     SDL_RenderClear(sdl_renderer);
     SDL_RenderCopy(sdl_renderer, sdl_texture, &src, &dst);
     host_osd_draw_sdl(sdl_renderer);
+    /* Fulfil a staged present_shot here: after RenderCopy + OSD, before
+     * RenderPresent, the renderer holds exactly the composed frame the player
+     * sees — including the logical-size aspect fit that every buffer-level
+     * capture misses. Reading back costs a GPU sync, so it only runs when a
+     * shot was explicitly requested. */
+    char shot_path[512];
+    if (present_shot_take(shot_path, (int)sizeof(shot_path))) {
+        int ow = 0, oh = 0;
+        uint8_t *packed = NULL;
+#if defined(PSX_SDL3)
+        SDL_Surface *surf = SDL_RenderReadPixels(sdl_renderer, NULL);
+        if (surf) {
+            SDL_Surface *conv = SDL_ConvertSurface(surf, SDL_PIXELFORMAT_RGB24);
+            SDL_DestroySurface(surf);
+            if (conv) {
+                ow = conv->w; oh = conv->h;
+                packed = (uint8_t *)std::malloc((size_t)ow * oh * 3);
+                if (packed) {
+                    /* SDL rows are pitch-aligned; png_write_rgb wants packed. */
+                    for (int y = 0; y < oh; y++)
+                        std::memcpy(packed + (size_t)y * ow * 3,
+                                    (const uint8_t *)conv->pixels + (size_t)y * conv->pitch,
+                                    (size_t)ow * 3);
+                }
+                SDL_DestroySurface(conv);
+            }
+        }
+#else
+        /* Size the buffer from the renderer's REAL output, not from a
+         * viewport*scale reconstruction: SDL_RenderReadPixels(NULL) fills the
+         * current viewport, and deriving that region from
+         * SDL_RenderGetViewport x SDL_RenderGetScale rounds independently of
+         * what SDL actually writes. The output size is a hard upper bound, so
+         * a full-output allocation cannot be overrun whatever SDL picks. */
+        int rw = 0, rh = 0;
+        if (SDL_GetRendererOutputSize(sdl_renderer, &rw, &rh) == 0 && rw > 0 && rh > 0) {
+            SDL_Rect vp; SDL_RenderGetViewport(sdl_renderer, &vp);
+            float sx = 1.0f, sy = 1.0f; SDL_RenderGetScale(sdl_renderer, &sx, &sy);
+            ow = (int)(vp.w * sx); oh = (int)(vp.h * sy);
+            if (ow <= 0 || ow > rw) ow = rw;
+            if (oh <= 0 || oh > rh) oh = rh;
+            packed = (uint8_t *)std::malloc((size_t)rw * rh * 3);   /* upper bound */
+            if (packed && SDL_RenderReadPixels(sdl_renderer, NULL,
+                                               SDL_PIXELFORMAT_RGB24,
+                                               packed, ow * 3) != 0) {
+                std::free(packed); packed = NULL;
+            }
+        }
+#endif
+        int wrote = 0;
+        if (packed && ow > 0 && oh > 0) {
+            FILE *pf = std::fopen(shot_path, "wb");
+            if (pf) {
+                wrote = png_write_rgb(pf, packed, (uint32_t)ow, (uint32_t)oh);
+                std::fclose(pf);
+            }
+        }
+        std::free(packed);
+        present_shot_done(wrote);
+    }
     /* §33: remember active rect for resim hold-last (not full 640x512). */
     s_sw_hold_src = src;
     s_sw_hold_dst = dst;

--- a/runtime/src/main.cpp
+++ b/runtime/src/main.cpp
@@ -10667,6 +10667,35 @@ int main(int argc, char** argv) {
     int         cli_renderer   = -1;   /* 0=software 1=opengl 2=vulkan */
     const char* cli_window_title = nullptr;  /* label windows in a fleet */
     const char* cli_memcard_dir = nullptr;   /* isolate writable state in a fleet */
+    std::vector<std::string> cli_path_arg_storage;
+    cli_path_arg_storage.reserve((size_t)argc);
+    auto is_cli_option = [](const char* arg) {
+        return arg && arg[0] == '-' && arg[1] == '-';
+    };
+    auto consume_path_arg = [&](int& i) -> const char* {
+        const int first = i + 1;
+        std::string combined;
+        std::string best;
+        int best_index = first;
+        for (int j = first; j < argc; ++j) {
+            if (j != first && is_cli_option(argv[j])) break;
+            if (!combined.empty()) combined += " ";
+            combined += argv[j];
+
+            std::error_code ec;
+            if (std::filesystem::exists(std::filesystem::path(combined), ec)) {
+                best = combined;
+                best_index = j;
+            }
+        }
+        if (best.empty()) {
+            best = argv[first];
+            best_index = first;
+        }
+        i = best_index;
+        cli_path_arg_storage.push_back(std::move(best));
+        return cli_path_arg_storage.back().c_str();
+    };
     PsxNetplayConfig net_cfg;
     psx_netplay_config_defaults(&net_cfg);
     psx_netplay_apply_env(&net_cfg);  /* CLI flags below win over env */
@@ -10692,17 +10721,17 @@ int main(int argc, char** argv) {
      * No --game-root flag: that remains config-driven. */
     for (int i = 1; i < argc; i++) {
         if (std::strcmp(argv[i], "--bios") == 0 && i + 1 < argc) {
-            bios_path = argv[++i];
+            bios_path = consume_path_arg(i);
             bios_from_cli = true;
             bios_explicit = true;
         } else if (std::strcmp(argv[i], "--game") == 0 && i + 1 < argc) {
-            game_config_path = argv[++i];
+            game_config_path = consume_path_arg(i);
         } else if (std::strcmp(argv[i], "--disc") == 0 && i + 1 < argc) {
-            disc_override_path = argv[++i];
+            disc_override_path = consume_path_arg(i);
         } else if (std::strcmp(argv[i], "--debug-port") == 0 && i + 1 < argc) {
             cli_debug_port = std::atoi(argv[++i]);
         } else if (std::strcmp(argv[i], "--memcard-dir") == 0 && i + 1 < argc) {
-            cli_memcard_dir = argv[++i];
+            cli_memcard_dir = consume_path_arg(i);
         } else if (std::strcmp(argv[i], "--renderer") == 0 && i + 1 < argc) {
             const char* r = argv[++i];
             if      (std::strcmp(r, "software") == 0) cli_renderer = 0;

--- a/runtime/src/mod_packages.cpp
+++ b/runtime/src/mod_packages.cpp
@@ -1572,6 +1572,7 @@ bool ModPackageManager::read_manifest(const fs::path& path, ModPackage& out,
                     ? toml::find<std::string>(v, "group") : "General";
                 feature.default_enabled =
                     toml::find_or<bool>(v, "default_enabled", false);
+                feature.hidden = toml::find_or<bool>(v, "hidden", false);
                 if (!valid_id(feature.id) ||
                     !feature_ids.insert(feature.id).second)
                     throw std::runtime_error("invalid or duplicate feature id");

--- a/runtime/src/mod_runtime.cpp
+++ b/runtime/src/mod_runtime.cpp
@@ -741,6 +741,7 @@ int provider_feature_get(void*, int index, RecompLauncherCModFeature* out) {
     copy_text(out->source_name, sizeof(out->source_name), package->source_name);
     copy_text(out->source_url, sizeof(out->source_url), package->source_url);
     copy_text(out->group, sizeof(out->group), feature->group);
+    out->hidden = feature->hidden ? 1 : 0;
     out->enabled =
         state().manager.feature_enabled(package->id, feature->id) ? 1 : 0;
     out->option_count =

--- a/runtime/src/ws_ui_group.c
+++ b/runtime/src/ws_ui_group.c
@@ -31,8 +31,10 @@ void ws_ui_group_assign(WsUiGroupItem *items, size_t count,
                         int32_t display_width, int dense_menu) {
     if (!items || count == 0 || display_width <= 0) return;
     if (dense_menu) {
-        for (size_t i = 0; i < count; i++)
+        for (size_t i = 0; i < count; i++) {
             items[i].anchor = display_width / 2;
+            items[i].root = (uint32_t)i;   /* diag: no runs formed */
+        }
         return;
     }
 
@@ -41,6 +43,7 @@ void ws_ui_group_assign(WsUiGroupItem *items, size_t count,
         for (size_t i = 0; i < count; i++) {
             items[i].anchor = ws_ui_anchor_for_bounds(
                 items[i].x, items[i].width, display_width);
+            items[i].root = (uint32_t)i;   /* diag: each item stands alone */
         }
         return;
     }
@@ -71,6 +74,7 @@ void ws_ui_group_assign(WsUiGroupItem *items, size_t count,
         }
         items[i].anchor =
             ws_ui_anchor_for_bounds(min_x, max_x - min_x, display_width);
+        items[i].root = (uint32_t)root;
     }
     free(parent);
 }

--- a/runtime/src/ws_ui_group.c
+++ b/runtime/src/ws_ui_group.c
@@ -51,6 +51,50 @@ static int same_element(const WsUiGroupItem *a, const WsUiGroupItem *b) {
            WS_UI_GROUP_STACK_GAP;
 }
 
+/* Close enough on screen to be part of the same widget: horizontally within a
+ * glyph-gap, vertically overlapping or all but touching. Weaker than
+ * same_element(), which additionally demands shared columns. */
+static int touching(const WsUiGroupItem *a, const WsUiGroupItem *b) {
+    return interval_gap(a, b) <= WS_UI_GROUP_JOIN_GAP &&
+           axis_gap(a->y, a->y + a->height, b->y, b->y + b->height) <=
+               WS_UI_GROUP_STACK_GAP;
+}
+
+/* The three ways two primitives are one HUD element.
+ *
+ * The third is submission adjacency: consecutive in the ordering-table walk
+ * AND touching. The array arrives in submission order -- gpu_ws_prepass_linked_
+ * list fills it as it walks the OT, and the max_rank filter compacts forward --
+ * so "adjacent index" needs no extra field.
+ *
+ * It is what the shared-columns test was standing in for. WipEout 3's
+ * speed/shield readout ends at x=288 and the meter bar it belongs to starts at
+ * x=306: no shared column, so same_element() cannot fire, and the digit font's
+ * CLUT differs from the bar's, so the key join cannot fire either. The readout
+ * was left as its own run; its bbox midpoint, 256.5, landed in the middle third
+ * against a screen centre of 254; and it stayed pinned near screen centre while
+ * its own meters went to the right edge. A 2 px gap in 4:3 opens to 64 frame-
+ * buffer pixels at 16:9, 110 at 21:9 and 159 at 32:9.
+ *
+ * No anchor threshold can fix that. The genuinely centred "pit ... check"
+ * message sits FARTHER RIGHT (midpoint 300.5) than the mis-anchored readout, so
+ * any threshold that pushed the readout into the right third would drag the
+ * message there first and tear it apart. Submission order is the only signal
+ * that separates them: one widget's draw code emits its parts back to back.
+ *
+ * The gap and row tests keep it narrow -- consecutive packets that are far
+ * apart on screen are simply the next widget. Simulated over six captures this
+ * forms exactly one union that changes an anchor, and that union is the defect;
+ * the bottom-left cluster does not chain in, because its nearest consecutive
+ * neighbour pair is 66 px apart. */
+static int items_join(const WsUiGroupItem *items, size_t i, size_t j) {
+    const WsUiGroupItem *a = &items[i], *b = &items[j];
+    if (same_element(a, b)) return 1;
+    if (a->key == b->key && interval_gap(a, b) <= WS_UI_GROUP_JOIN_GAP) return 1;
+    if (j == i + 1 && touching(a, b)) return 1;
+    return 0;
+}
+
 static size_t root_of(size_t *parent, size_t index) {
     while (parent[index] != index) {
         parent[index] = parent[parent[index]];
@@ -93,6 +137,7 @@ void ws_ui_group_assign(WsUiGroupItem *items, size_t count,
      *    or a bar and its frame, could never merge. They then got INDEPENDENT
      *    thirds anchors and were dragged toward opposite screen edges as the
      *    frame widened.
+     *  - SUBMISSION-ADJACENT and touching — see items_join().
      *
      * Observed on WipEout 3's race HUD at 32:9: the lap readout's digits at
      * [137,202] anchored left while the box beneath them at [138,202] anchored
@@ -101,10 +146,7 @@ void ws_ui_group_assign(WsUiGroupItem *items, size_t count,
      * aspect. */
     for (size_t i = 0; i < count; i++) {
         for (size_t j = i + 1; j < count; j++) {
-            if (!same_element(&items[i], &items[j]) &&
-                (items[i].key != items[j].key ||
-                 interval_gap(&items[i], &items[j]) > WS_UI_GROUP_JOIN_GAP))
-                continue;
+            if (!items_join(items, i, j)) continue;
             size_t ri = root_of(parent, i);
             size_t rj = root_of(parent, j);
             if (ri != rj) parent[rj] = ri;

--- a/runtime/src/ws_ui_group.c
+++ b/runtime/src/ws_ui_group.c
@@ -10,13 +10,45 @@ int32_t ws_ui_anchor_for_bounds(int32_t x, int32_t width,
     return display_width / 2;
 }
 
+static int32_t axis_gap(int32_t a0, int32_t a1, int32_t b0, int32_t b1) {
+    if (a1 < b0) return b0 - a1;
+    if (b1 < a0) return a0 - b1;
+    return 0;
+}
+
 static int32_t interval_gap(const WsUiGroupItem *a,
                             const WsUiGroupItem *b) {
-    int32_t a_right = a->x + a->width;
-    int32_t b_right = b->x + b->width;
-    if (a_right < b->x) return b->x - a_right;
-    if (b_right < a->x) return a->x - b_right;
-    return 0;
+    return axis_gap(a->x, a->x + a->width, b->x, b->x + b->width);
+}
+
+/* Are the two primitives one visual element -- drawn over or directly against
+ * each other -- as opposed to merely close? interval_gap() cannot tell those
+ * apart, but they are very different signals: horizontal adjacency is a weak
+ * hint that two runs might belong together, whereas sharing screen columns
+ * while touching vertically means a glyph on its background box, a bar in its
+ * frame, or a label sitting on the readout it annotates. Those must never be
+ * anchored independently.
+ *
+ * Both halves of the test are load-bearing, and each was learned from a real
+ * failure on WipEout 3's race HUD at 32:9:
+ *
+ *  - Drop the column test and everything joins by key alone, so a digit and
+ *    the box under it (different CLUT, different poly-vs-rect family) get
+ *    independent thirds anchors and are dragged to opposite screen edges.
+ *  - Drop the row test and X alone merges the top-left lap counter with the
+ *    bottom-left lap timer 200 scanlines below. Union is transitive, so that
+ *    chained all 71 HUD primitives into one run spanning [24,486], which
+ *    anchors centre and pulls the corners inward.
+ *  - Demand a strict row INTERSECTION and stacked rows are missed: the lap
+ *    readout draws its digits at y=[219,227] and the box they label at
+ *    y=[228,244] -- a one-pixel seam. The box then anchored centre while its
+ *    own digits anchored left, landing 500 screen pixels apart. Hence the
+ *    STACK_GAP slack rather than a bare intersection. */
+static int same_element(const WsUiGroupItem *a, const WsUiGroupItem *b) {
+    if (a->x >= b->x + b->width || b->x >= a->x + a->width)
+        return 0;   /* no shared columns */
+    return axis_gap(a->y, a->y + a->height, b->y, b->y + b->height) <=
+           WS_UI_GROUP_STACK_GAP;
 }
 
 static size_t root_of(size_t *parent, size_t index) {
@@ -50,11 +82,28 @@ void ws_ui_group_assign(WsUiGroupItem *items, size_t count,
     for (size_t i = 0; i < count; i++) parent[i] = i;
 
     /* Transitive union is important for text: each adjacent pair is close,
-     * even when the complete string spans more than one thirds region. */
+     * even when the complete string spans more than one thirds region.
+     *
+     * Two ways to join, and the second is not a relaxation of the first:
+     *
+     *  - SAME KEY and within JOIN_GAP — a run of glyphs from one font/CLUT.
+     *  - SAME ELEMENT, whatever the key — see same_element(). Requiring a
+     *    matching key here was a defect: the key folds in CLUT, texpage, a 24px
+     *    Y band and the poly-vs-rect family, so a digit and the box it sits on,
+     *    or a bar and its frame, could never merge. They then got INDEPENDENT
+     *    thirds anchors and were dragged toward opposite screen edges as the
+     *    frame widened.
+     *
+     * Observed on WipEout 3's race HUD at 32:9: the lap readout's digits at
+     * [137,202] anchored left while the box beneath them at [138,202] anchored
+     * centre, putting the box ~500 screen pixels from the digits it belongs to.
+     * That is the HUD pulling itself apart, and it gets worse the wider the
+     * aspect. */
     for (size_t i = 0; i < count; i++) {
         for (size_t j = i + 1; j < count; j++) {
-            if (items[i].key != items[j].key ||
-                interval_gap(&items[i], &items[j]) > WS_UI_GROUP_JOIN_GAP)
+            if (!same_element(&items[i], &items[j]) &&
+                (items[i].key != items[j].key ||
+                 interval_gap(&items[i], &items[j]) > WS_UI_GROUP_JOIN_GAP))
                 continue;
             size_t ri = root_of(parent, i);
             size_t rj = root_of(parent, j);

--- a/runtime/tests/test_disc_path_resolve.cpp
+++ b/runtime/tests/test_disc_path_resolve.cpp
@@ -71,6 +71,23 @@ void test_single_file_dump(const fs::path& root) {
 
     // The whole point: both picks agree on what to read identity/CRC from.
     check(same(from_cue.data, from_bin.data), "single: both picks share a data track");
+
+    write_sectors(dir / "Tomba! (USA).bin", 4, 0x12);
+    write_text(dir / "Tomba! (USA).cue",
+               "FILE \"Tomba! (USA).bin\" BINARY\n"
+               "  TRACK 01 MODE2/2352\n"
+               "    INDEX 01 00:00:00\n");
+
+    const auto bang_from_cue = resolve_disc_path(dir / "Tomba! (USA).cue");
+    check(bang_from_cue.from_cue, "single: cue path with ! mounts the cue");
+    check(same(bang_from_cue.data, dir / "Tomba! (USA).bin"),
+          "single: cue path with ! resolves the data track");
+
+    const auto bang_from_bin = resolve_disc_path(dir / "Tomba! (USA).bin");
+    check(bang_from_bin.upgraded_to_cue,
+          "single: bin path with ! upgrades to owning cue");
+    check(same(bang_from_cue.data, bang_from_bin.data),
+          "single: ! cue/bin picks share a data track");
 }
 
 // ---- 2. redump multi-track: picking any track file finds the cue ------------

--- a/runtime/tests/test_mod_load_acceleration.py
+++ b/runtime/tests/test_mod_load_acceleration.py
@@ -7,6 +7,9 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 MAIN = (ROOT / "runtime/src/main.cpp").read_text(encoding="utf-8")
 HEADER = (ROOT / "runtime/include/mod_plugins.h").read_text(encoding="utf-8")
+FNTRACE = (ROOT / "runtime/src/fntrace.c").read_text(encoding="utf-8")
+DIRTY_INTERP = (ROOT / "runtime/src/dirty_ram_interp.c").read_text(encoding="utf-8")
+CDROM = (ROOT / "runtime/src/cdrom.c").read_text(encoding="utf-8")
 CONFIG_H = (ROOT / "recompiler/src/config_loader.h").read_text(encoding="utf-8")
 CONFIG_CPP = (ROOT / "recompiler/src/config_loader.cpp").read_text(
     encoding="utf-8"
@@ -74,5 +77,10 @@ assert "release_run = g_turbo_load_release_frames;" in MAIN
 assert "g_frame_period_ms / (double)g_turbo_load_wall_multiplier" in MAIN
 assert "if (!manual_turbo_active && !turbo_load_paced && present_should_wall_pace())" in MAIN
 assert "if (g_mod_disc_speed_divisor >= 0)" in MAIN
+assert "fntrace_maybe_mark_game_started(cpu, addr);" in DIRTY_INTERP
+assert "dirty_ram_text_image_registered()" in FNTRACE
+assert "psx_game_address_in_text(addr) && psx_game_text_native_ok(addr)" in FNTRACE
+assert "mode_reg & 0x48u" in CDROM
+assert "if (xa_stream_active || (mode_reg & 0x68u)) return delay;" not in CDROM
 
 print("mod-owned load acceleration guard passed")

--- a/runtime/tests/test_ws_ui_group.c
+++ b/runtime/tests/test_ws_ui_group.c
@@ -69,6 +69,36 @@ int main(void) {
     assert(stacked[2].root == stacked[0].root);
     assert(stacked[3].root != stacked[0].root);
 
+    /* Submission adjacency. WipEout 3's speed/shield readout ends at x=288 and
+     * the meter bar it belongs to starts at x=306 with a different CLUT, so
+     * neither shared columns nor a matching key can join them; only being
+     * consecutive in the ordering-table walk while touching can. The bottom
+     * -left cluster must NOT chain in through the same rule, so the item before
+     * the readout is a far-away neighbour. Coordinates are the captured ones,
+     * with display_width 508 rather than the 384 used above. */
+    WsUiGroupItem submitted[] = {
+        {0x9a4d,  26, 32, 228, 16, 0, 0},  /* bottom-left, 66 px clear     */
+        {0xd82d, 277, 11, 234,  8, 0, 0},  /* last readout glyph           */
+        {0xb938, 306,112, 236,  6, 0, 0},  /* meter bar, gap 18, rows meet */
+        {0xf3e1, 418, 16, 236,  8, 0, 0},  /* bar end cap                  */
+    };
+    ws_ui_group_assign(submitted, 4, 508, 0);
+    assert(submitted[1].root == submitted[2].root);   /* readout joins meters */
+    assert(submitted[2].root == submitted[3].root);
+    assert(submitted[0].root != submitted[1].root);   /* left stays separate  */
+    assert(submitted[1].anchor == 508 && submitted[0].anchor == 0);
+
+    /* The same two primitives NOT consecutive in the walk must not join --
+     * otherwise the rule degenerates into plain proximity and chains the whole
+     * bottom row into one centre-anchored run. */
+    WsUiGroupItem apart[] = {
+        {0xd82d, 277, 11, 234, 8, 0, 0},
+        {0x1111,  10,  4,  10, 4, 0, 0},   /* unrelated, breaks adjacency */
+        {0xb938, 306,112, 236, 6, 0, 0},
+    };
+    ws_ui_group_assign(apart, 3, 508, 0);
+    assert(apart[0].root != apart[2].root);
+
     assert(ws_ui_anchor_for_bounds(8, 32, display_width) == 0);
     assert(ws_ui_anchor_for_bounds(344, 32, display_width) == 384);
     return 0;

--- a/runtime/tests/test_ws_ui_group.c
+++ b/runtime/tests/test_ws_ui_group.c
@@ -15,10 +15,11 @@ static int32_t scale_about(int32_t x, int32_t anchor,
 int main(void) {
     const int display_width = 384;
 
+    /* {key, x, width, y, height} — anchor and root are outputs. */
     WsUiGroupItem text[] = {
-        {1, 120, 16, 0}, {1, 136, 16, 0}, {1, 152, 16, 0},
-        {1, 168, 16, 0}, {1, 184, 16, 0}, {1, 200, 16, 0},
-        {1, 216, 16, 0}, {1, 232, 16, 0}, {1, 248, 16, 0},
+        {1, 120, 16, 100, 16}, {1, 136, 16, 100, 16}, {1, 152, 16, 100, 16},
+        {1, 168, 16, 100, 16}, {1, 184, 16, 100, 16}, {1, 200, 16, 100, 16},
+        {1, 216, 16, 100, 16}, {1, 232, 16, 100, 16}, {1, 248, 16, 100, 16},
     };
     ws_ui_group_assign(text, 9, display_width, 0);
     for (int i = 0; i < 9; i++) assert(text[i].anchor == 192);
@@ -26,8 +27,8 @@ int main(void) {
            scale_about(184, text[4].anchor, 4, 7));
 
     WsUiGroupItem monkeys[] = {
-        {2, 300, 16, 0}, {2, 320, 16, 0},
-        {2, 340, 16, 0}, {2, 360, 16, 0},
+        {2, 300, 16, 100, 16}, {2, 320, 16, 100, 16},
+        {2, 340, 16, 100, 16}, {2, 360, 16, 100, 16},
     };
     ws_ui_group_assign(monkeys, 4, display_width, 0);
     for (int i = 0; i < 4; i++) assert(monkeys[i].anchor == 384);
@@ -39,16 +40,34 @@ int main(void) {
     }
 
     WsUiGroupItem edge_runs[] = {
-        {3, 20, 16, 0}, {3, 36, 16, 0},
-        {3, 330, 16, 0}, {3, 346, 16, 0},
+        {3, 20, 16, 100, 16}, {3, 36, 16, 100, 16},
+        {3, 330, 16, 100, 16}, {3, 346, 16, 100, 16},
     };
     ws_ui_group_assign(edge_runs, 4, display_width, 0);
     assert(edge_runs[0].anchor == 0 && edge_runs[1].anchor == 0);
     assert(edge_runs[2].anchor == 384 && edge_runs[3].anchor == 384);
 
-    WsUiGroupItem dense[] = {{4, 8, 16, 0}, {5, 340, 16, 0}};
+    WsUiGroupItem dense[] = {{4, 8, 16, 100, 16}, {5, 340, 16, 100, 16}};
     ws_ui_group_assign(dense, 2, display_width, 1);
     assert(dense[0].anchor == 192 && dense[1].anchor == 192);
+
+    /* A digit drawn on top of its background box is ONE element even though
+     * the group key (CLUT / texpage / Y band / poly-vs-rect family) differs.
+     * A primitive elsewhere on screen that merely shares the same columns is
+     * NOT — overlap has to be judged in 2-D or union-find chains the whole HUD
+     * into a single run and the corners collapse toward the centre. */
+    WsUiGroupItem stacked[] = {
+        { 9, 200, 90, 200, 20, 0, 0},  /* background box                  */
+        {10, 210, 16, 204, 12, 0, 0},  /* digit sitting on the box        */
+        {12, 204, 60, 191,  8, 0, 0},  /* label stacked directly above it */
+        {11, 205, 24,  10, 16, 0, 0},  /* top row, same columns           */
+    };
+    ws_ui_group_assign(stacked, 4, display_width, 0);
+    assert(stacked[0].root == stacked[1].root);
+    /* One scanline of seam between the label and the box is still one
+     * element — this is the WipEout 3 lap readout that flew apart. */
+    assert(stacked[2].root == stacked[0].root);
+    assert(stacked[3].root != stacked[0].root);
 
     assert(ws_ui_anchor_for_bounds(8, 32, display_width) == 0);
     assert(ws_ui_anchor_for_bounds(344, 32, display_width) == 384);


### PR DESCRIPTION
## Summary

Ports the rbengine/rbengine-bak changes that looked appropriate for master after the wrong-base audit:

- PR #150: screenshot_hires pitch/full-cover fix and present_shot/present_shot_seq composed-frame capture.
- PR #153: read-only ws_ui_groups debug command.
- PR #154 subset: HUD grouping fixes for uto_ui_squash (same_element, submission-adjacent joins, rejection/rank-drop diagnostics, untextured rect support).
- PR #156 subset: backend-invariant psx_mod_function_entry hook from dirty RAM interpreter dispatch.
- PR #207 subset: CD read acceleration mode fix and hidden-feature metadata plumbing.

Left out deliberately:

- PR #154 HD texture substitution and PGXP depth work: broad feature/experiment bundle; the PR says PGXP depth remains off and still does not work.
- PR #156 clamp-rescue GPU path: coupled to PGXP lookup semantics and not safe to lift independently here.
- PR #207 8 MB RAM manifest resurrection: master no longer carries the surrounding 8 MB RAM feature package, so this PR only keeps the portable hidden metadata support.

## Validation

- Configured runtime CMake with -DPSX_REWIND=OFF -DPSXRECOMP_ALLOW_NO_BIOS=ON -DPSX_RECOMP_UI=OFF.
- Built psx-runtime, ws_ui_group_test, mod_packages_test, mod_runtime_test, gte_register_access_test.
- Ran ws_ui_group_test.exe.
- Ran mod_packages_test.exe.
- Ran mod_runtime_test.exe.
- Ran gte_register_access_test.exe.
- Ran py -3 runtime/tests/test_mod_load_acceleration.py.
- Built and ran ecompiler_patch_test.exe.
- git diff --check origin/master clean.