### PR TITLE
Fix PAL timing

### DIFF
--- a/recompiler/CMakeLists.txt
+++ b/recompiler/CMakeLists.txt
@@ -585,6 +585,7 @@ if(BUILD_TESTING)
                 release_zip
                 overlay_decodable_fallback
                 overlay_init_guard
+                pal_cadence_host_refresh
                 sdl3_main_single_include
                 spu_sample_scheduler_default
                 vk_build_default

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -501,6 +501,9 @@ if(BUILD_TESTING)
         add_test(NAME gl_depth24_upload_order_test
                  COMMAND ${Python3_EXECUTABLE}
                          ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_gl_depth24_upload_order.py)
+        add_test(NAME pal_cadence_host_refresh_test
+                 COMMAND ${Python3_EXECUTABLE}
+                         ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_pal_cadence_host_refresh.py)
     endif()
 
     # Full card protocol regression: read, write, address echo, per-slot state,

--- a/runtime/src/interrupts.c
+++ b/runtime/src/interrupts.c
@@ -178,8 +178,8 @@ void psx_irq_raise(uint32_t bit, uint32_t detail)
 
 /* Dispatch counter for vblank scheduling. */
 #define VBLANK_INTERVAL 50000        /* legacy: dispatch-count fallback (unused for VBlank gating now) */
-#define VBLANK_CYCLES   564480u      /* 33.8688 MHz / 60 Hz — real PSX NTSC VBlank period */
-#define VBLANK_DEFER_STALE_CYCLES (VBLANK_CYCLES * 10ull)
+#define VBLANK_DEFER_STALE_CYCLES (vblank_cycles * 10ull)
+uint32_t vblank_cycles = 564480u;    /* 33.8688 MHz / 60 Hz — real PSX NTSC VBlank period */
 static uint32_t dispatch_count;
 static uint64_t total_checks;
 static uint32_t cycles_since_vblank;  /* incremented by interrupts_advance_cycles */
@@ -471,13 +471,13 @@ static void fire_vblank_edge(void) {
     /* Subtract one VBlank period rather than reset to 0 so cycle overshoot
      * carries forward. Prevents long-running blocks from rounding multiple
      * VBlanks together. */
-    cycles_since_vblank -= VBLANK_CYCLES;
+    cycles_since_vblank -= vblank_cycles;
     dispatch_count = 0;
     /* DEQUEUE: this VBlank fired. ENQUEUE: next VBlank scheduled one period out. */
     event_ring_record_aux(EV_DEQ, (uint8_t)SRC_VBLANK,
                           (uint32_t)psx_get_cycle_count());
     event_ring_record_aux(EV_ENQ, (uint8_t)SRC_VBLANK,
-                          (uint32_t)(psx_get_cycle_count() + VBLANK_CYCLES));
+                          (uint32_t)(psx_get_cycle_count() + vblank_cycles));
     psx_irq_raise(IRQ_VBLANK, 0);
     g_vblank_raise_count++;
     event_ring_record(EV_ISTAT_RAISE, IRQ_VBLANK);
@@ -493,15 +493,15 @@ static void fire_vblank_edge(void) {
 void interrupts_service_scheduled_events(void) {
     note_sio_progress_cycle();
     if (in_exception) return;
-    while (cycles_since_vblank >= VBLANK_CYCLES) {
+    while (cycles_since_vblank >= vblank_cycles) {
         if (should_defer_vblank_for_sio()) return;
         fire_vblank_edge();
     }
 }
 
 uint32_t interrupts_cycles_to_vblank(void) {
-    if (cycles_since_vblank >= VBLANK_CYCLES) return 0;
-    return VBLANK_CYCLES - cycles_since_vblank;
+    if (cycles_since_vblank >= vblank_cycles) return 0;
+    return vblank_cycles - cycles_since_vblank;
 }
 
 uint32_t interrupts_get_cycles_since_vblank(void) {
@@ -984,8 +984,8 @@ uint32_t cycles_to_next_event(void) {
      * card-SIO case only pushes VBlank LATER, so this estimate stays a safe
      * under-estimate. */
     if (i_mask & (1u << IRQ_VBLANK)) {
-        uint32_t d = (cycles_since_vblank >= VBLANK_CYCLES)
-                       ? 0u : (VBLANK_CYCLES - cycles_since_vblank);
+        uint32_t d = (cycles_since_vblank >= vblank_cycles)
+                       ? 0u : (vblank_cycles - cycles_since_vblank);
         if (d < best) best = d;
     }
     uint32_t t = timers_cycles_to_irq(i_mask); if (t < best) best = t;

--- a/runtime/src/main.cpp
+++ b/runtime/src/main.cpp
@@ -202,6 +202,8 @@ extern "C" {
     extern int      g_call_unit_depth;
     /* psx_bios_backend.c */
     extern int      g_psx_dispatch_depth;
+    /* interrupts.c */
+    extern uint32_t vblank_cycles;
 }
 
 /* memory.c */
@@ -13019,7 +13021,14 @@ session_reboot:
         const auto ident = PSXRecompV4::identify_disc(
             disc_path_str, expected_serial, expected_crc,
             has_crc, /*compute_crc*/false);
-        if (ident.region == "PAL")         cdrom_set_disc_scex("SCEE");
+        if (ident.region == "PAL") {
+            cdrom_set_disc_scex("SCEE");
+
+            /* We need to adjust the frame pacing for PAL games to run at the
+             * correct speed */
+            vblank_cycles = 677376u;
+            g_frame_period_ms = 1000.0 / 50.0;  /* 50hz refresh rate */
+        }
         else if (ident.region == "NTSC-J") cdrom_set_disc_scex("SCEI");
         else if (ident.region == "NTSC-U") cdrom_set_disc_scex("SCEA");
         if (!ident.region.empty())

--- a/runtime/src/main.cpp
+++ b/runtime/src/main.cpp
@@ -2702,8 +2702,11 @@ static void apply_netplay_local_viewport_aspect(bool netplay_enabled) {
  * wall-clock pacer double-blocks the vblank callback (present is before the
  * guest resumes), which shows up as MotK FMV ~30–40 FPS in netplay vs ~50+
  * offline. Force immediate swaps for the session; restore on soft-exit. */
-static int host_refresh_is_approx_60hz(void) {
-    return g_host_refresh_hz >= 58.8 && g_host_refresh_hz <= 61.2;
+static int host_refresh_matches_guest_cadence(void) {
+    if (g_host_refresh_hz <= 0.0 || g_frame_period_ms <= 0.0)
+        return 0;
+    const double guest_hz = 1000.0 / g_frame_period_ms;
+    return std::fabs(g_host_refresh_hz - guest_hz) <= guest_hz * 0.02;
 }
 
 static int host_driver_vsync_unreliable(void) {
@@ -2747,7 +2750,7 @@ static int present_vsync_owns_cadence(void) {
         return 0;
     if (g_netplay_vsync_forced_off || psx_netplay_active())
         return 0;
-    return host_refresh_is_approx_60hz();
+    return host_refresh_matches_guest_cadence();
 }
 
 static int present_effective_swap_interval(void) {
@@ -13257,23 +13260,25 @@ session_reboot:
     if (!g_fullscreen && !g_video_win_w_explicit)
         SDL_MaximizeWindow(sdl_window);
 
-    /* Host refresh: if the panel is within ~2% of 60 Hz, record it so driver
-     * vsync can own cadence (pacer skipped). Non-~60 Hz and unknown refresh
-     * (common on Wayland) keep PSX 59.94 Hz pacing and force swap interval 0
-     * — vsync as the clock would run the sim at the panel rate. */
+    /* Host refresh: if the panel matches the current guest cadence, record it
+     * so driver vsync can own cadence (pacer skipped). Mismatched and unknown
+     * refresh rates keep guest pacing and force swap interval 0; vsync as the
+     * clock would otherwise run the sim at the panel rate. */
     {
         SDL_DisplayMode dm;
         int disp_idx = SDL_GetWindowDisplayIndex(sdl_window);
         if (disp_idx >= 0 && SDL_GetCurrentDisplayMode(disp_idx, &dm) == 0 && dm.refresh_rate > 0) {
             double host_hz = (double)dm.refresh_rate;
             g_host_refresh_hz = host_hz;
-            if (host_hz >= 58.8 && host_hz <= 61.2) {
+            if (host_refresh_matches_guest_cadence()) {
                 g_frame_period_ms = 1000.0 / host_hz;
                 std::printf("psxrecomp: sync-to-host-refresh: pacing to %.1f Hz panel "
                             "(%.4f ms/frame)\n", host_hz, g_frame_period_ms);
             } else {
-                std::printf("psxrecomp: host panel %.1f Hz not ~60 Hz; keeping PSX "
-                            "59.94 Hz pacing\n", host_hz);
+                std::printf("psxrecomp: host panel %.1f Hz does not match guest "
+                            "cadence; keeping %.2f Hz pacing\n",
+                            host_hz,
+                            g_frame_period_ms > 0.0 ? 1000.0 / g_frame_period_ms : 0.0);
             }
         }
     }

--- a/runtime/tests/test_pal_cadence_host_refresh.py
+++ b/runtime/tests/test_pal_cadence_host_refresh.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Guard PAL timing against 60 Hz host-refresh cadence leakage."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MAIN = (ROOT / "runtime" / "src" / "main.cpp").read_text(encoding="utf-8")
+
+
+def require(needle: str, message: str) -> None:
+    if needle not in MAIN:
+        raise AssertionError(message)
+
+
+require(
+    "static int host_refresh_matches_guest_cadence(void)",
+    "host refresh must be compared against the active guest cadence",
+)
+require(
+    "const double guest_hz = 1000.0 / g_frame_period_ms;",
+    "guest cadence must derive from the current frame period",
+)
+require(
+    "return std::fabs(g_host_refresh_hz - guest_hz) <= guest_hz * 0.02;",
+    "host refresh tolerance must be relative to the current guest cadence",
+)
+require(
+    "if (host_refresh_matches_guest_cadence())",
+    "host-refresh sync must not overwrite PAL timing from a hard-coded 60 Hz check",
+)
+require(
+    "return host_refresh_matches_guest_cadence();",
+    "driver vsync cadence ownership must respect the active guest cadence",
+)
+
+for forbidden in (
+    "host_refresh_is_approx_60hz",
+    "host_hz >= 58.8",
+    "g_host_refresh_hz >= 58.8",
+    "host_hz <= 61.2",
+    "g_host_refresh_hz <= 61.2",
+):
+    if forbidden in MAIN:
+        raise AssertionError(
+            f"PAL timing can leak back to the old 60 Hz-only cadence check: {forbidden}"
+        )
+
+print("PAL host-refresh cadence guard passed")


### PR DESCRIPTION
This change fixes PAL games by detecting the disc's region and changing `vblank_cycles` and `g_frame_period_ms` if PAL is detected.