### PR TITLE
Fix game startup crash when compiled with MSVC

### DIFF
--- a/runtime/src/main.cpp
+++ b/runtime/src/main.cpp
@@ -10625,8 +10625,8 @@ namespace {
 
 int main(int argc, char** argv) {
     /* Force line-buffered output so messages appear even if killed. */
-    std::setvbuf(stdout, nullptr, _IOLBF, 0);
-    std::setvbuf(stderr, nullptr, _IOLBF, 0);
+    std::setvbuf(stdout, nullptr, _IOLBF, BUFSIZ);
+    std::setvbuf(stderr, nullptr, _IOLBF, BUFSIZ);
     std::fprintf(stderr, "psxrecomp: main() entered\n");
     std::fflush(stderr);
 #if defined(RECOMP_LAUNCHER)


### PR DESCRIPTION
Game projects currently immediately crash upon entering main() due to 0 being passed for `size` when calling `std::setvbuf`. This is allowed by GCC, but MSVC explicitly requires this value to be between 2 and `INT_MAX` (https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/setvbuf?view=msvc-170). Changing this 0 to BUFSIZ fixes the crash while retaining compatibility with GCC.