### PR TITLE
tools: keep prepare_disc working on Python 3.9

### DIFF
--- a/tools/prepare_disc.py
+++ b/tools/prepare_disc.py
@@ -298,7 +298,11 @@ def stage_multitrack_cue(
         text = re.sub(
             r'FILE\s+"([^"]+)"\s+BINARY', _basename_file, text, flags=re.I
         )
-        cue_dest.write_text(text, encoding="utf-8", newline="\n")
+        # NB: Path.write_text(newline=) is Python 3.10+. Use open() so the
+        # tools keep working on 3.9, which RHEL/Rocky 9, Debian 11 and Ubuntu
+        # 20.04 still ship as the system python3.
+        with open(cue_dest, "w", encoding="utf-8", newline="\n") as fh:
+            fh.write(text)
         print(f"wrote {cue_dest}")
     else:
         print(f"source cue already at {cue_dest}")
@@ -626,13 +630,12 @@ def main() -> int:
         bin_path.write_bytes(bin_data)
 
     cue_path = cfg.out_dir / cfg.cue_name
-    cue_path.write_text(
-        f'FILE "{cfg.bin_name}" BINARY\n'
-        f"  TRACK 01 MODE2/2352\n"
-        f"    INDEX 01 00:00:00\n",
-        encoding="ascii",
-        newline="\n",
-    )
+    with open(cue_path, "w", encoding="ascii", newline="\n") as fh:
+        fh.write(
+            f'FILE "{cfg.bin_name}" BINARY\n'
+            f"  TRACK 01 MODE2/2352\n"
+            f"    INDEX 01 00:00:00\n"
+        )
     print(f"wrote {cue_path}")
 
     out_md5, out_sha1, out_size = file_hashes(bin_path)


### PR DESCRIPTION
`Path.write_text(newline=...)` is Python 3.10+. On distributions whose system
`python3` is still 3.9 — RHEL/Rocky 9, Debian 11, Ubuntu 20.04 — `prepare_disc`
dies after writing the .bin but before the .cue:

```
Traceback (most recent call last):
  File "tools/prepare_disc.py", line 653, in <module>
    raise SystemExit(main())
  File "tools/prepare_disc.py", line 629, in main
    cue_path.write_text(
TypeError: write_text() got an unexpected keyword argument 'newline'
```

`open(..., newline=...)` is behaviour-identical and available on every supported
version. Two call sites (lines 301 and 629) are the only ones affected.

This is the sole 3.10 dependency in the tools: everything else already relies on
`from __future__ import annotations`, and the repo declares no minimum Python
(no `python_requires`, no CI pin), so 3.9 is otherwise supported today.

### Testing

Ran the real `prepare_disc.py` under Python 3.9.25 on Rocky Linux 9.8 against a
retail dump — full path exercised, including digest verification and staging:

```
known digest OK
PSX.EXE PC0=0x80010100 (4096 bytes)
RESULT_CUE=.../disc/disc1.cue
```

Byte-identical output to the same run under 3.11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011sye8WS8A8WzgiMuPSgUc4
