### PR TITLE
tools: restore Unix modes when unpacking the toolchain zip

### DIFF
--- a/tools/toolchain_pack.py
+++ b/tools/toolchain_pack.py
@@ -817,6 +817,20 @@ def unpack_zip_to(zip_path: Path, dest: Path) -> Path:
     dest.mkdir(parents=True, exist_ok=True)
     with zipfile.ZipFile(zip_path, "r") as zf:
         zf.extractall(dest)
+        # zipfile.extractall() discards the Unix mode held in external_attr, so
+        # on POSIX hosts every binary lands 0644 and the pack is unusable:
+        # "Toolchain cmake probe failed ... [Errno 13] Permission denied".
+        # Restore the recorded mode (zips built on Windows record none, in
+        # which case the extracted default is already correct).
+        if os.name != "nt":
+            for info in zf.infolist():
+                if info.is_dir():
+                    continue
+                mode = (info.external_attr >> 16) & 0o7777
+                if mode:
+                    target = dest / info.filename
+                    if target.exists():
+                        target.chmod(mode)
     root = unwrap_pack_root(dest)
     if not pack_root_looks_usable(root):
         raise RuntimeError(f"toolchain zip missing bin/{cmake_name()}: {zip_path}")


### PR DESCRIPTION
`zipfile.extractall()` ignores the Unix mode recorded in
`ZipInfo.external_attr`, so on POSIX hosts every file in the cmake-clang-v1
pack is extracted `0644`. The toolchain is then unusable and
`ensure-toolchain` fails immediately after a successful download:

```
Downloading cmake-clang-v1-linux-x64.zip from TechnicallyComputers/retcomm-toolchains...
Toolchain cmake probe failed (.../cmake-clang-v1/1.0.14/bin/cmake):
  [Errno 13] Permission denied
Toolchain ensure: Downloaded toolchain but cmake is unusable
```

`unpack_zip_to()` now restores the recorded mode after extraction. Zips built on
Windows record no Unix mode, in which case the extracted default already
applies, and the block is skipped entirely on `nt`.

### Testing

Against a zip that records `0755` on a binary:

| | mode | `os.access(X_OK)` |
|---|---|---|
| `extractall()` alone | `0644` | False |
| with this change | `0755` | True |

Observed originally on Rocky Linux 9.8 while bootstrapping the recompiler
emitters; the downloaded pack could not be probed at all until the modes were
repaired by hand.

### Two related issues, not addressed here

1. When the toolchain is present but unusable, `_build_recompiler_targets` logs
   `Using system cmake/ninja on PATH for emitters` and then still invokes the
   toolchain's cmake/clang/sysroot, failing on the same `Permission denied`.
   When the toolchain is absent the fallback works correctly. This change makes
   that state much harder to reach but does not fix the inconsistency.
2. cmake-clang-v1 1.0.14's clang requires `GLIBCXX_3.4.30`; RHEL/Rocky 9 provide
   at most 3.4.29, so the pack's clang cannot execute there even with modes
   restored. A documented libstdc++ floor, or preferring system clang when the
   bundled one fails to run, would help. For reference, 45 titles built cleanly
   on this host with system clang 21.1.8 via `--no-toolchain-download`.

Happy to split those out if you would rather track them separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011sye8WS8A8WzgiMuPSgUc4
