### PR TITLE
runtime: pace frames the GL renderer elides a swap for

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -483,6 +483,9 @@ if(BUILD_TESTING)
         add_test(NAME frame_interpolation_context_ownership_test
                  COMMAND ${Python3_EXECUTABLE}
                          ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_frame_interpolation_context_ownership.py)
+        add_test(NAME present_skip_cadence_guard_test
+                 COMMAND ${Python3_EXECUTABLE}
+                         ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_present_skip_cadence_guard.py)
         add_test(NAME mod_bezel_test
                  COMMAND ${Python3_EXECUTABLE}
                          ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_mod_bezel.py)

--- a/runtime/include/frame_pacing.h
+++ b/runtime/include/frame_pacing.h
@@ -45,6 +45,16 @@ uint32_t frame_pacing_sleep_ms(uint64_t now, uint64_t deadline,
  * period in milliseconds (e.g. 1000.0 / 59.94). */
 void frame_pacer_wait(FramePacer *p, double period_ms);
 
+/* 1 while the display driver's swap block — not the pacer above — is what holds
+ * the guest to its vblank cadence (present_vsync_owns_cadence() in main.cpp).
+ * The two are XOR: when this returns 1 the frontend does not call
+ * frame_pacer_wait(), so the ONLY thing throttling the guest is the swap.
+ *
+ * A renderer that elides a redundant swap (unchanged front buffer) must
+ * therefore not do so while this is 1: the elided frame blocks on nothing, and
+ * a game that presents every other vblank runs at 2x. */
+int psx_present_vsync_owns_cadence(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/runtime/src/gpu_gl_renderer.c
+++ b/runtime/src/gpu_gl_renderer.c
@@ -72,6 +72,7 @@
 #include "psx_savestate_menu.h"
 #include "host_time.h"
 #include "latency_ring.h"
+#include "frame_pacing.h"
 #include "psx_rewind.h"
 
 #include "psx_sdl.h"
@@ -622,7 +623,14 @@ static uint64_t   s_coh_seq = 0;
 
 /* 16x16 native-pixel tiles changed since their last on-screen present. This
  * lets a double-buffered 30 Hz game avoid swapping the unchanged front buffer
- * on the intervening 60 Hz vblank without guessing from game identity. */
+ * on the intervening 60 Hz vblank without guessing from game identity.
+ *
+ * INVARIANT: eliding a swap also elides whatever that swap was blocking on.
+ * The frontend calls present once per guest vblank, so when the driver's swap
+ * block owns the guest cadence (psx_present_vsync_owns_cadence(), the XOR
+ * partner of the wall-clock pacer) an elided frame is an unthrottled frame:
+ * a 30 Hz-presenting game then advances two vblanks per block and runs at 2x.
+ * Every skip site below is therefore gated on that query. */
 #define PRES_TILE 16
 #define PRES_ROWS (VRAM_H / PRES_TILE)
 static uint64_t s_present_dirty[PRES_ROWS];
@@ -4181,6 +4189,7 @@ void gl_renderer_present_vram(int disp_x, int disp_y, int w, int h, int linear,
         s_last_dw == w && s_last_dh == h &&
         !present_dirty_test(disp_x, disp_y, disp_x + w - 1, disp_y + h - 1) &&
         !host_osd_needs_present() &&
+        !psx_present_vsync_owns_cadence() &&
         !gl_renderer_interpolation_owns_cadence()) {
         s_probe_skip++;
         gl_perf_present_enter();
@@ -4291,6 +4300,7 @@ int gl_renderer_present_wide_fbo(int disp_x, int disp_y, int disp_h, int linear)
         s_last_dw == g_wide_w && s_last_dh == disp_h &&
         !present_dirty_test(0, disp_y, VRAM_W - 1, disp_y + disp_h - 1) &&
         !host_osd_needs_present() &&
+        !psx_present_vsync_owns_cadence() &&
         !gl_renderer_interpolation_owns_cadence()) {
         s_probe_skip++;
         gl_perf_present_enter();

--- a/runtime/src/main.cpp
+++ b/runtime/src/main.cpp
@@ -2753,6 +2753,12 @@ static int present_vsync_owns_cadence(void) {
     return host_refresh_matches_guest_cadence();
 }
 
+/* C accessor for the renderers (frame_pacing.h). The GL present-skip
+ * optimisation must consult this before eliding a swap. */
+extern "C" int psx_present_vsync_owns_cadence(void) {
+    return present_vsync_owns_cadence();
+}
+
 static int present_effective_swap_interval(void) {
     if (g_netplay_vsync_forced_off || psx_netplay_active())
         return 0;

--- a/runtime/tests/test_present_skip_cadence_guard.py
+++ b/runtime/tests/test_present_skip_cadence_guard.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Every GL present-skip site must be gated on the vsync-cadence query.
+
+The renderer may elide a swap whose front buffer is unchanged. The frontend
+calls present once per guest vblank, so eliding a swap also elides whatever
+that swap was blocking on. When driver vsync owns the guest cadence the
+wall-clock pacer is deliberately not run (they are XOR), which makes the swap
+block the ONLY throttle -- and an elided frame is then unthrottled. A game that
+presents every other vblank (BoF3, and any other 30 Hz-presenting title) ran at
+exactly 2x on a ~60 Hz panel until each skip site consulted this query.
+"""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+RENDERER = (ROOT / "runtime" / "src" / "gpu_gl_renderer.c").read_text(
+    encoding="utf-8"
+)
+MAIN = (ROOT / "runtime" / "src" / "main.cpp").read_text(encoding="utf-8")
+PACING = (ROOT / "runtime" / "include" / "frame_pacing.h").read_text(
+    encoding="utf-8"
+)
+
+# The skip sites are the branches that increment the probe skip counter and
+# return without reaching SDL_GL_SwapWindow. Both consult the OSD, the
+# interpolation-cadence owner, and the vsync-cadence owner.
+skips = RENDERER.count("s_probe_skip++;")
+assert skips >= 2, "expected the VRAM and wide-FBO present-skip sites"
+assert RENDERER.count("!psx_present_vsync_owns_cadence() &&") == skips, (
+    "every present-skip site must be gated on psx_present_vsync_owns_cadence(); "
+    "an ungated skip lets the guest free-run when driver vsync owns cadence"
+)
+assert RENDERER.count("!host_osd_needs_present() &&") == skips
+assert RENDERER.count("!gl_renderer_interpolation_owns_cadence()) {") == skips
+
+# The query is declared beside the pacer it is the XOR partner of, and defined
+# in the frontend that owns the cadence decision.
+assert "int psx_present_vsync_owns_cadence(void);" in PACING
+assert 'extern "C" int psx_present_vsync_owns_cadence(void) {' in MAIN
+assert "return present_vsync_owns_cadence();" in MAIN
+
+print("present-skip cadence guard passed (%d skip sites gated)" % skips)


### PR DESCRIPTION
The GL renderer may skip SDL_GL_SwapWindow when the displayed rect is unchanged, so a double-buffered 30 Hz game does not swap an identical front buffer on the intervening vblank. The frontend calls present once per guest vblank, so eliding a swap also elides whatever that swap was blocking on.

That is only safe while the wall-clock pacer owns cadence, because the pacer runs per present regardless of what the renderer does. When driver vsync owns cadence instead (~60 Hz panel, present_vsync_owns_cadence()), the pacer is deliberately not run -- the two are XOR to avoid double-blocking -- and the swap block becomes the only throttle. An elided frame then blocks on nothing, and a game presenting every other vblank advances two guest vblanks per block: exactly 2x real time.

Measured on BreathOfFire3Recomp (SLPS-00990, 60 Hz panel, OpenGL): guest vblank counter sampled against wall clock ran 120.4 fps / 2.01x before, 59.8 fps / 0.997x after. Swaps per second are unchanged at 60 either way -- the fix removes a free-running guest frame, not a swap -- and per-frame GPU cost is unchanged (present_gpu_ms_avg 12.2 -> 12.6, scene_gpu_ms_avg 4.5 -> 4.1).

Gate both skip sites (VRAM and wide-FBO paths) on the cadence owner, alongside the existing OSD and interpolation-cadence guards. Only the GL renderer has this optimisation; the software and Vulkan paths always present and were never affected.