### PR TITLE
Make zero-BIOS registries portable to MSVC

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -537,6 +537,9 @@ if(BUILD_TESTING)
         add_test(NAME cdrom_lid_integration_test
                  COMMAND ${Python3_EXECUTABLE}
                          ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_cdrom_lid_integration.py)
+        add_test(NAME bios_registry_zero_entry_guard_test
+                 COMMAND ${Python3_EXECUTABLE}
+                         ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_bios_registry_zero_entry.py)
     endif()
 
     # Full card protocol regression: read, write, address echo, per-slot state,

--- a/runtime/runtime.cmake
+++ b/runtime/runtime.cmake
@@ -667,6 +667,15 @@ else()
     list(LENGTH _psxrt_bios_linked _psxrt_bios_count)
 endif()
 
+# ISO C requires at least one initializer. A setup host can intentionally have
+# zero linked BIOS backends, so give the generated array one unused null entry
+# while keeping its public count at zero. MSVC 19.44 otherwise crashes with
+# C1001 in CloseTypeServerPDB when it compiles an empty initializer list.
+if(NOT _psxrt_registry_entries)
+    set(_psxrt_registry_entries "    0, /* unused: registry count is zero */
+")
+endif()
+
 # Registry of the compiled-in backends, in preference order. Generated so the
 # stem list stays the single source of truth.
 set(_psxrt_registry_c "${CMAKE_BINARY_DIR}/psx_bios_registry.c")

--- a/runtime/tests/test_bios_registry_zero_entry.py
+++ b/runtime/tests/test_bios_registry_zero_entry.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+"""Keep setup-host BIOS registry generation valid ISO C."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+RUNTIME_CMAKE = (ROOT / "runtime" / "runtime.cmake").read_text(encoding="utf-8")
+
+guard = "if(NOT _psxrt_registry_entries)"
+sentinel = 'set(_psxrt_registry_entries "    0, /* unused: registry count is zero */'
+writer = 'set(_psxrt_registry_c "${CMAKE_BINARY_DIR}/psx_bios_registry.c")'
+
+assert guard in RUNTIME_CMAKE
+assert sentinel in RUNTIME_CMAKE
+assert RUNTIME_CMAKE.index(guard) < RUNTIME_CMAKE.index(writer)
+
+print("zero-entry BIOS registry guard passed")


### PR DESCRIPTION
## Summary

- emit one unused null sentinel when a setup host has no generated BIOS backends
- keep `psx_bios_registry_count` at zero, so runtime behavior is unchanged
- add a focused source regression

An empty C array initializer is not portable. MSVC rejects the former zero-entry output. The sentinel gives the array valid storage while the public count remains authoritative.

## Review and scope

- Upstream base: `47bda8172e43fdba1879c1a5885904a265c567f6`
- Reviewed head: `811d28be15fa64f7a9d580cbe848269818c75691`
- Fork review: https://github.com/Alexbeav/psxrecomp/pull/18
- Scope: 3 files; no game data, BIOS data, generated retail code, private paths, or title-specific hooks
- Final AI review: no issues found; no unresolved review threads

## Validation

- `test_bios_registry_zero_entry.py`: pass
- full framework build: pass
- CTest with `PYTHONUTF8=1`: 54 of 56 enabled tests pass
- generated a true zero-backend registry with one unused null sentinel and a public count of zero
- compiled that generated C file with MSVC 19.44: pass
- the full Visual Studio project still stops on the clean-base multi-config `psx_game_version.txt` collision; that separate repair is excluded from this PR

Developed with AI assistance; validated as described (test evidence in PR body). AI writes the code and the PR, but I always test before I send something up. Happy to iterate on this process with your feedback.
