### PR TITLE
runtime: preserve queued uploads after depth24 scanout

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -492,6 +492,9 @@ if(BUILD_TESTING)
         add_test(NAME screenshot_hires_pitch_test
                  COMMAND ${Python3_EXECUTABLE}
                          ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_screenshot_hires_pitch.py)
+        add_test(NAME gl_depth24_upload_order_test
+                 COMMAND ${Python3_EXECUTABLE}
+                         ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_gl_depth24_upload_order.py)
     endif()
 
     # Full card protocol regression: read, write, address echo, per-slot state,

--- a/runtime/src/gpu_gl_renderer.c
+++ b/runtime/src/gpu_gl_renderer.c
@@ -2495,8 +2495,13 @@ static void depth24_upload_policy(void) {
         s_up_nrects = 0;
         rect_clear(&s_d24_skip_fb);
     } else if (!d24 && s_depth24_skip_up) {
-        s_up_nrects = 0;
+        /* Small texture uploads are still queued while depth24 scanout uses
+         * the CPU mirror. Clear only the skipped movie band first, then land
+         * those newer uploads so texture pages which overlap that band win in
+         * PS1 command order. Dropping the queue here loses GT2's boot menu
+         * atlas; flushing before the clear would wipe it again. */
         depth24_clear_skipped_fb();
+        flush_cpu_upload();
         gpu_depth24_upload_span_reset();
         /* Force a fresh present after FMV→15-bit so menus/loading screens
          * are not held as a stale depth24 frame. */

--- a/runtime/tests/test_gl_depth24_upload_order.py
+++ b/runtime/tests/test_gl_depth24_upload_order.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Guard queued texture upload order when OpenGL leaves depth24 scanout."""
+
+from pathlib import Path
+import re
+
+
+SOURCE = Path(__file__).resolve().parents[1] / "src" / "gpu_gl_renderer.c"
+
+
+def function_body(source: str, name: str) -> str:
+    match = re.search(rf"\bstatic\s+void\s+{name}\s*\([^;]*?\)\s*\{{", source, re.S)
+    if not match:
+        raise AssertionError(f"missing function {name}")
+    start, depth = match.end(), 1
+    for position in range(start, len(source)):
+        depth += source[position] == "{"
+        depth -= source[position] == "}"
+        if depth == 0:
+            return source[start:position]
+    raise AssertionError(f"unterminated function {name}")
+
+
+body = function_body(SOURCE.read_text(encoding="utf-8"), "depth24_upload_policy")
+leave = body.index("else if (!d24 && s_depth24_skip_up)")
+leave_body = body[leave:]
+clear = leave_body.index("depth24_clear_skipped_fb();")
+flush = leave_body.index("flush_cpu_upload();")
+reset = leave_body.index("gpu_depth24_upload_span_reset();")
+
+if not clear < flush < reset:
+    raise AssertionError("depth24 exit must clear the movie band before queued uploads land")
+if re.search(r"\bs_up_nrects\s*=\s*0\s*;", leave_body[:reset]):
+    raise AssertionError("depth24 exit must not discard queued texture uploads")
+
+print("PASS: OpenGL depth24 exit preserves queued texture upload order.")


### PR DESCRIPTION
# PR: Preserve queued uploads after depth24 scanout

## Summary

The OpenGL renderer skips framebuffer uploads during 24-bit FMV scanout. Small
texture uploads can remain queued during that period.

The old exit path discarded that queue. This could remove a menu texture atlas
uploaded near the end of an FMV.

This change restores PS1 command order on the OpenGL exit path:

- Clear the skipped movie framebuffer band.
- Flush newer queued texture uploads after the clear.
- Reset the depth24 upload span after both operations.

The change is title-neutral. It does not add game addresses, retail data, or
game-specific conditions.

## Reproduction and manual routes

Gran Turismo 2 Arcade Mode exposed the problem. The operator used this process:

1. Boot through the intro and FMV path.
2. Inspect the Save, Options, and Replay menus.
3. Enter Arcade Mode and return to the main menu.
4. Inspect the same menus again.
5. Close the game and inspect the runtime artifacts.

The software renderer showed correct text. OpenGL showed corrupted or missing
menu text after the FMV. The reordered OpenGL path produced the accepted font
hash and correct first visits to all three menus.

Five additional routes passed with the same renderer change:

- Gran Turismo 2 Simulation Mode
- Parasite Eve
- Resident Evil 2
- Syphon Filter 2
- Final Fantasy VII

These manual routes used the identical patch before the final rebase. The
rebased PR head received a fresh runtime build and source regression.

## Tests

- `gl_depth24_upload_order_test`: pass
- runtime target link: pass
- complete current build: pass
- enabled runtime tests: 49 of 49 pass
- local Claude/Codex handshake: PASS

## Scope and risk

This PR changes only the OpenGL exit from 24-bit scanout. Vulkan remains
outside this qualification.

The correction preserves uploads that remain queued at exit. A pre-existing
queue overflow or another CPU-coherence request can flush earlier uploads
during 24-bit scanout. This PR does not change that behavior.

The regression is a structural source test. It protects the clear, flush, and
reset order. A future behavioral fixture must cover overlapping movie and
texture rectangles.

Developed with AI assistance; validated as described (test evidence in PR body). AI writes the code and the PR, but I always test before I send something up. Happy to iterate on this process with your feedback.
