### PR TITLE
runtime: cheap SPUCNT gate for the sample-event scheduler (~2x on MMIO-polling screens)

### DIFF
--- a/runtime/include/spu.h
+++ b/runtime/include/spu.h
@@ -81,6 +81,11 @@ typedef struct SpuGlobalState {
 
 void spu_get_voice_state(int voice, SpuVoiceState* out);
 void spu_get_global_state(SpuGlobalState* out);
+/* SPUCNT (0x1F801DAA) alone. The sample-event scheduler gates on one ctrl bit
+ * per device-service call; building the full SpuGlobalState there (register
+ * sweep + three 24-voice loops) was ~40% of emu-thread time during the Capcom
+ * FMV's MMIO-polling loop (gdb-sampled 2026-09-01). */
+uint16_t spu_ctrl_read(void);
 /* Debug peek into SPU sample RAM (spu_ram TCP command). */
 uint32_t spu_ram_peek(uint32_t addr, uint8_t *out, uint32_t len);
 

--- a/runtime/src/interrupts.c
+++ b/runtime/src/interrupts.c
@@ -418,7 +418,6 @@ static int spu_sample_event_mode(void) {
 }
 
 uint32_t psx_spu_sample_event_cycles_to_next(void) {
-    SpuGlobalState state;
     g_spu_sample_deadline_queries++;
     if (!spu_sample_event_mode()) {
         g_spu_sample_mode_rejects++;
@@ -428,8 +427,10 @@ uint32_t psx_spu_sample_event_cycles_to_next(void) {
         g_spu_sample_pump_null_rejects++;
         return UINT32_MAX;
     }
-    spu_get_global_state(&state);
-    if ((state.ctrl & 0x0040u) == 0) {
+    /* Gate on SPUCNT alone — this runs on every deadline recompute, and the
+     * full SpuGlobalState snapshot here dominated the emu thread under an
+     * MMIO-polling guest loop (Capcom FMV, gdb-sampled 2026-09-01). */
+    if ((spu_ctrl_read() & 0x0040u) == 0) {
         g_spu_sample_ctrl_rejects++;
         return UINT32_MAX;
     }
@@ -449,9 +450,9 @@ void psx_spu_sample_event_service(void) {
     g_spu_sample_service_checks++;
     if (!spu_sample_event_mode() || !s_midframe_audio_pump)
         return;
-    SpuGlobalState state;
-    spu_get_global_state(&state);
-    if ((state.ctrl & 0x0040u) != 0) {
+    /* SPUCNT alone — same hot-gate rationale as the deadline query above. */
+    const uint16_t ctrl = spu_ctrl_read();
+    if ((ctrl & 0x0040u) != 0) {
         g_spu_sample_enabled_services++;
         g_spu_sample_last_service_phase = (uint32_t)(psx_cycle_count % 768u);
     }
@@ -460,7 +461,7 @@ void psx_spu_sample_event_service(void) {
         if ((psx_get_cycle_count() % 768u) != 0)
             g_spu_sample_deferred_mismatches++;
     }
-    if ((state.ctrl & 0x0040u) != 0 &&
+    if ((ctrl & 0x0040u) != 0 &&
         (psx_get_cycle_count() % 768u) == 0) {
         g_spu_sample_service_pumps++;
         s_midframe_audio_pump();

--- a/runtime/src/spu.c
+++ b/runtime/src/spu.c
@@ -1601,6 +1601,10 @@ uint32_t spu_ram_peek(uint32_t addr, uint8_t *out, uint32_t len) {
     return len;
 }
 
+uint16_t spu_ctrl_read(void) {
+    return spu_regs[reg_index(0x1F801DAAu)];
+}
+
 void spu_get_global_state(SpuGlobalState* out) {
     if (!out) return;
     memset(out, 0, sizeof(*out));


### PR DESCRIPTION
## Problem

`psx_spu_sample_event_service()` and `psx_spu_sample_event_cycles_to_next()` build a **full `SpuGlobalState` snapshot** — `memset` + ~40 register reads + three 24-voice loops — on every call, just to test one bit (`SPUCNT & 0x40`, the SPU-IRQ9 enable that gates per-sample scheduling).

Both sit on the hottest paths in the runtime: the service runs in `advance_devices()` on **every device catch-up chunk**, and the deadline query runs in `devices_cycles_to_next_internal_event()` on **every deadline recompute**. Any guest MMIO-polling wait loop — i.e. most PS1 wait code — triggers both at very high frequency.

Found on Breath of Fire III's Capcom-logo FMV (a native-compiled polling loop over MDEC/CD/DMA status): gdb stack sampling of the emu thread showed **~40% of wall time inside `spu_get_global_state`/`voice_reg`**, with the guest CPU-bound at 0.47x realtime (~28 fps) and the VBlank-tied audio pump crackling downstream. Notably, guest-side counters could not see this — it profiles as ordinary emulation time.

## Fix

Add `spu_ctrl_read()` (a single `spu_regs[]` load) and gate both call sites on it. Semantics are identical: same register, same bit, same downstream behavior. No change when the tier is disabled or SPU IRQ9 is off — those paths just stop paying for a snapshot they discarded.

## Measured (BoF3 Capcom FMV, clean boot, headless vblank raises/s)

| build | before | after |
|---|---:|---:|
| Debug (-O0) | 28.5 | ~52 |
| RelWithDebInfo | — | 97–200 uncapped (>= 1.6x realtime) |

User-verified windowed on the optimized build: Capcom logo, world map, and memory-card screens all hold a locked 60 fps with clean audio (previously ~28 / ~50 / ~50). The audio crackle was downstream of the guest running < 60 Hz and disappears with it.

Every title pays this gate on every screen, so other projects with "mysteriously CPU-bound" FMVs or wait loops should see the same class of win.

## Blast radius

Three files, +17/−7, no behavior change by construction (the gate reads the same register bit it always did). The full `SpuGlobalState` snapshot remains in place for its real consumers (debug server, oracle comparison).

🤖 Generated with [Claude Code](https://claude.com/claude-code)