### PR TITLE
Preserve an explicit RECOMP_UI_ROOT

### DIFF
--- a/recompiler/CMakeLists.txt
+++ b/recompiler/CMakeLists.txt
@@ -610,6 +610,7 @@ if(BUILD_TESTING)
                 release_zip
                 overlay_decodable_fallback
                 overlay_init_guard
+                recomp_ui_root_override
                 pal_cadence_host_refresh
                 sdl3_main_single_include
                 spu_sample_scheduler_default

--- a/runtime/runtime.cmake
+++ b/runtime/runtime.cmake
@@ -1878,8 +1878,9 @@ function(psxrecomp_add_game_runtime target)
             "-DPSX_GAME_VERSION=${_psxg_release_version} or delete the build cache.")
     endif()
 
-    # Prefer game-root recomp-ui (runtime.cmake also auto-discovers this).
-    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/recomp-ui/recomp_ui.cmake")
+    # Use a game-root recomp-ui only when the caller did not select one.
+    if((NOT RECOMP_UI_ROOT OR RECOMP_UI_ROOT STREQUAL "")
+       AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/recomp-ui/recomp_ui.cmake")
         set(RECOMP_UI_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/recomp-ui" CACHE PATH
             "Path to recomp-ui launcher" FORCE)
     endif()

--- a/runtime/tests/test_recomp_ui_root_override.py
+++ b/runtime/tests/test_recomp_ui_root_override.py
@@ -10,10 +10,16 @@ RUNTIME_CMAKE = ROOT / "runtime" / "runtime.cmake"
 
 def main() -> None:
     text = RUNTIME_CMAKE.read_text(encoding="utf-8")
-    expected = """if((NOT RECOMP_UI_ROOT OR RECOMP_UI_ROOT STREQUAL \"\")
+    function_fallback = """if((NOT RECOMP_UI_ROOT OR RECOMP_UI_ROOT STREQUAL \"\")
        AND EXISTS \"${CMAKE_CURRENT_SOURCE_DIR}/recomp-ui/recomp_ui.cmake\")"""
-    assert expected in text, (
-        "runtime packaging must preserve an explicit RECOMP_UI_ROOT before "
+    module_fallback = """if(PSX_RECOMP_UI AND (NOT RECOMP_UI_ROOT OR RECOMP_UI_ROOT STREQUAL \"\"))
+    if(EXISTS \"${CMAKE_SOURCE_DIR}/recomp-ui/recomp_ui.cmake\")"""
+    assert function_fallback in text, (
+        "the game-runtime function must preserve an explicit RECOMP_UI_ROOT "
+        "before falling back to the game-root recomp-ui"
+    )
+    assert module_fallback in text, (
+        "the runtime module must preserve an explicit RECOMP_UI_ROOT before "
         "falling back to the game-root recomp-ui"
     )
 

--- a/runtime/tests/test_recomp_ui_root_override.py
+++ b/runtime/tests/test_recomp_ui_root_override.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+"""Guard the caller-selected recomp-ui root against game-root replacement."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+RUNTIME_CMAKE = ROOT / "runtime" / "runtime.cmake"
+
+
+def main() -> None:
+    text = RUNTIME_CMAKE.read_text(encoding="utf-8")
+    expected = """if((NOT RECOMP_UI_ROOT OR RECOMP_UI_ROOT STREQUAL \"\")
+       AND EXISTS \"${CMAKE_CURRENT_SOURCE_DIR}/recomp-ui/recomp_ui.cmake\")"""
+    assert expected in text, (
+        "runtime packaging must preserve an explicit RECOMP_UI_ROOT before "
+        "falling back to the game-root recomp-ui"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- keep a caller-supplied `RECOMP_UI_ROOT`
- use a game-local `recomp-ui` directory only when the variable is unset or empty
- test both fallback sites

This restores normal CMake ownership. An explicit dependency override is no longer replaced by a sibling checkout.

## Review and scope

- Upstream base: `47bda8172e43fdba1879c1a5885904a265c567f6`
- Reviewed head: `4be931502f70a321d63d0986b414169e10ba6ed3`
- Fork review: https://github.com/Alexbeav/psxrecomp/pull/17
- Scope: 3 files; no game data, BIOS data, generated retail code, private paths, or title-specific hooks
- Final AI review: no issues found; no unresolved review threads

## Validation

- `test_recomp_ui_root_override.py`: pass
- CMake retained a different explicit UI root even when a game-local directory existed
- full framework build: pass
- CTest with `PYTHONUTF8=1`: 54 of 56 enabled tests pass
- the same two failures occur on the clean base: `aot_overlay_discovery` assumes a missing MSYS2 GCC path, and `release_zip` expects Unix newlines on Windows

Developed with AI assistance; validated as described (test evidence in PR body). AI writes the code and the PR, but I always test before I send something up. Happy to iterate on this process with your feedback.
