### PR TITLE
cosim: key checkpoints on retired-instruction count, not guest cycles

### DIFF
--- a/runtime/src/cosim.c
+++ b/runtime/src/cosim.c
@@ -48,11 +48,10 @@ typedef struct { uint64_t cp; uint32_t pc; uint64_t hash; uint32_t istat, imask;
 static Entry    g_ring[RING_N];
 static uint64_t g_cp      = 0;          /* checkpoints crossed so far */
 static uint64_t g_chain   = 1469598103934665603ULL; /* cumulative FNV over checkpoints */
-static uint64_t g_stride  = 4096;       /* guest cycles per checkpoint (coordinator sets) */
-static uint64_t g_next_cp = 0;          /* next cycle at which to checkpoint */
+static uint64_t g_stride  = 4096;       /* retired instructions per checkpoint */
+static uint64_t g_next_cp = 0;          /* icount at which to take the next checkpoint */
 static uint32_t g_last_leader_pc = 0;   /* set by cosim_block, reported at checkpoints */
-static uint64_t g_pending_first_cycle = 0;
-static uint64_t g_pending_count = 0;
+static uint64_t g_icount  = 0;          /* retirement events (cosim_instr calls) */
 
 /* lockstep control (written by TCP thread, read by guest thread).
  * The guest parks at EVERY checkpoint boundary (a deterministic guest cycle = multiple
@@ -77,25 +76,29 @@ void cosim_block(uint32_t pc) { g_last_leader_pc = pc; }
 uint32_t cosim_last_block(void) { return g_last_leader_pc; }
 
 uint32_t cosim_cycles_to_next_checkpoint(void) {
-    uint64_t now = psx_cycle_count;
-    if (now >= g_next_cp) return 0;
-    uint64_t d = g_next_cp - now;
-    return d > 0xFFFFFFFFULL ? 0xFFFFFFFFu : (uint32_t)d;
+    return 0;   /* checkpoints are icount-keyed; no cycle sub-step cap needed */
 }
 
-/* Cycle-keyed checkpoint — called from psx_advance_cycles (both backends, identical
- * per-instruction charges). Folds a full-state hash into the chain at each guest-cycle
- * stride and parks at the coordinator's stop cycle. This is the alignment clock. */
-static void cosim_record_checkpoint(uint64_t cycle, uint32_t pc) {
+/* Instruction-count-keyed checkpoint — taken inside cosim_instr, which both
+ * backends call exactly once per retirement event (a branch and its delay slot
+ * retire as ONE event in both the dirty-RAM interp and the emitted code). That
+ * makes checkpoint k "the state after k*stride retirements" by construction, so
+ * the two instances always hash the SAME architectural position. The guest-cycle
+ * clock is part of the hash (cosim_state.c), so any cycle-accounting drift shows
+ * up as a chain divergence AT an exact instruction instead of silently skewing
+ * where the two instances park (the old cycle-keyed design parked at the first
+ * instruction boundary after the stride cycle, which the two backends could
+ * reach at different retirement positions — phantom divergences). */
+static void cosim_record_checkpoint(uint64_t icount, uint32_t pc) {
     uint64_t h = cosim_state_hash(NULL);
     uint64_t cp = ++g_cp;
-    g_chain = fold(fold(g_chain, cycle), h);
+    g_chain = fold(fold(g_chain, icount), h);
     Entry *e = &g_ring[cp & (RING_N - 1u)];
     e->cp = cp; e->pc = pc; e->hash = h;
-    e->istat = i_stat; e->imask = i_mask; e->cycle = cycle;
+    e->istat = i_stat; e->imask = i_mask; e->cycle = psx_cycle_count;
 
     /* deterministic park: consume one checkpoint of budget, else block for `step`.
-     * The guest ALWAYS stops here (a fixed cycle boundary), never at a wall-time point. */
+     * The guest ALWAYS stops here (a fixed icount boundary), never at a wall-time point. */
     if (g_run_budget > 0) { g_run_budget--; return; }
     g_parked = 1;
     while (g_run_budget <= 0) {
@@ -107,29 +110,24 @@ static void cosim_record_checkpoint(uint64_t cycle, uint32_t pc) {
 }
 
 void cosim_tick(void) {
-    uint64_t now = psx_cycle_count;
-    if (now < g_next_cp) return;
-
-    if (g_cp == 0 && now == 0 && g_next_cp == 0) {
-        cosim_record_checkpoint(0, g_last_leader_pc);
-        g_next_cp = g_stride ? g_stride : 1;
-        return;
-    }
-
-    while (now >= g_next_cp) {
-        if (g_pending_count == 0) g_pending_first_cycle = g_next_cp;
-        g_pending_count++;
-        g_next_cp += g_stride ? g_stride : 1;
-    }
+    /* Retained for the psx_advance_cycles call sites; checkpointing moved to
+     * the icount key in cosim_instr (see cosim_record_checkpoint comment). */
 }
 
 void cosim_instr(uint32_t pc) {
     g_last_leader_pc = pc;
-    while (g_pending_count > 0) {
-        uint64_t cycle = g_pending_first_cycle;
-        g_pending_first_cycle += g_stride ? g_stride : 1;
-        g_pending_count--;
-        cosim_record_checkpoint(cycle, pc);
+    g_icount++;
+    if (g_cp == 0 && g_next_cp == 0) {
+        /* Initial park at the very first retirement: the coordinator gains
+         * control before the guest free-runs (unless PSX_COSIM_START_CYCLE
+         * set a free-run target, which makes g_next_cp nonzero). */
+        cosim_record_checkpoint(g_icount, pc);
+        g_next_cp = g_icount + (g_stride ? g_stride : 1);
+        return;
+    }
+    if (g_icount >= g_next_cp) {
+        cosim_record_checkpoint(g_icount, pc);
+        g_next_cp = g_icount + (g_stride ? g_stride : 1);
     }
 }
 
@@ -200,8 +198,9 @@ static void handle_line(sock_t s, char *line) {
     if (sscanf(line, "%31s", cmd) != 1) { send_line(s, "err empty\n"); return; }
 
     if (!strcmp(cmd, "status")) {
-        snprintf(out, sizeof out, "cp %llu cycle %llu chain %016llx stride %llu parked %d\n",
+        snprintf(out, sizeof out, "cp %llu cycle %llu icnt %llu chain %016llx stride %llu parked %d\n",
                  (unsigned long long)g_cp, (unsigned long long)psx_cycle_count,
+                 (unsigned long long)g_icount,
                  (unsigned long long)g_chain, (unsigned long long)g_stride, g_parked);
         send_line(s, out); return;
     }
@@ -229,9 +228,10 @@ static void handle_line(sock_t s, char *line) {
         while (g_run_budget > 0 && spins < 1200000) { COSIM_SLEEP(1); spins++; }
         /* small settle so g_parked/g_chain reflect the checkpoint just recorded */
         int s2 = 0; while (!g_parked && g_run_budget <= 0 && s2 < 2000) { COSIM_SLEEP(1); s2++; }
-        snprintf(out, sizeof out, "%s cp %llu cycle %llu chain %016llx\n",
+        snprintf(out, sizeof out, "%s cp %llu cycle %llu icnt %llu chain %016llx\n",
                  g_parked ? "parked" : "running",
                  (unsigned long long)g_cp, (unsigned long long)psx_cycle_count,
+                 (unsigned long long)g_icount,
                  (unsigned long long)g_chain);
         send_line(s, out); return;
     }
@@ -369,8 +369,9 @@ void cosim_init(void) {
     unsigned short port = 4600;
     const char *e = getenv("PSX_COSIM_PORT");
     if (e && *e) port = (unsigned short)atoi(e);
-    /* Stride fixed at launch (env) so the checkpoint cycle boundaries are identical in
-     * both processes before either runs a single instruction — no set-stride race. */
+    /* Stride fixed at launch (env) so the checkpoint icount boundaries are identical
+     * in both processes before either runs a single instruction — no set-stride race.
+     * Both stride and start are in RETIRED INSTRUCTIONS (icount), not guest cycles. */
     const char *st = getenv("PSX_COSIM_STRIDE");
     if (st && *st) { unsigned long long v = strtoull(st, 0, 10); if (v) g_stride = v; }
     const char *sc = getenv("PSX_COSIM_START_CYCLE");

--- a/tools/cosim.py
+++ b/tools/cosim.py
@@ -2,12 +2,16 @@
 """cosim.py — first-divergence co-simulation coordinator. See COSIM_ORACLE.md.
 
 Launches two clean psx-cosim instances (each its own complete deterministic PSX),
-advances BOTH to the same guest-cycle checkpoints, and compares their full-state chain
-hashes. The first checkpoint whose chains differ brackets the first divergence; the
+advances BOTH to the same retired-instruction-count (icount) checkpoints, and compares
+their full-state chain hashes. Checkpoints are icount-keyed (stride / --max /
+--start-cycle are all in retired instructions, where a branch+delay-slot retires as
+ONE event), so both sides always hash the same architectural position; the guest-cycle
+clock is inside the hash, so cycle-accounting drift is itself a detectable divergence.
+The first checkpoint whose chains differ brackets the first divergence; the
 per-subsystem `sub` hashes + the ring `window` say WHAT and WHERE.
 
 The two instances are NOT interleaved on one timeline — they are two independent
-deterministic runs, sampled at matched guest cycles. Validity rests ENTIRELY on
+deterministic runs, sampled at matched icounts. Validity rests ENTIRELY on
 determinism, which is why you MUST pass the gates first:
 
   # GATE 1 — determinism/hashing: two of the SAME backend must NEVER diverge.
@@ -42,6 +46,27 @@ def tail_file(path, max_bytes=8192):
 
 def launch(mode, port, stride, start_cycle):
     os.makedirs(LOGDIR, exist_ok=True)
+    # Two instances sharing one runtime dir race on mods/state.toml publish
+    # (temp-file rename collision, ENOENT). The mods root is EXE-DIR-relative
+    # (main.cpp: exe_dir_from_argv(argv[0]) / "mods"), NOT cwd-relative — so
+    # instance B needs its OWN exe copy, not just its own cwd. COSIM_CWD_B
+    # names B's runtime dir; B runs the exe found there (override: COSIM_EXE_B).
+    cwd = CWD
+    exe = EXE
+    cwd_b = os.environ.get("COSIM_CWD_B", "")
+    if cwd_b and port != 4600 and str(port).endswith("1"):
+        cwd = cwd_b
+        exe_b = os.environ.get("COSIM_EXE_B",
+                               os.path.join(cwd_b, os.path.basename(EXE)))
+        if not os.path.isfile(exe_b):
+            raise RuntimeError(
+                f"instance B exe not found: {exe_b} — copy the freshly built "
+                f"exe into COSIM_CWD_B (its mods/ root is exe-dir-relative)")
+        if os.path.getmtime(exe_b) < os.path.getmtime(EXE) - 1:
+            raise RuntimeError(
+                f"instance B exe is STALE: {exe_b} is older than {EXE} — "
+                f"copy the freshly built exe into COSIM_CWD_B")
+        exe = exe_b
     env = dict(os.environ)
     env["PSX_HEADLESS"] = "1"
     env["PSX_COSIM_PORT"] = str(port)
@@ -56,8 +81,8 @@ def launch(mode, port, stride, start_cycle):
         env["PSX_FORCE_INTERP"] = "1"
     log_path = os.path.join(LOGDIR, f"cosim_{mode}_{port}_{os.getpid()}.log")
     log_file = open(log_path, "wb")
-    p = subprocess.Popen([EXE, "--headless", "--no-launcher", "--game", GAME],
-                         cwd=CWD, env=env,
+    p = subprocess.Popen([exe, "--headless", "--no-launcher", "--game", GAME],
+                         cwd=cwd, env=env,
                          stdout=log_file, stderr=subprocess.STDOUT,
                          creationflags=0x00000200)
     p._cosim_log_path = log_path
@@ -150,13 +175,15 @@ def main():
     ap.add_argument("--a", default="compiled", choices=["compiled", "interp"])
     ap.add_argument("--b", default="interp",   choices=["compiled", "interp"])
     ap.add_argument("--stride", type=int, default=65536)
-    ap.add_argument("--max", type=int, default=1_500_000_000)  # ~2650 frames
+    ap.add_argument("--max", type=int, default=1_500_000_000,
+                    help="stop after this many retired instructions (icount units)")
     ap.add_argument("--porta", type=int, default=4600)
     ap.add_argument("--portb", type=int, default=4601)
     ap.add_argument("--inject-at", type=int, default=0)
     ap.add_argument("--inject", default="")   # e.g. ram:100000:1  or reg:2:1
     ap.add_argument("--start-cycle", type=int, default=0,
-                    help="free-run to this absolute guest cycle before checkpointing")
+                    help="free-run to this absolute retired-instruction count "
+                         "(icount) before checkpointing")
     ap.add_argument("--cpudiff-at-cp", type=int, default=0,
                     help="step both to this checkpoint and field-diff the CPU dump")
     args = ap.parse_args()
@@ -259,9 +286,12 @@ def main():
                       f"  A: {ra}\n  B: {rb}", flush=True); return
             cyc_a, cyc_b = ra.get("cycle"), rb.get("cycle")
             if cyc_a != cyc_b:
-                print(f"[WARN] cycle skew A={cyc_a} B={cyc_b} at cp {ra.get('cp')} — "
-                      f"the two runs are NOT parking at the same cycle (harness "
-                      f"nondeterminism, not a guest divergence). Investigate before trusting.",
+                print(f"[TIMING] cycle skew A={cyc_a} B={cyc_b} at cp {ra.get('cp')} "
+                      f"icnt A={ra.get('icnt')} B={rb.get('icnt')} — checkpoints are "
+                      f"icount-keyed, so BOTH sides hashed the state after the same "
+                      f"retired-instruction count; a cycle difference here is a REAL "
+                      f"cycle-accounting divergence between the backends (the clock is "
+                      f"in the chain hash, so the chain should differ too).",
                       flush=True)
             if ca != cb:
                 print(f"\n*** FIRST DIVERGENCE at checkpoint cp={ra.get('cp')} "


### PR DESCRIPTION
## Problem
The first-divergence oracle keyed checkpoints on guest cycles, but the
hash/park happened at the first `cosim_instr` boundary AFTER the stride
cycle was crossed. The two backends can reach that crossing at different
retirement positions (charges land in different lumps mid-instruction),
so the oracle compared different architectural states. Observed on CMR2
as a +5-cycle park skew and phantom CPU-register divergences; the WARN
in cosim.py fired on every run past ~6.7e9 cycles, making verdicts
untrustworthy on mixed-mode titles.

## Fix
Checkpoints are now taken inside `cosim_instr`, keyed on the retirement
count itself. Both backends call `cosim_instr` exactly once per
retirement event (a branch and its delay slot retire as ONE event in
both the dirty-RAM interp and the emitted code), so checkpoint k is
"the state after k*stride retirements" on both sides by construction.
The guest-cycle clock stays inside the state hash, so real
cycle-accounting drift still flags — now pinned to an exact instruction
window instead of corrupting the alignment.

cosim.py: stride/--max/--start-cycle are now retirement units; the
cycle-skew warning reports a real timing divergence; `launch()` gives
instance B its own exe copy (the mods root is exe-dir-relative —
`exe_dir_from_argv(argv[0]) / "mods"` — so a shared exe races on
mods/state.toml publish regardless of cwd separation) and refuses a
stale `COSIM_CWD_B` exe.

## Validation (CMR2, SLUS-01222)
- Gate 1: compiled/compiled and interp/interp both clean over 100M
  retirements — with IDENTICAL chain values across the two pairs
  (compiled==interp through ~465 frames).
- Gate 4: injected 1-bit RAM fault detected at the next checkpoint.
- The corrected oracle then found a REAL first divergence at retirement
  3,203,596,289 that the cycle-keyed design had been mislocating — the
  stale-static overlay bug fixed in the companion PR.
