### PR TITLE
Hardening Deployments == self-build: fail loudly on marker skew instead of looping generate+build

### DIFF
--- a/docs/ci/templates/game.gitignore
+++ b/docs/ci/templates/game.gitignore
@@ -69,6 +69,8 @@ psx_crash.txt
 psx_last_run_report.json
 psx_screenshot.bmp
 psx_freeze_heartbeat.json
+.psxrecomp_last_generate
+.psxrecomp_write_probe
 starvation_dump.jsonl
 
 # Diagnostic dumps (root-level) — keep catalog / probe trackable

--- a/docs/ci/templates/setup-release.yml
+++ b/docs/ci/templates/setup-release.yml
@@ -195,6 +195,14 @@ jobs:
         shell: bash
         run: bash psxrecomp/tools/ci/record_pins.sh
 
+      # A skew between game.toml, CMakeLists GEN_MARKER and codegen_setup.c
+      # makes every player's self-build loop generate+build forever. The CLI
+      # also refuses the skew at generate time, but failing the release is
+      # cheaper than failing the player.
+      - name: Lint boot-EXE name consistency
+        shell: bash
+        run: bash psxrecomp/tools/ci/check_boot_exe.sh .
+
       - name: Setup host mode (no game C / BIOS backends in CI)
         shell: bash
         run: bash psxrecomp/tools/ci/clear_generated.sh

--- a/host/psxrecomp_codegen_host.c
+++ b/host/psxrecomp_codegen_host.c
@@ -6,6 +6,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 
 #if defined(_WIN32)
 #  include <windows.h>
@@ -3582,6 +3583,165 @@ static void host_update_disc_set(RecompLauncherCPrepareProgressFn on_progress,
                     "Could not record every disc — continuing with the boot disc.");
 }
 
+/* ---- self-build loop breaker + preflight ------------------------------- */
+
+#define HOST_LAST_GENERATE_SIDECAR ".psxrecomp_last_generate"
+/* A wizard loop iterates in minutes; a recent stamp with sources still
+ * missing means "generate worked but nothing gates on its output" — a
+ * config skew — not a user who wiped generated/ last week. */
+#define HOST_LOOP_BREAKER_WINDOW_SECS (6 * 60 * 60)
+
+static char g_loop_breaker_note[1024];
+
+/* Comma-join the *_dispatch.c basenames under <root>/generated. */
+static void list_generated_dispatch(char* out, size_t cap) {
+    char dir[1100];
+    size_t used = 0;
+    out[0] = '\0';
+    if (!join_path(dir, sizeof(dir), g_project_root, "generated"))
+        return;
+#if defined(_WIN32)
+    {
+        char pat[1200];
+        WIN32_FIND_DATAA fd;
+        HANDLE h;
+        if (!join_path(pat, sizeof(pat), dir, "*_dispatch.c"))
+            return;
+        h = FindFirstFileA(pat, &fd);
+        if (h == INVALID_HANDLE_VALUE)
+            return;
+        do {
+            int n = snprintf(out + used, cap - used, "%s%s",
+                             used ? ", " : "", fd.cFileName);
+            if (n <= 0 || (size_t)n >= cap - used)
+                break;
+            used += (size_t)n;
+        } while (FindNextFileA(h, &fd));
+        FindClose(h);
+    }
+#else
+    {
+        static const char suffix[] = "_dispatch.c";
+        DIR* d = opendir(dir);
+        struct dirent* e;
+        if (!d)
+            return;
+        while ((e = readdir(d)) != NULL) {
+            size_t len = strlen(e->d_name);
+            int n;
+            if (len <= sizeof(suffix) - 1 ||
+                strcmp(e->d_name + len - (sizeof(suffix) - 1), suffix) != 0)
+                continue;
+            n = snprintf(out + used, cap - used, "%s%s",
+                         used ? ", " : "", e->d_name);
+            if (n <= 0 || (size_t)n >= cap - used)
+                break;
+            used += (size_t)n;
+        }
+        closedir(d);
+    }
+#endif
+}
+
+static void host_record_generate_ok(void) {
+    char sidecar[1200], line[32];
+    if (!join_path(sidecar, sizeof(sidecar), g_project_root,
+                   HOST_LAST_GENERATE_SIDECAR))
+        return;
+    snprintf(line, sizeof(line), "%lld", (long long)time(NULL));
+    write_line_file(sidecar, line);
+}
+
+static void host_clear_generate_stamp(void) {
+    char sidecar[1200];
+    if (join_path(sidecar, sizeof(sidecar), g_project_root,
+                  HOST_LAST_GENERATE_SIDECAR))
+        remove(sidecar);
+}
+
+/* apply() consults this when the wizard is about to reopen because sources
+ * are missing. If a generate succeeded here recently, re-running it will
+ * loop — say exactly what is missing and what exists instead of silently
+ * re-prompting. Returns NULL when there is nothing to warn about. */
+static const char* host_loop_breaker_note(void) {
+    char sidecar[1200], line[64], found[512], marker_abs[1200];
+    long long then, now;
+    const char* marker_rel;
+    int game_missing, bios_missing;
+    if (!join_path(sidecar, sizeof(sidecar), g_project_root,
+                   HOST_LAST_GENERATE_SIDECAR))
+        return NULL;
+    if (!read_line_file(sidecar, line, sizeof(line)))
+        return NULL;
+    then = strtoll(line, NULL, 10);
+    now = (long long)time(NULL);
+    if (then <= 0 || now < then || now - then > HOST_LOOP_BREAKER_WINDOW_SECS)
+        return NULL;
+    marker_rel = cfg_or(g_cfg->gen_marker_relpath,
+                        "generated/SLUS_011.89_dispatch.c");
+    game_missing =
+        !join_path(marker_abs, sizeof(marker_abs), g_project_root,
+                   marker_rel) ||
+        !path_is_file(marker_abs);
+    bios_missing = bios_backends_missing();
+    if (!game_missing && !bios_missing)
+        return NULL;
+    list_generated_dispatch(found, sizeof(found));
+    snprintf(g_loop_breaker_note, sizeof(g_loop_breaker_note),
+             "A Generate completed here recently, yet the launcher still "
+             "cannot find %s%s%s. generated/ contains: %s. Running Generate "
+             "again will very likely loop — please report this to the port "
+             "maintainer: the project's boot-EXE names disagree.",
+             game_missing ? marker_rel : "",
+             (game_missing && bios_missing) ? " and " : "",
+             bios_missing ? "the BIOS backends under psxrecomp/generated/"
+                          : "",
+             found[0] ? found : "no *_dispatch.c at all");
+    fprintf(stderr, "psxrecomp-codegen: %s\n", g_loop_breaker_note);
+    return g_loop_breaker_note;
+}
+
+/* Generating into Explorer's temporary zip extraction (Windows) or an
+ * unwritable folder always ends badly — the output evaporates or never
+ * lands, and the wizard reopens forever. Refuse with instructions. */
+static int host_preflight_project_root(char* err_msg, size_t err_cap) {
+#if defined(_WIN32)
+    {
+        char tmp[MAX_PATH];
+        DWORD n = GetTempPathA((DWORD)sizeof(tmp), tmp);
+        if (n > 0 && n < (DWORD)sizeof(tmp) &&
+            _strnicmp(g_project_root, tmp, strlen(tmp)) == 0) {
+            snprintf(err_msg, err_cap,
+                     "This game is running from a temporary folder (%s), "
+                     "usually because the downloaded ZIP was opened without "
+                     "extracting it. Extract the whole ZIP to a normal "
+                     "folder, then run the game from there.",
+                     g_project_root);
+            return 0;
+        }
+    }
+#endif
+    {
+        char probe[1200];
+        FILE* f;
+        if (!join_path(probe, sizeof(probe), g_project_root,
+                       ".psxrecomp_write_probe"))
+            return 1; /* path too long — let the CLI surface the real error */
+        f = fopen(probe, "wb");
+        if (!f) {
+            snprintf(err_msg, err_cap,
+                     "The install folder is not writable: %s. Move the game "
+                     "folder somewhere writable (e.g. your user folder) or "
+                     "fix its permissions, then retry.",
+                     g_project_root);
+            return 0;
+        }
+        fclose(f);
+        remove(probe);
+    }
+    return 1;
+}
+
 static int host_prepare_generate(const char* source_path, char* out_path,
                                  size_t out_cap, char* err_msg, size_t err_cap,
                                  RecompLauncherCPrepareProgressFn on_progress,
@@ -3594,6 +3754,8 @@ static int host_prepare_generate(const char* source_path, char* out_path,
         snprintf(err_msg, err_cap, "No disc selected.");
         return 0;
     }
+    if (!host_preflight_project_root(err_msg, err_cap))
+        return 0;
     activate_toolchain_path();
     if (!find_python(g_python, sizeof(g_python))) {
         /* First-run / pruned cache: page 0 normally installed the pack; heal. */
@@ -3698,6 +3860,10 @@ static int host_prepare_generate(const char* source_path, char* out_path,
                        "psxrecomp generate"))
         return 0;
 #endif
+
+    /* Stamp the success so apply() can tell "generate worked but the
+     * launcher still cannot see its output" apart from a plain first run. */
+    host_record_generate_ok();
 
     snprintf(out_path, out_cap, "%s", source_path);
     if (on_progress)
@@ -4365,6 +4531,19 @@ void psxrecomp_codegen_host_apply(RecompLauncherCGameInfo* gi,
     if (psxrecomp_codegen_host_sources_missing(cfg) || force_setup) {
         gi->needs_setup = 1;
         gi->prepare_required_before_continue = 1;
+        if (!force_setup) {
+            /* Loop breaker: a recent successful generate with sources still
+             * missing is a config skew, not a first run — say so in the
+             * wizard instead of silently asking for another round. */
+            const char* note = host_loop_breaker_note();
+            if (note)
+                gi->prepare_disc_note = note;
+        }
+    } else {
+        /* Sources are visible again — the last generate resolved; drop the
+         * stamp so a much later manual wipe of generated/ reads as a fresh
+         * first run, not a loop. */
+        host_clear_generate_stamp();
     }
 #endif /* PSX_HAS_SETUP_WIZARD */
 }

--- a/host/psxrecomp_codegen_host.c
+++ b/host/psxrecomp_codegen_host.c
@@ -3645,19 +3645,31 @@ static int host_prepare_generate(const char* source_path, char* out_path,
     fprintf(stderr, "psxrecomp-codegen: generate disc=%s bios=%s\n", source_path,
             have_bios ? bios_path : "(OpenBIOS)");
 
+    /* The exact dispatch filename this host (and CMakeLists GEN_MARKER) will
+     * gate on later. Handing it to generate makes a boot-exe name skew fail
+     * there, loudly, instead of surfacing as an endless setup-wizard loop. */
+    const char* marker_rel =
+        cfg_or(g_cfg->gen_marker_relpath, "generated/SLUS_011.89_dispatch.c");
+    const char* marker_name = marker_rel;
+    for (const char* p = marker_rel; *p; ++p)
+        if (*p == '/' || *p == '\\')
+            marker_name = p + 1;
+
 #if defined(_WIN32)
     char cmdline[4096];
     if (have_bios) {
         snprintf(cmdline, sizeof(cmdline),
                  "\"%s\" \"%s\" generate --project-root \"%s\" --config \"%s\" "
-                 "--disc \"%s\" --bios \"%s\" --json-progress",
+                 "--disc \"%s\" --bios \"%s\" --gen-marker \"%s\" "
+                 "--json-progress",
                  g_python, g_cli_path, g_project_root, g_game_toml, source_path,
-                 bios_path);
+                 bios_path, marker_name);
     } else {
         snprintf(cmdline, sizeof(cmdline),
                  "\"%s\" \"%s\" generate --project-root \"%s\" --config \"%s\" "
-                 "--disc \"%s\" --json-progress",
-                 g_python, g_cli_path, g_project_root, g_game_toml, source_path);
+                 "--disc \"%s\" --gen-marker \"%s\" --json-progress",
+                 g_python, g_cli_path, g_project_root, g_game_toml, source_path,
+                 marker_name);
     }
     if (!run_cli_win(cmdline, on_progress, progress_ctx, err_msg, err_cap,
                      "psxrecomp generate"))
@@ -3678,6 +3690,8 @@ static int host_prepare_generate(const char* source_path, char* out_path,
         argv[argc++] = "--bios";
         argv[argc++] = bios_path;
     }
+    argv[argc++] = "--gen-marker";
+    argv[argc++] = (char*)marker_name;
     argv[argc++] = "--json-progress";
     argv[argc] = NULL;
     if (!run_cli_posix(argv, on_progress, progress_ctx, err_msg, err_cap,
@@ -3742,6 +3756,14 @@ static int write_windows_deferred_rebuild_helper(int force_pgo,
     bat_write_set(f, "EXE_BASE", g_exe_basename);
     bat_write_set(f, "EXE", g_exe_path);
     bat_write_set(f, "DISPLAY", g_display);
+    {
+        /* Post-build sanity: the dispatch file the launcher will gate on. */
+        char marker_abs[1200];
+        if (join_path(marker_abs, sizeof(marker_abs), g_project_root,
+                      cfg_or(g_cfg->gen_marker_relpath,
+                             "generated/SLUS_011.89_dispatch.c")))
+            bat_write_set(f, "GEN_MARKER", marker_abs);
+    }
     if (force_pgo && disc_path && disc_path[0])
         bat_write_set(f, "DISC", disc_path);
     if (g_toolchain_bin[0])
@@ -3788,8 +3810,36 @@ static int write_windows_deferred_rebuild_helper(int force_pgo,
             "  pause\r\n"
             "  exit /b 1\r\n"
             ")\r\n"
+            /* %EXE% was guessed before the build; runtime.cmake publishes the
+             * OUTPUT_NAME it really used, which wins the moment a title is
+             * renamed. Then verify game code + exe exist before relaunching,
+             * so a setup-host build stops here with a message instead of
+             * reopening the wizard in a loop. */
+            "set \"EXE_FINAL=%%EXE%%\"\r\n"
+            "set \"PUBLISHED=\"\r\n"
+            "if exist \"%%BUILD_DIR%%\\psxrecomp_exe_name-%%TARGET%%.txt\" "
+            "set /p PUBLISHED=<\"%%BUILD_DIR%%\\psxrecomp_exe_name-%%TARGET%%.txt\"\r\n"
+            "if defined PUBLISHED if exist \"%%BUILD_DIR%%\\%%PUBLISHED%%.exe\" "
+            "set \"EXE_FINAL=%%BUILD_DIR%%\\%%PUBLISHED%%.exe\"\r\n"
+            "if defined GEN_MARKER if not exist \"%%GEN_MARKER%%\" (\r\n"
+            "  echo.\r\n"
+            "  echo Build finished but the generated game code is missing:\r\n"
+            "  echo   %%GEN_MARKER%%\r\n"
+            "  echo Launching now would reopen setup in a loop. Please report\r\n"
+            "  echo this to the port maintainer: the boot-EXE name in\r\n"
+            "  echo game.toml disagrees with GEN_MARKER in CMakeLists.txt.\r\n"
+            "  pause\r\n"
+            "  exit /b 1\r\n"
+            ")\r\n"
+            "if not exist \"%%EXE_FINAL%%\" (\r\n"
+            "  echo.\r\n"
+            "  echo Build finished but the game executable is missing:\r\n"
+            "  echo   %%EXE_FINAL%%\r\n"
+            "  pause\r\n"
+            "  exit /b 1\r\n"
+            ")\r\n"
             "echo Starting %%DISPLAY%%...\r\n"
-            "start \"\" /D \"%%ROOT%%\" \"%%EXE%%\" --launcher\r\n"
+            "start \"\" /D \"%%ROOT%%\" \"%%EXE_FINAL%%\" --launcher\r\n"
             "endlocal\r\n");
     fclose(f);
     return 1;

--- a/psxrecomp_cli.py
+++ b/psxrecomp_cli.py
@@ -1165,12 +1165,24 @@ def cmd_generate(args: argparse.Namespace, progress: ProgressReporter) -> int:
     marker_name = args.gen_marker or f"{boot}_dispatch.c"
     marker = out_dir / marker_name
     if not marker.is_file():
-        # Accept any *_dispatch.c
+        # The build (CMakeLists GEN_MARKER) and the setup host
+        # (codegen_setup.c gen_marker_relpath) both gate on this exact
+        # filename. Accepting a differently named dispatch here used to
+        # report success while the next rebuild silently produced another
+        # setup host — an endless generate+build loop. Fail loudly instead.
         hits = list(out_dir.glob("*_dispatch.c"))
         if not hits:
             progress.error(f"generate produced no dispatch under {out_dir}", code=EXIT_ERROR)
             return EXIT_ERROR
-        marker = hits[0]
+        progress.error(
+            f"generate produced {', '.join(h.name for h in hits)} under "
+            f"{out_dir}, but the project expects {marker_name}. The boot-exe "
+            "name in game.toml disagrees with GEN_MARKER in CMakeLists.txt / "
+            "codegen_setup.c — the rebuild would link no game code. Fix the "
+            "project so all three name the same boot EXE.",
+            code=EXIT_ERROR,
+        )
+        return EXIT_ERROR
 
     progress.phase("done", pct=1.0, message="Generate complete")
     progress.result(
@@ -1625,12 +1637,20 @@ def cmd_rebuild(args: argparse.Namespace, progress: ProgressReporter) -> int:
                 return EXIT_ERROR
             progress.log("Using system cmake on PATH")
 
-    cmake_extra = []
+    # Full playable link after local generate (not the CI setup-host shape).
+    # The legacy BPE_ alias in runtime.cmake only maps ON, so clear the
+    # canonical name too; REQUIRE_GAME_C turns a marker-name skew into a
+    # loud configure failure instead of a silently rebuilt setup host that
+    # reopens the wizard forever. --cmake-extra comes last so a deliberate
+    # override (e.g. -DPSXRECOMP_REQUIRE_GAME_C=OFF) still wins.
+    cmake_extra = [
+        "-DBPE_FORCE_SETUP_HOST=OFF",
+        "-DPSXRECOMP_FORCE_SETUP_HOST=OFF",
+        "-DPSXRECOMP_ALLOW_NO_BIOS=OFF",
+        "-DPSXRECOMP_REQUIRE_GAME_C=ON",
+    ]
     if args.cmake_extra:
         cmake_extra.extend(args.cmake_extra)
-    # Full playable link after local generate (not the CI setup-host shape).
-    cmake_extra.append("-DBPE_FORCE_SETUP_HOST=OFF")
-    cmake_extra.append("-DPSXRECOMP_ALLOW_NO_BIOS=OFF")
 
     clamped = clamp_future_mtimes(project_root, skip=build_dir)
     if clamped:

--- a/tools/ci/check_boot_exe.sh
+++ b/tools/ci/check_boot_exe.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Assert the three baked copies of the boot-EXE name agree.
+#
+# A game project carries the boot-EXE name in three places, all filled from
+# the same @BOOT_EXE@ token at instantiation: game.toml ([prepare_disc]
+# boot_exe, or the basename of [game] exe), CMakeLists.txt (GEN_MARKER),
+# and codegen_setup.c (.gen_marker_relpath). generate names its output
+# after game.toml while the build and the launcher gate on the other two,
+# so a skew makes every player's self-build loop generate+build forever.
+# The CLI also refuses the skew at generate time; failing the release here
+# is cheaper than failing the player.
+#
+# Usage: check_boot_exe.sh [game-repo-root]   (default: .)
+# Runs on bash 3.2+ (macOS runners) — no associative arrays.
+set -euo pipefail
+
+ROOT="${1:-.}"
+
+toml_get() { # <section> <key> — first quoted value of key inside [section]
+  awk -v sec="$1" -v key="$2" '
+    /^[[:space:]]*\[/ { in_sec = ($0 ~ ("^[[:space:]]*\\[" sec "\\]")) }
+    in_sec && $0 ~ ("^[[:space:]]*" key "[[:space:]]*=") {
+      if (match($0, /"[^"]*"/)) { print substr($0, RSTART + 1, RLENGTH - 2) }
+      exit
+    }' "${ROOT}/game.toml"
+}
+
+n_toml="" n_cmake="" n_setup=""
+
+if [[ -f "${ROOT}/game.toml" ]]; then
+  n_toml="$(toml_get prepare_disc boot_exe || true)"
+  if [[ -z "${n_toml}" ]]; then
+    exe="$(toml_get game exe || true)"
+    n_toml="${exe##*/}"
+  fi
+fi
+if [[ -f "${ROOT}/CMakeLists.txt" ]]; then
+  n_cmake="$(sed -n \
+    's/.*GEN_MARKER[[:space:]]*"generated\/\(.*\)_dispatch\.c".*/\1/p' \
+    "${ROOT}/CMakeLists.txt" | head -n1)"
+fi
+if [[ -f "${ROOT}/codegen_setup.c" ]]; then
+  n_setup="$(sed -n \
+    's/.*\.gen_marker_relpath[[:space:]]*=[[:space:]]*"generated\/\(.*\)_dispatch\.c".*/\1/p' \
+    "${ROOT}/codegen_setup.c" | head -n1)"
+fi
+
+found=0
+ref=""
+mismatch=0
+report() { # <label> <value>
+  [[ -z "$2" ]] && return 0
+  echo "  $1 -> $2"
+  found=$((found + 1))
+  if [[ -z "${ref}" ]]; then
+    ref="$2"
+  elif [[ "$2" != "${ref}" ]]; then
+    mismatch=1
+  fi
+}
+
+echo "boot-EXE name sources:"
+report "game.toml (boot_exe / game.exe)" "${n_toml}"
+report "CMakeLists.txt GEN_MARKER" "${n_cmake}"
+report "codegen_setup.c gen_marker_relpath" "${n_setup}"
+
+if [[ "${found}" -lt 2 ]]; then
+  echo "warning: fewer than two boot-EXE sources found under ${ROOT} —" \
+    "nothing to cross-check (non-standard layout?)"
+  exit 0
+fi
+if [[ "${mismatch}" -ne 0 ]]; then
+  echo "error: the boot-EXE names above disagree. generate names its output" >&2
+  echo "after game.toml, while the build (GEN_MARKER) and the launcher" >&2
+  echo "(gen_marker_relpath) gate on the exact other names — players'" >&2
+  echo "self-builds would loop generate+build forever. Make all three name" >&2
+  echo "the same boot EXE." >&2
+  exit 1
+fi
+echo "boot-EXE names agree: ${ref}"

--- a/tools/new_project_layout/templates/gitignore.in
+++ b/tools/new_project_layout/templates/gitignore.in
@@ -71,6 +71,8 @@ psx_crash.txt
 psx_last_run_report.json
 psx_screenshot.bmp
 psx_freeze_heartbeat.json
+.psxrecomp_last_generate
+.psxrecomp_write_probe
 starvation_dump.jsonl
 
 # Diagnostic dumps (root-level) — keep catalog / probe trackable


### PR DESCRIPTION
## Problem

Some ports' self-build users hit an infinite generate+build loop where **every stage reports success**. Root cause: the three baked copies of `@BOOT_EXE@` (game.toml, `codegen_setup.c` `gen_marker_relpath`, CMakeLists `GEN_MARKER`) are never cross-checked, and every consumer fails soft:

1. `generate` looks for the exact `<boot>_dispatch.c` but silently accepts *any* `generated/*_dispatch.c` and reports `ok=True`.
2. `runtime.cmake` silently builds **another setup host** when the exact `GEN_MARKER` path is missing (only a STATUS line); `PSXRECOMP_REQUIRE_GAME_C` exists but defaults OFF and nothing set it.
3. The Windows deferred rebuild helper `start`s the freshly built exe unconditionally — the rebuilt setup host sees `sources_missing()` and reopens first-run setup. Loop.

This is not hypothetical: the lint added here immediately caught a live instance — **Tomba2Recomp ships the template placeholder `gen_marker_relpath = "generated/SLUS_01234_dispatch.c"`** against a real `SCUS_944.54` everywhere else, so its launcher can never see the generated sources it gates on (fixed separately in that repo).

## Fix — each stage asserts what the next one gates on

**Commit 1 — fail loudly on the skew:**
- **`cmd_rebuild`** configures with `-DPSXRECOMP_REQUIRE_GAME_C=ON` (rebuild is documented as the full playable link after generate) and the canonical `-DPSXRECOMP_FORCE_SETUP_HOST=OFF` — the legacy `BPE_` alias only maps ON, so clearing just the old name was a no-op. Defaults are ordered before `--cmake-extra`, so a deliberate `-DPSXRECOMP_REQUIRE_GAME_C=OFF` override still wins.
- **`cmd_generate`** hard-fails when the produced dispatch name differs from the expected marker, naming both files and the config skew to fix. The setup host now passes `--gen-marker <basename of gen_marker_relpath>` (Windows and posix invocations), so generate validates the exact name the launcher and CMake will later demand.
- **Windows deferred helper** re-resolves the exe from `psxrecomp_exe_name-<target>.txt` after the build (the pre-build `%EXE%` guess goes stale the moment a title is renamed) and verifies the dispatch marker + exe exist before relaunching; otherwise it pauses with a report-to-the-port-maintainer message and exits 1 instead of relaunching into the wizard.

**Commit 2 — make the class un-loopable and un-shippable:**
- **Loop breaker:** a successful generate stamps `.psxrecomp_last_generate` at the project root. If the wizard is about to reopen because sources are missing while the stamp is recent (6h window), the prepare note becomes a diagnostic naming exactly which gate is unmet (expected `*_dispatch.c` and/or BIOS backends) and what `generated/` actually contains, instead of silently prompting for another round. The stamp clears once sources are visible again.
- **Preflight:** generate refuses up front when the project root sits under the Windows temp directory (Explorer's run-from-inside-the-ZIP extraction, which evaporates) or is not writable — with instructions, instead of failing downstream in ways that present as the same loop.
- **CI lint:** new `tools/ci/check_boot_exe.sh` cross-checks the three boot-EXE name copies; the setup-release template gains a fail-fast **Lint boot-EXE name consistency** step, so a skew fails the maintainer's release instead of the player's install. `op_emit_ci_workflow`'s step-name drift detection flags already-installed workflows automatically. Both gitignore templates learn the new sidecar names.

Multi-disc titles are unaffected by the strict name check: `update_disc_set.py` only maintains `discs` / `disc_serials`, the boot EXE stays single, so there is one dispatch name per title.

## Verification

- `python -m py_compile psxrecomp_cli.py`; `host/psxrecomp_codegen_host.c` syntax-checked with both `gcc` and `x86_64-w64-mingw32-gcc` (`-DPSX_HAS_SETUP_WIZARD=1`, recomp-ui headers); template YAML parses.
- The generated batch tail was executed under Wine cmd for all three paths: published-name healing picks up the renamed exe; the marker-missing and exe-missing gates stop with the right message and exit 1.
- `check_boot_exe.sh` exercised on fixtures (consistent, skewed, `boot_exe` override winning over a commented default, single-source warn-pass) and on real ports — TombaRecomp and ApeEscapeRecomp pass; Tomba2Recomp correctly fails on its placeholder.

Ports pick this up with their next framework pin + release cut; already-shipped setup exes keep the old behavior until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KfPHUBEYiSCwaGiwRc8ea7