### PR TITLE
tools: support SYSTEM.CNF-less discs via the BIOS PSX.EXE boot path

### DIFF
--- a/tools/new_project_layout/probe_disc.py
+++ b/tools/new_project_layout/probe_disc.py
@@ -412,12 +412,24 @@ def probe(cue_path: Path, *, identity_only: bool = False) -> DiscProbe:
     entries = parse_root_entries(bytes(root[:root_size]))
 
     if "SYSTEM.CNF" not in entries:
-        raise SystemExit(
-            f"SYSTEM.CNF missing on disc (found {sorted(entries)[:24]})"
+        # Very early titles (e.g. King's Field, Dec 1994) ship no SYSTEM.CNF;
+        # the BIOS falls back to booting PSX.EXE from the root directory.
+        psx_exe = next((k for k in entries if k.upper() == "PSX.EXE"), None)
+        if psx_exe is None:
+            raise SystemExit(
+                f"SYSTEM.CNF missing on disc and no PSX.EXE fallback "
+                f"(found {sorted(entries)[:24]})"
+            )
+        boot_token = psx_exe
+        warnings.append(
+            "SYSTEM.CNF missing; using the BIOS PSX.EXE fallback boot path. "
+            "No serial is recoverable from the filesystem — set game_id "
+            "manually in catalog_identity.json / game.toml."
         )
-    extent, fsize = entries["SYSTEM.CNF"]
-    cnf = read_file(read_user, data, extent, fsize)
-    boot_token = parse_system_cnf(cnf)
+    else:
+        extent, fsize = entries["SYSTEM.CNF"]
+        cnf = read_file(read_user, data, extent, fsize)
+        boot_token = parse_system_cnf(cnf)
     serial, boot_exe = normalize_serial(boot_token)
 
     disc_boot = boot_token

--- a/tools/prepare_disc.py
+++ b/tools/prepare_disc.py
@@ -400,7 +400,23 @@ def extract_via(
     root = bytes(root[:root_size])
     entries = parse_root_entries(root)
     files: dict[str, bytes] = {}
-    for need in ("SYSTEM.CNF", boot_exe):
+    # Very early titles (e.g. King's Field, Dec 1994) ship no SYSTEM.CNF; the
+    # BIOS falls back to booting PSX.EXE from the root directory. probe_disc.py
+    # already accepts these discs (5ab7a053); staging has to accept the same
+    # ones or a clean worktree can never prepare them.
+    needed = ["SYSTEM.CNF", boot_exe]
+    if "SYSTEM.CNF" not in entries:
+        if boot_exe not in entries:
+            raise SystemExit(
+                f"SYSTEM.CNF missing on disc and no {boot_exe} fallback "
+                f"(found {sorted(entries)[:20]})"
+            )
+        print(
+            "  SYSTEM.CNF missing; using the BIOS "
+            f"{boot_exe} fallback boot path"
+        )
+        needed = [boot_exe]
+    for need in needed:
         if need not in entries:
             raise SystemExit(f"missing {need} on disc (found {sorted(entries)[:20]})")
         extent, size = entries[need]


### PR DESCRIPTION
Pre-1995 PlayStation discs ship no `SYSTEM.CNF`; the BIOS boots `PSX.EXE` from
the root directory instead. Both disc tools currently reject those discs
outright, so such a title cannot be scaffolded or staged at all.

```
missing SYSTEM.CNF on disc (found ['COPY.TXT', 'E0.', 'E1.', 'E2.', 'E3.',
  'GAME.EXE', 'KF', 'LICENSEJ.DAT', 'OPEN.EXE', 'PSX.EXE'])
```

Two commits, one per tool:

1. `probe_disc.py` — fall back to a root `PSX.EXE` when `SYSTEM.CNF` is absent,
   and warn that no serial is recoverable from the filesystem (it has to be set
   manually in `game.toml` / `catalog_identity.json`).
2. `prepare_disc.py` — same fallback in `extract_via()` so staging accepts the
   discs the probe now accepts. Without this, `generate` still fails on any
   clean worktree, because `psxrecomp_cli` only skips `prepare_disc` when the
   boot EXE is already staged (`need_prep = (not boot_path.is_file()) or ...`).

### Testing

King's Field (Japan, SLPS-00017, Dec 1994 — the first SYSTEM.CNF-less title we
have hit) on Rocky Linux 9.8, clang 21.1.8:

```
SYSTEM.CNF missing; using the BIOS PSX.EXE fallback boot path
PSX.EXE PC0=0x80010100 (4096 bytes)
Dispatch table written (9 entries)
boot_gate: PASS (frames=9699, min=600)
```

The 9-entry dispatch matches the reference build made on Windows with the probe
half applied locally. Discs that do have `SYSTEM.CNF` are unaffected — the
fallback only triggers when the file is missing, and a missing `PSX.EXE` still
raises. 44 other titles built unchanged with these commits in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011sye8WS8A8WzgiMuPSgUc4
