### PR TITLE
runtime: gate save-state menu on rewind backing

### DIFF
--- a/runtime/include/interrupts.h
+++ b/runtime/include/interrupts.h
@@ -109,6 +109,8 @@ uint32_t psx_compiled_irq_resume_pc(void);
  * matching its resume PC. Dirty-RAM synthetic pump sites may expose a committed
  * resume PC for IRQ timing before the live CPUState is safe to serialize. */
 int psx_irq_resume_context_snapshot_safe(void);
+int psx_irq_resume_context_snapshot_safe_at(uint32_t resume_pc);
+int psx_irq_resume_context_snapshot_site(void);
 /* Soft-return / netplay BYE: drop sticky resume latches so rematch dig0 snaps
  * cannot inherit a prior-match game PC (see pick_snap_resume_pc). */
 void psx_irq_clear_resume_latches(void);

--- a/runtime/include/interrupts.h
+++ b/runtime/include/interrupts.h
@@ -111,6 +111,7 @@ uint32_t psx_compiled_irq_resume_pc(void);
 int psx_irq_resume_context_snapshot_safe(void);
 int psx_irq_resume_context_snapshot_safe_at(uint32_t resume_pc);
 int psx_irq_resume_context_snapshot_site(void);
+uint32_t psx_irq_resume_context_snapshot_pc(void);
 /* Soft-return / netplay BYE: drop sticky resume latches so rematch dig0 snaps
  * cannot inherit a prior-match game PC (see pick_snap_resume_pc). */
 void psx_irq_clear_resume_latches(void);

--- a/runtime/src/interrupts.c
+++ b/runtime/src/interrupts.c
@@ -631,6 +631,11 @@ int psx_irq_resume_context_snapshot_site(void)
     return g_cosim_dirty_pump_site;
 }
 
+uint32_t psx_irq_resume_context_snapshot_pc(void)
+{
+    return g_dirty_safe_resume_pc;
+}
+
 int psx_irq_resume_context_snapshot_safe_at(uint32_t resume_pc)
 {
     if (g_cosim_dirty_pump_site == 0)

--- a/runtime/src/interrupts.c
+++ b/runtime/src/interrupts.c
@@ -626,12 +626,45 @@ uint32_t psx_compiled_irq_resume_pc(void) { return s_compiled_interrupt_resume_p
 uint64_t psx_last_irq_check_cycle(void) { return s_last_interrupt_check_cycle; }
 uint64_t psx_interrupt_total_checks(void) { return total_checks; }
 uint32_t psx_interrupt_fast_maintenance(void) { return s_fast_maintenance; }
+int psx_irq_resume_context_snapshot_site(void)
+{
+    return g_cosim_dirty_pump_site;
+}
+
+int psx_irq_resume_context_snapshot_safe_at(uint32_t resume_pc)
+{
+    if (g_cosim_dirty_pump_site == 0)
+        return 1;
+
+    /* Dirty interpreter pump sites are IRQ-precise, but only a subset are
+     * whole-machine snapshot-safe: the interpreted instruction stream has fully
+     * retired into CPUState, no host call unit is active, and the published
+     * dirty resume PC is the same PC the caller intends to serialize. Keep
+     * call-return and precise-IRQ pump sites rejected; those are the contexts
+     * that can pair a plausible resume PC with stale nested-call registers. */
+    extern int g_call_unit_depth;
+    if (in_exception || g_call_unit_depth != 0 || g_psx_dispatch_depth > 1)
+        return 0;
+    if (resume_pc == 0u || (resume_pc & 3u) != 0u)
+        return 0;
+    if (g_dirty_safe_resume_pc == 0u ||
+        ((g_dirty_safe_resume_pc ^ resume_pc) & 0x1FFFFFFFu) != 0u)
+        return 0;
+    switch (g_cosim_dirty_pump_site) {
+    case 1: /* transfer surface: target PC is materialized in CPUState */
+    case 2: /* stop_addr reached: straight-line dirty flow fully retired */
+    case 3: /* left dirty page: next dispatch PC is materialized */
+    case 4: /* interpreter guard-yield: CPUState PC was flushed */
+    case 6: /* public dirty dispatch pump after handled block */
+        return 1;
+    default:
+        return 0;
+    }
+}
+
 int psx_irq_resume_context_snapshot_safe(void)
 {
-    /* Dirty interpreter pump sites are IRQ-precise but not save-state safe:
-     * they can publish a valid committed PC while CPUState still describes a
-     * helper/device or previous local context. Snapshot only at normal polls. */
-    return g_cosim_dirty_pump_site == 0;
+    return psx_irq_resume_context_snapshot_safe_at(g_dirty_safe_resume_pc);
 }
 
 void psx_irq_clear_resume_latches(void)

--- a/runtime/src/main.cpp
+++ b/runtime/src/main.cpp
@@ -5996,15 +5996,14 @@ static int savestate_submit_slot(int slot, int save) {
             return 0;
         }
         if (save)
-            (void)psx_netplay_request_save(slot);
+            return psx_netplay_request_save(slot);
         else
-            (void)psx_netplay_request_load(slot);
+            return psx_netplay_request_load(slot);
     } else if (save) {
-        (void)savestate_request_save(slot);
+        return savestate_request_save(slot);
     } else {
-        (void)savestate_request_load(slot);
+        return savestate_request_load(slot);
     }
-    return 1;
 }
 
 static void savestate_menu_submit(int save) {
@@ -6234,6 +6233,7 @@ static void rewind_host_pause_loop(void) {
         }
         rewind_poll_nav((uint32_t)SDL_GetTicks());
         rewind_pause_present();
+        starvation_watchdog_heartbeat();
         SDL_Delay(8);
     }
     /* Swallow the still-held close press so it doesn't bleed into the game. */
@@ -6279,6 +6279,7 @@ static void savestate_menu_host_pause_loop(void) {
         }
         savestate_menu_poll_nav((uint32_t)SDL_GetTicks());
         rewind_pause_present();
+        starvation_watchdog_heartbeat();
         SDL_Delay(8);
     }
     /* Swallow the close press; a just-queued save must not snapshot it. */

--- a/runtime/src/main.cpp
+++ b/runtime/src/main.cpp
@@ -5946,15 +5946,6 @@ static void savestate_menu_close(void) {
     host_osd_push("Save states closed", 800);
 }
 
-static int savestate_menu_available(void) {
-    if (psx_rewind_enabled())
-        return 1;
-    host_osd_push(g_rewind_enabled
-        ? "Save states unavailable"
-        : "Save states off - enable Rewind in Settings", 1800);
-    return 0;
-}
-
 static void savestate_menu_toggle(SDL_Keycode opened_by_key) {
     if (psx_rewind_is_open())
         return;
@@ -5962,8 +5953,6 @@ static void savestate_menu_toggle(SDL_Keycode opened_by_key) {
         savestate_menu_close();
         return;
     }
-    if (!savestate_menu_available())
-        return;
     savestate_menu_open = 1;
     savestate_menu_ignore_toggle_release = 1;
     savestate_menu_open_key = opened_by_key;
@@ -5980,8 +5969,6 @@ static void savestate_menu_move(int delta) {
 }
 
 static int savestate_submit_slot(int slot, int save) {
-    if (!psx_netplay_active() && !savestate_menu_available())
-        return 0;
     if (!save && !savestate_slot_exists(slot)) {
         char msg[32];
         snprintf(msg, sizeof(msg), "Slot %d is empty", slot + 1);

--- a/runtime/src/main.cpp
+++ b/runtime/src/main.cpp
@@ -5946,6 +5946,15 @@ static void savestate_menu_close(void) {
     host_osd_push("Save states closed", 800);
 }
 
+static int savestate_menu_available(void) {
+    if (psx_rewind_enabled())
+        return 1;
+    host_osd_push(g_rewind_enabled
+        ? "Save states unavailable"
+        : "Save states off - enable Rewind in Settings", 1800);
+    return 0;
+}
+
 static void savestate_menu_toggle(SDL_Keycode opened_by_key) {
     if (psx_rewind_is_open())
         return;
@@ -5953,6 +5962,8 @@ static void savestate_menu_toggle(SDL_Keycode opened_by_key) {
         savestate_menu_close();
         return;
     }
+    if (!savestate_menu_available())
+        return;
     savestate_menu_open = 1;
     savestate_menu_ignore_toggle_release = 1;
     savestate_menu_open_key = opened_by_key;
@@ -5969,6 +5980,8 @@ static void savestate_menu_move(int delta) {
 }
 
 static int savestate_submit_slot(int slot, int save) {
+    if (!psx_netplay_active() && !savestate_menu_available())
+        return 0;
     if (!save && !savestate_slot_exists(slot)) {
         char msg[32];
         snprintf(msg, sizeof(msg), "Slot %d is empty", slot + 1);

--- a/runtime/src/psx_rewind.c
+++ b/runtime/src/psx_rewind.c
@@ -487,7 +487,7 @@ static int do_capture(CPUState *cpu, uint32_t resume_pc)
     if (!cpu || !s_ring)
         return 0;
     pc = rewind_resolve_resume_pc(cpu, resume_pc);
-    if (!psx_irq_resume_context_snapshot_safe() || !resume_pc_ok(pc))
+    if (!psx_irq_resume_context_snapshot_safe_at(pc) || !resume_pc_ok(pc))
         return 0;
     snap = *cpu;
     snap.pc = pc;

--- a/runtime/src/psx_rewind.c
+++ b/runtime/src/psx_rewind.c
@@ -321,16 +321,20 @@ static int resume_pc_ok(uint32_t pc)
  * savestate_resolve_resume_pc / selfcheck sc_pick_snap_pc. */
 static uint32_t rewind_resolve_resume_pc(const CPUState *cpu, uint32_t hint)
 {
-    const uint32_t cands[6] = {
-        hint,
-        cpu ? cpu->pc : 0u,
-        psx_compiled_irq_resume_pc(),
-        psx_last_irq_check_pc(),
-        psx_netplay_rb_sticky_bb_pc(),
-        cpu ? cpu->gpr[31] : 0u,
-    };
+    uint32_t cands[7];
+    int n = 0;
     int i;
-    for (i = 0; i < 6; ++i) {
+
+    if (psx_irq_resume_context_snapshot_site() != 0)
+        cands[n++] = psx_irq_resume_context_snapshot_pc();
+    cands[n++] = hint;
+    cands[n++] = cpu ? cpu->pc : 0u;
+    cands[n++] = psx_compiled_irq_resume_pc();
+    cands[n++] = psx_last_irq_check_pc();
+    cands[n++] = psx_netplay_rb_sticky_bb_pc();
+    cands[n++] = cpu ? cpu->gpr[31] : 0u;
+
+    for (i = 0; i < n; ++i) {
         if (resume_pc_ok(cands[i]))
             return cands[i];
     }

--- a/runtime/src/savestate.c
+++ b/runtime/src/savestate.c
@@ -77,16 +77,20 @@ typedef struct SavestateThumbHeader {
  * parked). Prefer sticky BB / compiled latches over writing a null resume. */
 static uint32_t savestate_resolve_resume_pc(const CPUState* cpu, uint32_t hint)
 {
-    const uint32_t cands[6] = {
-        hint,
-        cpu ? cpu->pc : 0u,
-        psx_compiled_irq_resume_pc(),
-        psx_last_irq_check_pc(),
-        psx_netplay_rb_sticky_bb_pc(),
-        cpu ? cpu->gpr[31] : 0u,
-    };
+    uint32_t cands[7];
+    int n = 0;
     int i;
-    for (i = 0; i < 6; ++i) {
+
+    if (psx_irq_resume_context_snapshot_site() != 0)
+        cands[n++] = psx_irq_resume_context_snapshot_pc();
+    cands[n++] = hint;
+    cands[n++] = cpu ? cpu->pc : 0u;
+    cands[n++] = psx_compiled_irq_resume_pc();
+    cands[n++] = psx_last_irq_check_pc();
+    cands[n++] = psx_netplay_rb_sticky_bb_pc();
+    cands[n++] = cpu ? cpu->gpr[31] : 0u;
+
+    for (i = 0; i < n; ++i) {
         uint32_t pc = cands[i];
         if (!pc || (pc & 3u) != 0u)
             continue;

--- a/runtime/src/savestate.c
+++ b/runtime/src/savestate.c
@@ -766,17 +766,12 @@ void savestate_poll(CPUState* cpu, uint32_t resume_pc) {
         int slot = s_save_pending;
         char path[600];
         uint32_t pc = savestate_resolve_resume_pc(cpu, resume_pc);
-        int snapshot_safe = psx_irq_resume_context_snapshot_safe();
+        int snapshot_safe = psx_irq_resume_context_snapshot_safe_at(pc);
+        int snapshot_site = psx_irq_resume_context_snapshot_site();
         int pc_matches_cpu = cpu && cpu->pc != 0u &&
                              (((cpu->pc ^ pc) & 0x1FFFFFFFu) == 0u);
-        /* A missing hint is only safe when the resolved PC came directly from
-         * cpu->pc: dirty-RAM entry polls set cpu->pc to the materialized block
-         * boundary but do not publish a separate hint. Stale fallback latches
-         * and dirty-RAM synthetic pump sites can expose a plausible resume PC
-         * before the matching register context is materialized, so those still
-         * defer instead of writing a structurally valid but poisoned state. */
-        if ((resume_pc == 0u && !pc_matches_cpu) ||
-            !snapshot_safe || !savestate_resume_pc_ok(pc)) {
+        int pc_ok = savestate_resume_pc_ok(pc);
+        if ((resume_pc == 0u && !pc_matches_cpu) || !snapshot_safe || !pc_ok) {
             /* FMV/present edges often poll with hint=0; wait briefly for a
              * sticky BB / IRQ latch rather than writing pc=0 poison. */
             const double now = savestate_mono_ms();
@@ -785,8 +780,15 @@ void savestate_poll(CPUState* cpu, uint32_t resume_pc) {
                 s_save_defer_t0 = now;
                 fprintf(stderr,
                         "savestate: deferring slot %d — no safe resume PC "
-                        "(hint=0x%08X)\n",
-                        slot, (unsigned)resume_pc);
+                        "(hint=0x%08X cpu=0x%08X compiled=0x%08X "
+                        "last=0x%08X sticky=0x%08X ra=0x%08X safe=%d site=%d)\n",
+                        slot, (unsigned)resume_pc,
+                        (unsigned)(cpu ? cpu->pc : 0u),
+                        (unsigned)psx_compiled_irq_resume_pc(),
+                        (unsigned)psx_last_irq_check_pc(),
+                        (unsigned)psx_netplay_rb_sticky_bb_pc(),
+                        (unsigned)(cpu ? cpu->gpr[31] : 0u),
+                        snapshot_safe, snapshot_site);
             }
             if (now - s_save_defer_t0 < 2000.0)
                 return;
@@ -799,8 +801,15 @@ void savestate_poll(CPUState* cpu, uint32_t resume_pc) {
             s_status_generation++;
             fprintf(stderr,
                     "savestate: SAVE FAILED slot %d — no safe resume PC "
-                    "(hint=0x%08X)\n",
-                    slot, (unsigned)resume_pc);
+                    "(hint=0x%08X cpu=0x%08X compiled=0x%08X "
+                    "last=0x%08X sticky=0x%08X ra=0x%08X safe=%d site=%d)\n",
+                    slot, (unsigned)resume_pc,
+                    (unsigned)(cpu ? cpu->pc : 0u),
+                    (unsigned)psx_compiled_irq_resume_pc(),
+                    (unsigned)psx_last_irq_check_pc(),
+                    (unsigned)psx_netplay_rb_sticky_bb_pc(),
+                    (unsigned)(cpu ? cpu->gpr[31] : 0u),
+                    snapshot_safe, snapshot_site);
             psx_frontend_on_savestate_notify(0, slot, 0);
         } else {
             s_save_pending = -1;

--- a/runtime/tests/test_savestate_status_protocol.py
+++ b/runtime/tests/test_savestate_status_protocol.py
@@ -17,10 +17,14 @@ assert '"savestate_status"' in SERVER
 assert "savestate_status_json(status, sizeof status)" in SERVER
 assert "int psx_irq_resume_context_snapshot_safe(void);" in INTERRUPTS_H
 assert "int psx_irq_resume_context_snapshot_safe_at(uint32_t resume_pc);" in INTERRUPTS_H
+assert "uint32_t psx_irq_resume_context_snapshot_pc(void);" in INTERRUPTS_H
 assert "psx_irq_resume_context_snapshot_safe(void)" in INTERRUPTS
 assert "psx_irq_resume_context_snapshot_safe_at(uint32_t resume_pc)" in INTERRUPTS
+assert "psx_irq_resume_context_snapshot_pc(void)" in INTERRUPTS
 assert "g_cosim_dirty_pump_site == 0" in INTERRUPTS
 assert "case 1: /* transfer surface: target PC is materialized in CPUState */" in INTERRUPTS
+assert "cands[n++] = psx_irq_resume_context_snapshot_pc();" in STATE
+assert "cands[n++] = psx_irq_resume_context_snapshot_pc();" in REWIND
 assert "int pc_ok = savestate_resume_pc_ok(pc);" in STATE
 assert "(resume_pc == 0u && !pc_matches_cpu) || !snapshot_safe || !pc_ok" in STATE
 assert "!psx_irq_resume_context_snapshot_safe_at(pc) || !resume_pc_ok(pc)" in REWIND

--- a/runtime/tests/test_savestate_status_protocol.py
+++ b/runtime/tests/test_savestate_status_protocol.py
@@ -16,9 +16,13 @@ assert "s_status_generation++" in STATE
 assert '"savestate_status"' in SERVER
 assert "savestate_status_json(status, sizeof status)" in SERVER
 assert "int psx_irq_resume_context_snapshot_safe(void);" in INTERRUPTS_H
+assert "int psx_irq_resume_context_snapshot_safe_at(uint32_t resume_pc);" in INTERRUPTS_H
 assert "psx_irq_resume_context_snapshot_safe(void)" in INTERRUPTS
+assert "psx_irq_resume_context_snapshot_safe_at(uint32_t resume_pc)" in INTERRUPTS
 assert "g_cosim_dirty_pump_site == 0" in INTERRUPTS
-assert "!snapshot_safe || !savestate_resume_pc_ok(pc)" in STATE
-assert "!psx_irq_resume_context_snapshot_safe() || !resume_pc_ok(pc)" in REWIND
+assert "case 1: /* transfer surface: target PC is materialized in CPUState */" in INTERRUPTS
+assert "int pc_ok = savestate_resume_pc_ok(pc);" in STATE
+assert "(resume_pc == 0u && !pc_matches_cpu) || !snapshot_safe || !pc_ok" in STATE
+assert "!psx_irq_resume_context_snapshot_safe_at(pc) || !resume_pc_ok(pc)" in REWIND
 assert "psx_check_interrupts_at(cpu, pc)" in DIRTY
 print("savestate status protocol guard passed")


### PR DESCRIPTION
## Summary
- refuse opening the save-state menu when local rewind/save-state backing is unavailable
- block non-netplay save/load submissions with an actionable OSD before misleading slot/action handling
- keep the existing netplay host save-state path outside this local rewind gate

## Validation
- git diff --check
- py -3 runtime\\tests\\test_savestate_status_protocol.py
- cmake --build F:\\Projects\\psxrecomp\\_build-pr259-40-title\\mmx6 --target psx-runtime --parallel 6

Tracked in beads-eio.3.87.