### PR TITLE
runtime: two causes of unbounded guest speed (present pacing, turbo focus gate)

### DIFF
--- a/runtime/src/main.cpp
+++ b/runtime/src/main.cpp
@@ -573,6 +573,30 @@ static void fps_telemetry_toggle(void) {
     host_osd_push(enabled ? "FPS readout on" : "FPS readout off", 1500);
 }
 
+/* Hold-to-act host hotkeys must not fire while the game window does not hold
+ * keyboard focus.
+ *
+ * SDL_GetKeyboardState() returns a CACHED array that SDL updates from events.
+ * A key whose key-UP is delivered to some other window stays latched in that
+ * array with nothing to clear it -- and the canonical way to move focus away
+ * is Alt+TAB, where TAB is exactly the fast-forward bind. The game then runs
+ * at the fast-forward multiplier with no key held, indefinitely. Regaining
+ * focus makes SDL reconcile the array, which is why the symptom "stops" the
+ * moment you click back into the window and press anything.
+ *
+ * Gating on real input focus fixes that and is independently correct: a
+ * hold-to-turbo must not run while the player is typing in another
+ * application. Edge-triggered hotkeys are unaffected -- they go through
+ * host_keymap_match() on real key EVENTS, which are only delivered to the
+ * focused window in the first place.
+ *
+ * No window (headless, or before the window exists) means focus is not a
+ * concept here; do not suppress in that case. */
+static bool host_hotkey_input_focused(void) {
+    if (!sdl_window) return true;
+    return (SDL_GetWindowFlags(sdl_window) & SDL_WINDOW_INPUT_FOCUS) != 0;
+}
+
 static int manual_fast_forward_multiplier(void) {
     static int value = -2; /* -2 = unread, -1 = max/unbounded */
     if (value == -2) {
@@ -6601,7 +6625,8 @@ static NetplayVblankEpilogue sdl_vblank_present_body(void) {
         const Uint8* keys = SDL_GetKeyboardState(NULL);
         static int turbo_skip = 0;
         static int turbo_was_down = 0;
-        if (host_keymap_down(HOST_KEYMAP_TURBO, keys, (int)SDL_GetModState())) {
+        if (host_hotkey_input_focused() &&
+            host_keymap_down(HOST_KEYMAP_TURBO, keys, (int)SDL_GetModState())) {
             const int mult = manual_fast_forward_multiplier();
             const int present_every = (mult < 0) ? 4 : (mult <= 4 ? 2 : 4);
             manual_turbo_active = true;

--- a/runtime/src/main.cpp
+++ b/runtime/src/main.cpp
@@ -2790,7 +2790,23 @@ static int present_should_wall_pace(void) {
     if (g_frame_interpolation && g_gl_active &&
         gl_renderer_interpolation_owns_cadence())
         return 0;
-    return g_frame_period_ms > 0.0 && !present_vsync_owns_cadence();
+    /* Run the pacer even when driver vsync is SUPPOSED to own the cadence.
+     *
+     * Skipping it here trusts the swap to block, and a swap that does not
+     * block leaves the guest with NO speed limit at all -- the game simply
+     * free-runs. Measured on NVIDIA GL under a compositing WM: 45 s of
+     * gameplay produced 4771 guest frames (~106 fps, 1.77x) with vsync
+     * "owning" cadence, against 2651 (~58.9 fps, 1.00x) with PSX_VSYNC=0
+     * forcing this pacer on. Nothing was held; it looked exactly like a stuck
+     * fast-forward.
+     *
+     * This is safe to run alongside a vsync that DOES block, because
+     * frame_pacer_wait() is deadline-based rather than a fixed sleep: if the
+     * swap already consumed the period, `now >= next_deadline` and it returns
+     * immediately after advancing the deadline. So it costs nothing where
+     * vsync works and supplies the cap where it does not, which also means it
+     * cannot add latency to the healthy path. */
+    return g_frame_period_ms > 0.0;
 }
 
 static void apply_present_cadence(void) {
@@ -2808,9 +2824,15 @@ static void apply_present_cadence(void) {
 
 static void log_present_cadence(void) {
     if (present_vsync_owns_cadence()) {
-        std::printf("psxrecomp: present cadence: driver vsync (%.1f Hz panel, "
-                    "wall-clock pacer skipped)\n",
-                    g_host_refresh_hz);
+        /* The pacer still runs underneath as a deadline cap (see
+         * present_should_wall_pace) -- a no-op whenever the swap actually
+         * blocks, and the only speed limit when it does not. Say so: this
+         * line is how a bring-up session decides whether pacing is accounted
+         * for, and "skipped" sent this one hunting a phantom stuck
+         * fast-forward instead of an unpaced present. */
+        std::printf("psxrecomp: present cadence: driver vsync (%.1f Hz panel; "
+                    "wall-clock cap %.4f ms/frame)\n",
+                    g_host_refresh_hz, g_frame_period_ms);
     } else if (g_frame_period_ms > 0.0) {
         if (g_video_vsync != 0 && !g_frame_interpolation &&
             !g_netplay_vsync_forced_off) {


### PR DESCRIPTION
Two independent causes of the same reported symptom: the guest running far
above 1.0x with nothing held, indistinguishable to a player from a stuck
fast-forward. Both are host-side present/input bugs; neither touches codegen.

### 1. Hold-to-turbo ran while the window had no input focus

`SDL_GetKeyboardState()` returns a **cached** array that SDL reconciles from
events. A key whose key-UP is delivered to a different window stays latched
there with nothing to clear it — and the canonical way to move focus away is
Alt+TAB, where TAB is exactly the fast-forward bind. The guest then sits at the
fast-forward multiplier indefinitely. Regaining focus makes SDL reconcile the
array, which is why the symptom appears to stop the moment you click back in
and press anything. (The report that surfaced this blamed the FPS-readout key
for "stopping the turbo"; it was the focus change that came with reaching for
it.)

Gated the held-key read on real input focus. This is independently correct —
hold-to-turbo must not run while the player is typing in another application.
Edge-triggered hotkeys are unaffected: they go through `host_keymap_match()` on
real key **events**, which are only delivered to the focused window anyway.
Headless and pre-window cases are explicitly not suppressed.

### 2. The wall-clock pacer was skipped whenever vsync "owned" the cadence

`present_should_wall_pace()` returned early on `present_vsync_owns_cadence()`,
trusting the GL swap to block. **A swap that does not block then leaves the
guest with no speed limit at all.**

Running the pacer underneath vsync is safe because `frame_pacer_wait()` is
deadline-based rather than a fixed sleep: when the swap has already consumed
the period, `now >= next_deadline` and it returns immediately after advancing
the deadline. So it costs nothing where vsync works — in particular it adds no
latency to the healthy path, which is why vsync was given sole ownership in the
first place — and supplies the cap where vsync does not block.

The frame-interpolation exclusion is deliberately kept: that path subdivides
this same interval and would genuinely double-pace.

The startup log line is corrected with it. `wall-clock pacer skipped` is how a
bring-up session decides pacing is accounted for, and it is what sent this
investigation hunting a phantom stuck fast-forward instead of an unpaced
present.

### Measurements

FF7 (SCUS-94163), NVIDIA GL under a compositing WM, 45 s, nothing held,
telemetry off:

| state | guest frames | fps | speed |
|---|---|---|---|
| before either fix | 9678 | — | — |
| after the focus gate | 4771 | ~106 | 1.77x |
| `PSX_VSYNC=0` (pacer forced on) | 2651 | ~58.9 | 1.00x |
| **both fixes, default settings** | **2643** | **~58.7** | **0.98x** |

The two are sequential findings on one symptom: the second is only visible
once the first stops masking it, which is why the frame counts chain. Turbo
attribution was confirmed by changing `PSX_FAST_FORWARD_SPEED`, which only
`manual_fast_forward_multiplier()` reads and which is only reached inside the
gated branch — the speed tracked it, so the branch was demonstrably executing.

### Scope, verification, and the pin

- **Game-agnostic.** Runtime only, no per-game configuration, no new settings.
- **Pin bump required to consume; regen NOT required** — both changes are
  runtime-only (`runtime/src/main.cpp`), no codegen or emitter change.
- **Built and run in a real integration.** The identical changes are the
  submodule pin of
  [TechnicallyComputers/Final-Fantasy-VII@de2a9a2](https://github.com/TechnicallyComputers/Final-Fantasy-VII/commit/de2a9a2),
  which builds and boots (OpenGL, HLE BIOS, headless and windowed).
- This branch is those two commits **rebased onto current `master`**; the
  cherry-pick applied cleanly and the result compiles with the project
  toolchain (cmake-clang-v1). The frame measurements above were taken on the
  game's pin, not on this rebase.

### Known limitations

- Frame counts are from one machine and one GPU/WM combination. The failing
  case is specifically a non-blocking swap; on a driver where vsync genuinely
  blocks, change 2 is a no-op by construction rather than by measurement.
- Not oracle-diffed against Beetle. These are host present/input paths and do
  not alter guest-visible timing, interrupts, or emulated state, so a co-sim
  diff has nothing to compare — worth saying explicitly given CONTRIBUTING's
  verification bar.

### On PR focus

CONTRIBUTING asks for one thing per PR, and this is two fixes. They are here
together because they are one investigation of one symptom and the evidence
chains through both — the 4771-frame row is the state *between* them. Happy to
split into two stacked PRs if you would rather review them separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UWiDNcWuNtDWHE7Pnhq4jp
