### PR TITLE
overlays: parallel static compile, linear resume-wrapper pass, split output

### DIFF
--- a/docs/COMPILING_OVERLAYS.md
+++ b/docs/COMPILING_OVERLAYS.md
@@ -118,10 +118,25 @@ python psxrecomp/tools/compile_overlays.py \
     --cps
 ```
 
-Output: `generated/overlays_static.c`, containing every in-overlay
-`func_XXXXXXXX` plus an auto-generated `psx_overlay_dispatch()` switch. Add that
-file to the runtime build (it's a normal translation unit) and rebuild the exe.
-No `cache/` folder and no DLL loading are involved at runtime.
+Output: `generated/overlays_static.c` — the auto-generated, content-validated
+`psx_overlay_dispatch()` plus an extern prototype for every compiled entry —
+and **one translation unit per overlay** beside it, `overlays_static_0000.c`,
+`overlays_static_0001.c`, … (each carries its own `#include`s and a private
+symbol namespace, so it compiles standalone). Point the runtime build at
+`overlays_static.c` (`GAME_OVERLAY_STATIC_C` in `psxrecomp_add_game_runtime`);
+`runtime.cmake` globs the sibling parts with `CONFIGURE_DEPENDS`, so a run that
+changes the part count needs no reconfigure. No `cache/` folder and no DLL
+loading are involved at runtime.
+
+Why split: a whole title's overlays make a single C file of hundreds of MB
+(BoF3: 309 MB, 8.6 M lines), which one `gcc` invocation compiles on one core.
+Per-overlay units build across every core, and because the tool only rewrites
+a part whose content changed, an incremental rebuild recompiles only the
+overlays that changed. `--static-single-file` restores the monolithic output.
+
+The tool side parallelizes too: `--jobs N` (default cores−2) runs each
+capture's recompile + audit in a process pool and merges results in capture
+order, so the emitted C is byte-identical to `--jobs 1`.
 
 **Trade-off vs. the DLL cache:** `--static` is a fixed snapshot chosen at build
 time — it will *not* grow as the player explores new areas. The DLL cache (§0/§1)

--- a/runtime/runtime.cmake
+++ b/runtime/runtime.cmake
@@ -969,6 +969,21 @@ function(psxrecomp_add_runtime_target target)
     if(PSXRT_GAME_OVERLAY_STATIC_C AND EXISTS "${PSXRT_GAME_OVERLAY_STATIC_C}")
         set_source_files_properties("${PSXRT_GAME_OVERLAY_STATIC_C}" PROPERTIES GENERATED TRUE)
         list(APPEND generated_sources "${PSXRT_GAME_OVERLAY_STATIC_C}")
+        # compile_overlays.py --static splits its output: overlays_static.c is
+        # the dispatcher and each overlay is its own translation unit,
+        # overlays_static_NNNN.c, beside it. One 300 MB file compiled on one
+        # core is what that replaced. CONFIGURE_DEPENDS re-globs at build time,
+        # so a run that changes the part count needs no reconfigure (a
+        # --static-single-file run simply has no parts to glob).
+        get_filename_component(_ov_static_dir  "${PSXRT_GAME_OVERLAY_STATIC_C}" DIRECTORY)
+        get_filename_component(_ov_static_stem "${PSXRT_GAME_OVERLAY_STATIC_C}" NAME_WE)
+        file(GLOB _ov_static_parts CONFIGURE_DEPENDS
+             "${_ov_static_dir}/${_ov_static_stem}_[0-9][0-9][0-9][0-9].c")
+        list(SORT _ov_static_parts)
+        foreach(_ov_part IN LISTS _ov_static_parts)
+            set_source_files_properties("${_ov_part}" PROPERTIES GENERATED TRUE)
+        endforeach()
+        list(APPEND generated_sources ${_ov_static_parts})
         set(has_overlay_dispatch TRUE)
     endif()
 

--- a/tools/compile_overlays.py
+++ b/tools/compile_overlays.py
@@ -21,6 +21,9 @@ Each DLL exports:
 """
 
 import argparse
+import itertools
+import io
+import contextlib
 import base64
 import binascii
 from bisect import bisect_left
@@ -2274,6 +2277,91 @@ def add_cps_resume_case(src: str, host_symbol: str,
         '        }\n'
         '    }')
     return src[:definition.end()] + prologue_text + src[definition.end():], True
+
+
+_CPS_SIGNATURE_RE = re.compile(r'^void ([A-Za-z_][A-Za-z0-9_]*)\(CPUState\* cpu\)',
+                               re.MULTILINE)
+
+
+def add_cps_resume_cases(src: str, requests: list) -> tuple:
+    """Batch form of add_cps_resume_case().
+
+    requests: [(host_symbol, host, [entry, ...]), ...]. Returns
+    (src, {host_symbol: set(entries made legal)}).
+
+    Per entry this applies exactly the rule add_cps_resume_case() applies --
+    the block label must exist in the host's own segment, an existing arm is
+    left alone, otherwise the arm goes before the resume switch's ``default:``
+    (or a fresh switch is created after the opening brace). The difference is
+    cost: the per-entry function re-scans and rebuilds the WHOLE part source
+    (tens of MB) for every entry, which made the post-pass quadratic -- 7,386
+    wrappers on a 19 MB part took ~7 minutes. Here every function signature is
+    located once, each host's segment is edited in isolation, and the source
+    is rebuilt once. Output is byte-identical to the per-entry form.
+    """
+    sigs = list(_CPS_SIGNATURE_RE.finditer(src))
+    def_index = {}
+    for i, m in enumerate(sigs):
+        # A definition is the signature followed by "\n{"; the first one wins,
+        # like re.search() did.
+        if src.startswith('\n{', m.end()) and m.group(1) not in def_index:
+            def_index[m.group(1)] = i
+    edits = []
+    ok_by_symbol = {}
+    for host_symbol, host, entries in requests:
+        i = def_index.get(host_symbol)
+        if i is None:
+            continue
+        m = sigs[i]
+        start = m.start()
+        def_len = (m.end() + 2) - start            # through the opening brace
+        end = sigs[i + 1].start() if i + 1 < len(sigs) else len(src)
+        seg = src[start:end]
+        labels = set(re.findall(r'^block_[0-9A-Fa-f]{8}:', seg, re.MULTILINE))
+        ok = set()
+        changed = False
+        for entry in entries:
+            if f'block_{entry:08X}:' not in labels:
+                continue
+            if f'case 0x{entry:08X}u: goto block_{entry:08X};' in seg:
+                ok.add(entry)
+                continue
+            hook = seg.find('debug_server_log_call_entry')
+            prologue = seg[:hook] if hook >= 0 else ''
+            default_match = re.search(r'^\s+default:', prologue, re.MULTILINE)
+            if 'if (cpu->pc != 0u)' in prologue and default_match:
+                insert = default_match.start()
+                indent = re.match(r'\s*', prologue[default_match.start():]).group(0)
+                arm = f'{indent}case 0x{entry:08X}u: goto block_{entry:08X};\n'
+                seg = seg[:insert] + arm + seg[insert:]
+            else:
+                prologue_text = (
+                    '\n    if (cpu->pc != 0u) {\n'
+                    '        uint32_t _cont = cpu->pc; cpu->pc = 0;\n'
+                    '        switch (_cont) {\n'
+                    f'            case 0x{entry:08X}u: goto block_{entry:08X};\n'
+                    f'            case 0x{host:08X}u: break;  /* entry at prologue */\n'
+                    f'            default: cpu->pc = _cont; psx_native_bad_entry(cpu, '
+                    f'0x{host:08X}u, _cont); return;\n'
+                    '        }\n'
+                    '    }')
+                seg = seg[:def_len] + prologue_text + seg[def_len:]
+            ok.add(entry)
+            changed = True
+        ok_by_symbol[host_symbol] = ok
+        if changed:
+            edits.append((start, end, seg))
+    if edits:
+        edits.sort()
+        pieces = []
+        pos = 0
+        for start, end, seg in edits:
+            pieces.append(src[pos:start])
+            pieces.append(seg)
+            pos = end
+        pieces.append(src[pos:])
+        src = ''.join(pieces)
+    return src, ok_by_symbol
 
 
 def generate_overlay_dispatch(variants: list) -> str:
@@ -5377,6 +5465,282 @@ def cached_shard_manifest_status(dll_path: str, expected_abi: int | None,
 # Main
 # ---------------------------------------------------------------------------
 
+# ---------------------------------------------------------------------------
+# Static mode (--static): per-capture worker + split output writer
+# ---------------------------------------------------------------------------
+
+def static_capture_job(cap: dict, args, toml: dict, forced_interiors: set,
+                       static_out: str) -> dict:
+    """Recompile ONE capture for static mode. Module-level and self-contained so
+    it can run in a worker process (ProcessPoolExecutor needs a picklable
+    callable and picklable arguments: the capture dict, the argparse Namespace,
+    the parsed game.toml, the forced-interior set).
+
+    Nothing here touches shared state. Everything the sequential path used to
+    write into main()'s accumulators comes back in the result and is merged by
+    the caller in canonical capture order, so the emitted C is byte-identical
+    whether --jobs is 1 or 12. Prints go to result['log'] instead of stdout so
+    parallel workers never interleave.
+
+    result: label, outcome ('ok' | 'skip' | 'fail'), fail=(class, detail),
+            part (the static_parts entry, or None), requested_entries (set),
+            entry_sources ({entry: (data, load_addr, size, phys_addr)}), log.
+    """
+    result = {'label': None, 'outcome': None, 'fail': None, 'part': None,
+              'requested_entries': set(), 'entry_sources': {}, 'log': ''}
+    log = io.StringIO()
+    with contextlib.redirect_stdout(log):
+        try:
+            _static_capture_job(cap, args, toml, forced_interiors, static_out,
+                                result)
+        finally:
+            result['log'] = log.getvalue()
+    return result
+
+
+def _static_capture_job(cap, args, toml, forced_interiors, static_out, result):
+    load_addr = int(cap['load_addr'], 16)
+    size      = int(cap['size'])
+    data      = base64.b64decode(cap['bytes_b64'])
+    crc32     = binascii.crc32(data) & 0xFFFFFFFF
+    phys_addr = (load_addr & 0x1FFFFFFF)
+    _label = f'overlay 0x{load_addr:08X} crc {crc32:08X}'
+    result['label'] = _label
+
+    def fail(cls, detail):
+        result['outcome'] = 'fail'
+        result['fail'] = (cls, detail)
+
+    for captured_entry in _parse_addr_list(cap.get('dispatch_entry_pcs', [])):
+        entry = ((captured_entry & 0x1FFFFFFF) | 0x80000000)
+        result['requested_entries'].add(entry)
+        result['entry_sources'][entry] = (data, load_addr, size, phys_addr)
+    # --force-interior is an explicit operator assertion that a live dispatch
+    # entry was observed even if the retained capture lost its classifier
+    # provenance. Bind the requested PC to this capture's exact bytes; the
+    # post-pass builds a content-validated isolated shard for it.
+    region_hi = phys_addr + size
+    for forced_entry in forced_interiors:
+        forced_phys = forced_entry & 0x1FFFFFFF
+        if phys_addr <= forced_phys < region_hi:
+            entry = forced_phys | 0x80000000
+            result['requested_entries'].add(entry)
+            result['entry_sources'][entry] = (data, load_addr, size, phys_addr)
+
+    seeds, seed_audit = classify_overlay_seeds(cap, data, load_addr, size,
+                                               crc32, toml)
+    print(f'Overlay  load=0x{load_addr:08X}  size={size}  crc32=0x{crc32:08X}')
+    print(f'  seeds: {len(seeds)}  mode: static -> {static_out}')
+    print_seed_audit(seed_audit)
+
+    root_seeds = [
+        seed for seed in seeds
+        if ((seed.split()[0] in ('call_root', 'dispatch_root')) or
+            seed.split()[0].startswith('0x'))
+    ]
+    if not root_seeds:
+        print('  SKIP: no walk-root seeds (data-only region)\n')
+        result['outcome'] = 'skip'
+        return
+
+    with tempfile.TemporaryDirectory() as tmp:
+        # Fake PS-EXE: the header entry PC becomes a walk root in the
+        # recompiler, so it must be a walk-root seed, never an interior one.
+        entry_pc = int(root_seeds[0].split()[-1], 16)
+        psx_path = os.path.join(tmp, f'overlay_{load_addr:08X}.psx')
+        with open(psx_path, 'wb') as f:
+            f.write(make_psxexe(load_addr, entry_pc, data))
+        seeds_path = os.path.join(tmp, 'seeds.txt')
+        with open(seeds_path, 'w') as f:
+            for seed in seeds:
+                f.write(seed + '\n')
+        out_dir_tmp = os.path.join(tmp, 'out')
+        os.makedirs(out_dir_tmp)
+
+        # Evidence-scoped discovery (the overlay-compilation contract): compile
+        # only the proven entry seeds and what they reach, never a whole-byte
+        # sweep. Same invocation as the DLL path.
+        cmd = [args.recompiler, psx_path,
+               '--seeds', seeds_path,
+               '--out-dir', out_dir_tmp,
+               '--overlay',
+               '--ws-config', os.path.abspath(args.game_toml)]
+        cmd += recompiler_project_root_args(args)
+        print(f'  recompile: {args.recompiler} ...{" [CPS]" if args.cps else ""}')
+        toml_dir = os.path.dirname(os.path.abspath(args.game_toml))
+        sub_env = dict(os.environ)
+        if args.cps:
+            sub_env['PSX_CPS'] = '1'   # §25: emit continuation-passing overlay C
+        r = subprocess.run(cmd, capture_output=True, text=True,
+                           cwd=toml_dir, env=sub_env)
+        if r.returncode != 0:
+            print(f'  RECOMPILER ERROR:\n{r.stderr or r.stdout}')
+            fail('recompiler', r.stderr or r.stdout)
+            return
+
+        stem = os.path.basename(psx_path)
+        full_c = os.path.join(out_dir_tmp, stem + '_full.c')
+        if not os.path.exists(full_c):
+            candidates = [f for f in os.listdir(out_dir_tmp) if f.endswith('_full.c')]
+            if not candidates:
+                print(f'  ERROR: no _full.c in {out_dir_tmp}')
+                fail('no_output', 'no _full.c emitted')
+                return
+            full_c = os.path.join(out_dir_tmp, candidates[0])
+        with open(full_c) as f:
+            src = f.read()
+        ranges_src = None
+        for fn in os.listdir(out_dir_tmp):
+            if fn.endswith('_full.ranges'):
+                ranges_src = os.path.join(out_dir_tmp, fn)
+                break
+
+        src, func_addrs = patch_generated_c_static(src, load_addr, size)
+        continuation_owners = parse_cps_continuation_owners(src)
+        c_audit = audit_generated_c(src, load_addr, size, crc32, toml)
+        print_generated_c_audit(load_addr, size, crc32, c_audit)
+        if c_audit['unknown_bad'] or c_audit['unsupported_todo_addrs']:
+            print('  GENERATED-C AUDIT FAILED\n')
+            fail('audit', f'{len(c_audit["unknown_bad"])} unknown_bad, '
+                          f'{len(c_audit["unsupported_todo_addrs"])} unsupported')
+            return
+        if not ranges_src:
+            print('  STATIC RANGE AUDIT FAILED: no _full.ranges manifest\n')
+            fail('no_ranges', 'no _full.ranges manifest')
+            return
+
+        func_ids = parse_overlay_func_ids(ranges_src, data, load_addr, size)
+        ids_by_addr = {}
+        for ev, code_crc, ranges in func_ids:
+            ids_by_addr.setdefault(ev, []).append((code_crc, ranges))
+        missing = sorted(set(func_addrs) - set(ids_by_addr))
+        if missing:
+            sample = ', '.join(f'0x{a:08X}' for a in missing[:8])
+            print(f'  STATIC RANGE AUDIT FAILED: {len(missing)} '
+                  f'dispatchable function(s) lack exact ranges: {sample}\n')
+            fail('static_ranges', f'{len(missing)} funcs lack exact ranges')
+            return
+
+        # Whole-image identity plus compiled-entry coverage makes the namespace
+        # deterministic while allowing a later, richer seed capture of
+        # identical bytes to coexist without symbol clashes.
+        cov_blob = ','.join(f'{a:08X}' for a in sorted(func_addrs)).encode()
+        cov_crc = binascii.crc32(cov_blob) & 0xFFFFFFFF
+        namespace = f'ov_{phys_addr:08X}_{crc32:08X}_{cov_crc:08X}'
+        src, symbols = namespace_generated_static(src, namespace, func_addrs)
+        variants = []
+        for ev in sorted(func_addrs):
+            for code_crc, ranges in ids_by_addr[ev]:
+                variants.append({
+                    'addr': ev,
+                    'symbol': symbols[ev],
+                    'crc': code_crc,
+                    'ranges': ranges,
+                })
+        result['part'] = {
+            'src': src,
+            'variants': variants,
+            'namespace': namespace,
+            'func_addrs': set(func_addrs),
+            'symbols': symbols,
+            'ids_by_addr': ids_by_addr,
+            'continuation_owners': continuation_owners,
+        }
+        print(f'  recompiled: {len(func_addrs)} functions, '
+              f'{len(variants)} exact identities\n')
+        result['outcome'] = 'ok'
+
+
+STATIC_HEADER = ('/* Auto-generated overlay dispatch -- do not edit.\n'
+                 ' * Rebuild: python3 psxrecomp/tools/compile_overlays.py --static ...\n'
+                 ' */\n')
+_STATIC_PART_RE = re.compile(r'_(\d{4})\.c$')
+
+
+def static_part_paths(static_out: str) -> list:
+    """Existing split-output part files next to static_out, sorted."""
+    d = os.path.dirname(static_out) or '.'
+    stem = os.path.splitext(os.path.basename(static_out))[0]
+    if not os.path.isdir(d):
+        return []
+    out = []
+    for fn in os.listdir(d):
+        if fn.startswith(stem + '_') and _STATIC_PART_RE.search(fn):
+            out.append(os.path.join(d, fn))
+    return sorted(out)
+
+
+def _write_if_changed(path: str, text: str) -> bool:
+    """Write only when the content differs, so an unchanged translation unit
+    keeps its mtime and the build system does not recompile it."""
+    try:
+        with open(path, encoding='utf-8') as f:
+            if f.read() == text:
+                return False
+    except (OSError, UnicodeDecodeError):
+        pass
+    with open(path, 'w', encoding='utf-8', newline='\n') as f:
+        f.write(text)
+    return True
+
+
+def write_static_outputs(static_out: str, parts: list, variants: list,
+                         dispatch_src: str, single_file: bool = False) -> list:
+    """Emit the static overlay C.
+
+    Default (split): `static_out` holds the content-validated dispatcher plus
+    an extern prototype for every compiled entry, and each part becomes its own
+    translation unit `<stem>_NNNN.c` beside it. Every part already carries its
+    own #includes and a private symbol namespace, so it compiles standalone.
+    The build then parallelizes across parts, and because unchanged parts are
+    not rewritten, only overlays whose code changed recompile. Stale parts from
+    a previous, larger run are deleted so a glob never links a leftover.
+
+    single_file: the pre-split behaviour, everything in `static_out`.
+
+    Returns the list of files that make up the output (written or unchanged).
+    """
+    stale = static_part_paths(static_out)
+    if single_file:
+        combined = STATIC_HEADER
+        for part in parts:
+            combined += part['src']
+        combined += dispatch_src
+        _write_if_changed(static_out, combined)
+        for p in stale:
+            os.remove(p)
+        return [static_out]
+
+    d = os.path.dirname(static_out) or '.'
+    stem = os.path.splitext(os.path.basename(static_out))[0]
+    written = []
+    for index, part in enumerate(parts):
+        path = os.path.join(d, f'{stem}_{index:04d}.c')
+        # No part COUNT in the header: adding or dropping an overlay must leave
+        # every unchanged unit byte-identical (and therefore not rebuilt).
+        text = (STATIC_HEADER +
+                f'/* Static overlay translation unit {index}: '
+                f'{part["namespace"]} */\n' + part['src'])
+        _write_if_changed(path, text)
+        written.append(path)
+    keep = set(written)
+    for p in stale:
+        if p not in keep:
+            os.remove(p)
+
+    symbols = sorted({variant['symbol'] for variant in variants})
+    main = STATIC_HEADER
+    main += '#include "psx_runtime.h"\n\n'
+    main += (f'/* Dispatcher for {len(parts)} overlay translation unit(s) '
+             f'({stem}_0000.c ...). Every compiled entry has external linkage '
+             f'in its own unit; declare them here. */\n')
+    main += ''.join(f'void {sym}(CPUState *cpu);\n' for sym in symbols)
+    main += dispatch_src
+    _write_if_changed(static_out, main)
+    return [static_out] + written
+
+
+
 def main():
     ap = argparse.ArgumentParser(description=__doc__,
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
@@ -5427,6 +5791,10 @@ def main():
                          'interior fragment (repeatable; diagnostic recovery for '
                          'an observed dispatch PC whose classifier provenance was '
                          'lost after a later capture)')
+    ap.add_argument('--static-single-file', action='store_true',
+                    help='with --static: emit one monolithic overlays_static.c '
+                         '(pre-split behaviour) instead of the dispatcher plus '
+                         'one translation unit per overlay.')
     ap.add_argument('--static',          action='store_true',
                     help='B-2 mode: compile into binary (overlays_static.c) instead of DLL')
     ap.add_argument('--flavor',          type=int, default=0,
@@ -5444,7 +5812,10 @@ def main():
                          'independent (dedup coverage, prior-ranges merge, '
                          'fragments, and filenames all key on the region), '
                          'captures within one region stay ordered. 1 = the '
-                         'sequential path. --static always runs sequential.')
+                         'sequential path. In --static mode each capture is an '
+                         'independent recompile+audit, run in a process pool '
+                         'and merged in capture order (byte-identical output '
+                         'to the sequential path).')
     args = ap.parse_args()
     forced_interiors = {
         (int(v, 0) & 0x1FFFFFFF) | 0x80000000
@@ -5576,6 +5947,23 @@ def main():
     # whose own compile is skipped or audit-fails.
     interior_frag_jobs = []
 
+    def _merge_static_result(res):
+        """Fold one static_capture_job result into the shared accumulators.
+        Called in canonical capture order for both the sequential and the
+        --jobs path, so static_parts / entry sources are order-identical."""
+        if res['log']:
+            print(res['log'], end='')
+        static_requested_entries.update(res['requested_entries'])
+        static_entry_sources.update(res['entry_sources'])
+        if res['outcome'] == 'ok':
+            static_parts.append(res['part'])
+            stats.add_ok()
+        elif res['outcome'] == 'skip':
+            stats.add_skip()
+        else:
+            cls, detail = res['fail']
+            stats.add_fail(res['label'], cls, detail)
+
     # Per-capture body, extracted so the region-parallel driver below can call
     # it. All shared state is either read-only closure (args/toml/cache_dir)
     # or passed per-region (region_coverage_cache / interior_frag_jobs), so a
@@ -5588,25 +5976,11 @@ def main():
         phys_addr = (load_addr & 0x1FFFFFFF)
         _label = f'overlay 0x{load_addr:08X} crc {crc32:08X}'
         if args.static:
-            for captured_entry in _parse_addr_list(
-                    cap.get('dispatch_entry_pcs', [])):
-                entry = ((captured_entry & 0x1FFFFFFF) | 0x80000000)
-                static_requested_entries.add(entry)
-                static_entry_sources[entry] = (
-                    data, load_addr, size, phys_addr)
-            # --force-interior is an explicit operator assertion that a live
-            # dispatch entry was observed even if the retained capture lost its
-            # classifier provenance. Static mode must honor it just like DLL
-            # mode: bind the requested PC to this capture's exact bytes, then
-            # the post-pass will build a content-validated isolated shard.
-            region_hi = phys_addr + size
-            for forced_entry in forced_interiors:
-                forced_phys = forced_entry & 0x1FFFFFFF
-                if phys_addr <= forced_phys < region_hi:
-                    entry = forced_phys | 0x80000000
-                    static_requested_entries.add(entry)
-                    static_entry_sources[entry] = (
-                        data, load_addr, size, phys_addr)
+            # Static mode is one self-contained job per capture (see
+            # static_capture_job); the sequential and --jobs paths share it.
+            _merge_static_result(static_capture_job(
+                cap, args, toml, forced_interiors, static_out))
+            return
 
         # Reclassify prior F entry addresses from an identical image. Callable
         # entries may become current roots; other entries re-enter as dispatch
@@ -5667,10 +6041,7 @@ def main():
             dll_path = os.path.join(cache_dir, f'{phys_addr:08X}_{crc32:08X}{overlay_ext()}')
 
         print(f'Overlay  load=0x{load_addr:08X}  size={size}  crc32=0x{crc32:08X}')
-        if args.static:
-            print(f'  seeds: {len(seeds)}  mode: static -> {static_out}')
-        else:
-            print(f'  seeds: {len(seeds)}  dll: {dll_path}')
+        print(f'  seeds: {len(seeds)}  dll: {dll_path}')
         print_seed_audit(seed_audit)
 
         demanded_root_entries = walk_root_seed_entries(seeds)
@@ -5781,246 +6152,185 @@ def main():
                     ranges_src = os.path.join(out_dir_tmp, fn)
                     break
 
-            # Post-process
-            if args.static:
-                src, func_addrs = patch_generated_c_static(src, load_addr, size)
-                continuation_owners = parse_cps_continuation_owners(src)
-                c_audit = audit_generated_c(src, load_addr, size, crc32, toml)
-                print_generated_c_audit(load_addr, size, crc32, c_audit)
-                if c_audit['unknown_bad'] or c_audit['unsupported_todo_addrs']:
-                    print('  GENERATED-C AUDIT FAILED\n')
-                    stats.add_fail(_label, 'audit',
-                                   f'{len(c_audit["unknown_bad"])} unknown_bad, '
-                                   f'{len(c_audit["unsupported_todo_addrs"])} unsupported')
+            # Post-process (DLL path; static mode returned early above)
+            src = patch_generated_c(src, load_addr, size)
+            c_audit = audit_generated_c(src, load_addr, size, crc32, toml)
+            print_generated_c_audit(load_addr, size, crc32, c_audit)
+            # Always save the debug copy for inspection — including on audit
+            # failure, so opcode gaps / boundary artifacts can be classified.
+            os.makedirs(os.path.dirname(dll_path), exist_ok=True)
+            debug_c = os.path.join(os.path.dirname(dll_path),
+                                   f'{crc32:08X}_patched.c')
+            with open(debug_c, 'w') as f:
+                f.write(src)
+            if c_audit['unknown_bad'] or c_audit['unsupported_todo_addrs']:
+                fallback = optional_enrichment_fallback_capture(cap)
+                if fallback is not None:
+                    print('  OPTIONAL ENRICHMENT AUDIT REJECTED; '
+                          'retrying conservative recipe\n')
+                    _do_capture(fallback, region_coverage_cache,
+                                interior_frag_jobs, stats)
                     return
-                if not ranges_src:
-                    print('  STATIC RANGE AUDIT FAILED: no _full.ranges manifest\n')
-                    stats.add_fail(_label, 'no_ranges', 'no _full.ranges manifest')
-                    return
+                print('  GENERATED-C AUDIT FAILED\n')
+                stats.add_fail(_label, 'audit',
+                               f'{len(c_audit["unknown_bad"])} unknown_bad, '
+                               f'{len(c_audit["unsupported_todo_addrs"])} unsupported')
+                return
+            patched_c = os.path.join(tmp, 'overlay_patched.c')
+            with open(patched_c, 'w') as f:
+                f.write(src)
 
-                func_ids = parse_overlay_func_ids(ranges_src, data,
-                                                  load_addr, size)
-                ids_by_addr = {}
-                for ev, code_crc, ranges in func_ids:
-                    ids_by_addr.setdefault(ev, []).append((code_crc, ranges))
-                missing = sorted(set(func_addrs) - set(ids_by_addr))
-                if missing:
-                    sample = ', '.join(f'0x{a:08X}' for a in missing[:8])
-                    print(f'  STATIC RANGE AUDIT FAILED: {len(missing)} '
-                          f'dispatchable function(s) lack exact ranges: {sample}\n')
-                    stats.add_fail(_label, 'static_ranges',
-                                   f'{len(missing)} funcs lack exact ranges')
-                    return
+            # overlay-cache v2 dedup: compute this capture's per-function
+            # identity set BEFORE the (expensive) gcc compile. The loader
+            # content-matches each function by (entry, code_crc) across ALL
+            # DLLs at this region_start, so if every function we'd produce is
+            # already provided by an existing DLL, a new DLL adds nothing —
+            # skip the build. This is what stops volatile-data regions (a
+            # changing whole-region CRC over byte-identical code) from minting
+            # an endless pile of redundant DLLs.
+            this_ids = (parse_overlay_func_ids(ranges_src, data, load_addr, size)
+                        if ranges_src else [])
+            delay_errors = audit_func_id_delay_slots(
+                this_ids, data, load_addr)
+            if delay_errors:
+                entry, pc, reason = delay_errors[0]
+                where = f' at 0x{pc:08X}' if pc is not None else ''
+                print(f'  DELAY-SLOT IDENTITY AUDIT FAILED: '
+                      f'func 0x{entry:08X}{where}: {reason}\n')
+                stats.add_fail(_label, 'delay_slot_identity', reason)
+                return
+            this_set = {(ev, crc) for ev, crc, _ in this_ids}
 
-                # Whole-image identity plus compiled-entry coverage makes the
-                # namespace deterministic while allowing a later, richer seed
-                # capture of identical bytes to coexist without symbol clashes.
-                cov_blob = ','.join(f'{a:08X}'
-                                    for a in sorted(func_addrs)).encode()
-                cov_crc = binascii.crc32(cov_blob) & 0xFFFFFFFF
-                namespace = f'ov_{phys_addr:08X}_{crc32:08X}_{cov_crc:08X}'
-                src, symbols = namespace_generated_static(src, namespace,
-                                                          func_addrs)
-                variants = []
-                for ev in sorted(func_addrs):
-                    for code_crc, ranges in ids_by_addr[ev]:
-                        variants.append({
-                            'addr': ev,
-                            'symbol': symbols[ev],
-                            'crc': code_crc,
-                            'ranges': ranges,
-                        })
-                static_parts.append({
-                    'src': src,
-                    'variants': variants,
-                    'namespace': namespace,
-                    'func_addrs': set(func_addrs),
-                    'symbols': symbols,
-                    'ids_by_addr': ids_by_addr,
-                    'continuation_owners': continuation_owners,
-                })
-                print(f'  recompiled: {len(func_addrs)} functions, '
-                      f'{len(variants)} exact identities\n')
-                stats.add_ok()
-            else:
-                src = patch_generated_c(src, load_addr, size)
-                c_audit = audit_generated_c(src, load_addr, size, crc32, toml)
-                print_generated_c_audit(load_addr, size, crc32, c_audit)
-                # Always save the debug copy for inspection — including on audit
-                # failure, so opcode gaps / boundary artifacts can be classified.
-                os.makedirs(os.path.dirname(dll_path), exist_ok=True)
-                debug_c = os.path.join(os.path.dirname(dll_path),
-                                       f'{crc32:08X}_patched.c')
-                with open(debug_c, 'w') as f:
-                    f.write(src)
-                if c_audit['unknown_bad'] or c_audit['unsupported_todo_addrs']:
-                    fallback = optional_enrichment_fallback_capture(cap)
-                    if fallback is not None:
-                        print('  OPTIONAL ENRICHMENT AUDIT REJECTED; '
-                              'retrying conservative recipe\n')
-                        _do_capture(fallback, region_coverage_cache,
-                                    interior_frag_jobs, stats)
-                        return
-                    print('  GENERATED-C AUDIT FAILED\n')
-                    stats.add_fail(_label, 'audit',
-                                   f'{len(c_audit["unknown_bad"])} unknown_bad, '
-                                   f'{len(c_audit["unsupported_todo_addrs"])} unsupported')
-                    return
-                patched_c = os.path.join(tmp, 'overlay_patched.c')
-                with open(patched_c, 'w') as f:
-                    f.write(src)
+            with cov_lock:
+                covered = region_coverage_cache.get(phys_addr)
+                if covered is None:
+                    covered = load_region_coverage(
+                        cache_dir, phys_addr,
+                        overlay_abi_tag(args.runtime_include, args.flavor))
+                    region_coverage_cache[phys_addr] = covered
+                fully_covered = (bool(this_set) and this_set <= covered
+                                 and not args.force
+                                 and cap.get('producer') !=
+                                     BIOS_RESIDENT_PRODUCER)
+            if fully_covered:
+                print(f'  SKIP: all {len(this_set)} function(s) already '
+                      f'covered by existing DLL(s) at this region — no new '
+                      f'native code to build\n')
+                stats.add_skip()
+                return
 
-                # overlay-cache v2 dedup: compute this capture's per-function
-                # identity set BEFORE the (expensive) gcc compile. The loader
-                # content-matches each function by (entry, code_crc) across ALL
-                # DLLs at this region_start, so if every function we'd produce is
-                # already provided by an existing DLL, a new DLL adds nothing —
-                # skip the build. This is what stops volatile-data regions (a
-                # changing whole-region CRC over byte-identical code) from minting
-                # an endless pile of redundant DLLs.
-                this_ids = (parse_overlay_func_ids(ranges_src, data, load_addr, size)
-                            if ranges_src else [])
-                delay_errors = audit_func_id_delay_slots(
-                    this_ids, data, load_addr)
-                if delay_errors:
-                    entry, pc, reason = delay_errors[0]
-                    where = f' at 0x{pc:08X}' if pc is not None else ''
-                    print(f'  DELAY-SLOT IDENTITY AUDIT FAILED: '
-                          f'func 0x{entry:08X}{where}: {reason}\n')
-                    stats.add_fail(_label, 'delay_slot_identity', reason)
-                    return
-                this_set = {(ev, crc) for ev, crc, _ in this_ids}
+            if not this_ids:
+                print('  WARNING: recompiler emitted no usable _full.ranges -- '
+                      'preserving any prior DLL/ranges pair and leaving this '
+                      'region to the interpreter')
+                stats.add_fail(_label, 'no_ranges',
+                               'no usable function identities (DLL not built)')
+                return
+            missing_exports = {
+                entry for entry, _crc, _ranges in this_ids
+                if entry not in c_audit['defs']
+            }
+            if missing_exports:
+                detail = ', '.join(
+                    f'0x{entry:08X}' for entry in sorted(missing_exports))
+                print('  GENERATED-C/MANIFEST EXPORT AUDIT FAILED: '
+                      f'{detail}\n')
+                stats.add_fail(
+                    _label, 'manifest_exports',
+                    f'{len(missing_exports)} manifest entries lack C definitions')
+                return
+            representability_error = validate_overlay_func_ids(
+                this_ids, 'region')
+            if representability_error:
+                print('  RANGE MANIFEST AUDIT FAILED: '
+                      f'{representability_error}\n')
+                stats.add_fail(
+                    _label, 'manifest_ranges', representability_error)
+                return
+            pair_id = overlay_pair_id(src, this_ids)
+            src = add_overlay_pair_export(src, pair_id)
+            # Retained source is the exact source compiled into the DLL.
+            with open(patched_c, 'w') as f:
+                f.write(src)
 
-                with cov_lock:
-                    covered = region_coverage_cache.get(phys_addr)
-                    if covered is None:
-                        covered = load_region_coverage(
+            # Compile to DLL
+            include_dirs = [args.runtime_include]
+            recomp_root = os.path.dirname(os.path.dirname(args.recompiler))
+            for lib_inc in ['lib/fmt/include']:
+                p = os.path.join(recomp_root, lib_inc)
+                if os.path.isdir(p):
+                    include_dirs.append(p)
+
+            publication = {}
+            success = compile_dll(patched_c, dll_path, include_dirs,
+                                  gcc=args.gcc, flavor=args.flavor,
+                                  compiler=args.compiler, tcc=args.tcc,
+                                  func_ids=this_ids,
+                                  pair_id=pair_id,
+                                  preserve_existing_pair=(
+                                      not args.force and
+                                      cap.get('producer') !=
+                                      BIOS_RESIDENT_PRODUCER),
+                                  expected_existing_abi=overlay_abi_tag(
+                                      args.runtime_include, args.flavor),
+                                  publication_result=publication,
+                                  candidate_cap=overlay_candidate_cap(
+                                      args.runtime_include))
+            if success:
+                # compile_dll transactionally published the per-entry range
+                # manifest beside the DLL from the same func-id list used by
+                # dedup. The loader keys it by the same filename stem.
+                ranges_out = os.path.splitext(dll_path)[0] + '.ranges'
+                if this_ids:
+                    nfn = len(this_ids)
+                    published = publication.get('published', True)
+                    reconcile_bios_resident_marker(
+                        dll_path, cap, published)
+                    print(f'  ranges: {nfn} functions -> {ranges_out}')
+                    # New identities are now available for this region_start;
+                    # keep the warm coverage set current so later captures in
+                    # this same run dedup against them. (Parallel note: the
+                    # check→build→update window is deliberately unlocked, so
+                    # two concurrent captures can both build overlapping DLLs.
+                    # That is redundancy, not corruption — the loader content-
+                    # matches every function by (entry, code_crc) across all
+                    # DLLs at a region.)
+                    with cov_lock:
+                        covered |= load_region_coverage(
                             cache_dir, phys_addr,
-                            overlay_abi_tag(args.runtime_include, args.flavor))
-                        region_coverage_cache[phys_addr] = covered
-                    fully_covered = (bool(this_set) and this_set <= covered
-                                     and not args.force
-                                     and cap.get('producer') !=
-                                         BIOS_RESIDENT_PRODUCER)
-                if fully_covered:
-                    print(f'  SKIP: all {len(this_set)} function(s) already '
-                          f'covered by existing DLL(s) at this region — no new '
-                          f'native code to build\n')
+                            overlay_abi_tag(
+                                args.runtime_include, args.flavor))
+                    if published:
+                        print(f'  OK -> {dll_path}\n')
+                        stats.add_ok()
+                    else:
+                        print(f'  PRESERVED concurrent valid pair -> '
+                              f'{dll_path}\n')
+                        stats.add_skip()
+                else:
+                    print('  WARNING: recompiler emitted no _full.ranges — '
+                          'loader will leave this region to the interpreter')
+                    # A DLL with no .ranges is dead weight: the loader has no
+                    # per-function identities to dispatch, so the region stays
+                    # interpreted. Tally it as a failure, not a silent "OK".
+                    stats.add_fail(_label, 'no_ranges',
+                                   'DLL built but no _full.ranges (undispatchable)')
+            else:
+                if publication.get('capacity_error'):
+                    print('  CACHE CAPACITY REACHED; shard left to the '
+                          'interpreter\n')
                     stats.add_skip()
                     return
-
-                if not this_ids:
-                    print('  WARNING: recompiler emitted no usable _full.ranges -- '
-                          'preserving any prior DLL/ranges pair and leaving this '
-                          'region to the interpreter')
-                    stats.add_fail(_label, 'no_ranges',
-                                   'no usable function identities (DLL not built)')
+                fallback = optional_enrichment_fallback_capture(cap)
+                if fallback is not None:
+                    print('  OPTIONAL ENRICHMENT COMPILE REJECTED; '
+                          'retrying conservative recipe\n')
+                    _do_capture(fallback, region_coverage_cache,
+                                interior_frag_jobs, stats)
                     return
-                missing_exports = {
-                    entry for entry, _crc, _ranges in this_ids
-                    if entry not in c_audit['defs']
-                }
-                if missing_exports:
-                    detail = ', '.join(
-                        f'0x{entry:08X}' for entry in sorted(missing_exports))
-                    print('  GENERATED-C/MANIFEST EXPORT AUDIT FAILED: '
-                          f'{detail}\n')
-                    stats.add_fail(
-                        _label, 'manifest_exports',
-                        f'{len(missing_exports)} manifest entries lack C definitions')
-                    return
-                representability_error = validate_overlay_func_ids(
-                    this_ids, 'region')
-                if representability_error:
-                    print('  RANGE MANIFEST AUDIT FAILED: '
-                          f'{representability_error}\n')
-                    stats.add_fail(
-                        _label, 'manifest_ranges', representability_error)
-                    return
-                pair_id = overlay_pair_id(src, this_ids)
-                src = add_overlay_pair_export(src, pair_id)
-                # Retained source is the exact source compiled into the DLL.
-                with open(patched_c, 'w') as f:
-                    f.write(src)
-
-                # Compile to DLL
-                include_dirs = [args.runtime_include]
-                recomp_root = os.path.dirname(os.path.dirname(args.recompiler))
-                for lib_inc in ['lib/fmt/include']:
-                    p = os.path.join(recomp_root, lib_inc)
-                    if os.path.isdir(p):
-                        include_dirs.append(p)
-
-                publication = {}
-                success = compile_dll(patched_c, dll_path, include_dirs,
-                                      gcc=args.gcc, flavor=args.flavor,
-                                      compiler=args.compiler, tcc=args.tcc,
-                                      func_ids=this_ids,
-                                      pair_id=pair_id,
-                                      preserve_existing_pair=(
-                                          not args.force and
-                                          cap.get('producer') !=
-                                          BIOS_RESIDENT_PRODUCER),
-                                      expected_existing_abi=overlay_abi_tag(
-                                          args.runtime_include, args.flavor),
-                                      publication_result=publication,
-                                      candidate_cap=overlay_candidate_cap(
-                                          args.runtime_include))
-                if success:
-                    # compile_dll transactionally published the per-entry range
-                    # manifest beside the DLL from the same func-id list used by
-                    # dedup. The loader keys it by the same filename stem.
-                    ranges_out = os.path.splitext(dll_path)[0] + '.ranges'
-                    if this_ids:
-                        nfn = len(this_ids)
-                        published = publication.get('published', True)
-                        reconcile_bios_resident_marker(
-                            dll_path, cap, published)
-                        print(f'  ranges: {nfn} functions -> {ranges_out}')
-                        # New identities are now available for this region_start;
-                        # keep the warm coverage set current so later captures in
-                        # this same run dedup against them. (Parallel note: the
-                        # check→build→update window is deliberately unlocked, so
-                        # two concurrent captures can both build overlapping DLLs.
-                        # That is redundancy, not corruption — the loader content-
-                        # matches every function by (entry, code_crc) across all
-                        # DLLs at a region.)
-                        with cov_lock:
-                            covered |= load_region_coverage(
-                                cache_dir, phys_addr,
-                                overlay_abi_tag(
-                                    args.runtime_include, args.flavor))
-                        if published:
-                            print(f'  OK -> {dll_path}\n')
-                            stats.add_ok()
-                        else:
-                            print(f'  PRESERVED concurrent valid pair -> '
-                                  f'{dll_path}\n')
-                            stats.add_skip()
-                    else:
-                        print('  WARNING: recompiler emitted no _full.ranges — '
-                              'loader will leave this region to the interpreter')
-                        # A DLL with no .ranges is dead weight: the loader has no
-                        # per-function identities to dispatch, so the region stays
-                        # interpreted. Tally it as a failure, not a silent "OK".
-                        stats.add_fail(_label, 'no_ranges',
-                                       'DLL built but no _full.ranges (undispatchable)')
-                else:
-                    if publication.get('capacity_error'):
-                        print('  CACHE CAPACITY REACHED; shard left to the '
-                              'interpreter\n')
-                        stats.add_skip()
-                        return
-                    fallback = optional_enrichment_fallback_capture(cap)
-                    if fallback is not None:
-                        print('  OPTIONAL ENRICHMENT COMPILE REJECTED; '
-                              'retrying conservative recipe\n')
-                        _do_capture(fallback, region_coverage_cache,
-                                    interior_frag_jobs, stats)
-                        return
-                    print(f'  FAILED\n')
-                    stats.add_fail(_label, 'compile',
-                                   'gcc/tcc compile failed (see COMPILE ERROR above)')
+                print(f'  FAILED\n')
+                stats.add_fail(_label, 'compile',
+                               'gcc/tcc compile failed (see COMPILE ERROR above)')
 
     # Interior-entry "island" fragments (overlay-cache v2): the FMV-driver class.
     # Run as a SEPARATE pass AFTER all region compiles, so it is DECOUPLED from
@@ -6669,8 +6979,26 @@ def main():
     # capture order.
     stats = ShardStats()
     if args.static:
-        for cap in captures:
-            _do_capture(cap, region_coverage_cache, interior_frag_jobs, stats)
+        if args.jobs > 1 and len(captures) > 1:
+            # Each capture is an independent recompiler subprocess plus a
+            # Python-side audit/namespace pass; the latter is CPU-bound, so
+            # processes, not threads. pool.map yields in submission order, and
+            # the merge runs in that order, so the result is byte-identical to
+            # the sequential loop.
+            from concurrent.futures import ProcessPoolExecutor
+            print(f'Static mode: {args.jobs} worker processes, '
+                  f'results merged in capture order\n')
+            with ProcessPoolExecutor(max_workers=args.jobs) as pool:
+                for res in pool.map(static_capture_job, captures,
+                                    itertools.repeat(args),
+                                    itertools.repeat(toml),
+                                    itertools.repeat(forced_interiors),
+                                    itertools.repeat(static_out),
+                                    chunksize=1):
+                    _merge_static_result(res)
+        else:
+            for cap in captures:
+                _do_capture(cap, region_coverage_cache, interior_frag_jobs, stats)
     else:
         # Publication order is part of the reproducible cache result whenever
         # the process-lifetime Candidate cap can bind. Sort complete capture
@@ -6775,18 +7103,32 @@ def main():
             nonlocal synthesized
             for part in parts:
                 done = part.setdefault('resume_entries', set())
+                # Same per-entry rules as before, but the resume arms are
+                # inserted per HOST in one pass (add_cps_resume_cases) and the
+                # wrappers appended in one concatenation. Entry order is the
+                # sorted order the per-entry loop used, so the emitted C is
+                # byte-identical; the cost drops from quadratic in the part
+                # size to linear.
+                candidates = []
+                by_host = {}
                 for entry, host in sorted(part['continuation_owners'].items()):
                     if entry in part['func_addrs'] or entry in done:
                         continue
                     if host not in part['ids_by_addr']:
                         continue
-                    symbol = f'{part["namespace"]}_func_{entry:08X}'
+                    candidates.append((entry, host))
+                    by_host.setdefault(host, []).append(entry)
+                requests = [(part['symbols'][host], host, entries)
+                            for host, entries in by_host.items()]
+                part['src'], ok_by_symbol = add_cps_resume_cases(
+                    part['src'], requests)
+                wrappers = []
+                for entry, host in candidates:
                     host_symbol = part['symbols'][host]
-                    part['src'], resume_ok = add_cps_resume_case(
-                        part['src'], host_symbol, host, entry)
-                    if not resume_ok:
+                    if entry not in ok_by_symbol.get(host_symbol, ()):
                         continue
-                    part['src'] += (
+                    symbol = f'{part["namespace"]}_func_{entry:08X}'
+                    wrappers.append(
                         f'\n/* CPS block resume entry owned by 0x{host:08X}. */\n'
                         f'void {symbol}(CPUState* cpu)\n{{\n'
                         f'    cpu->pc = 0x{entry:08X}u;\n'
@@ -6801,6 +7143,7 @@ def main():
                         })
                     done.add(entry)
                     synthesized += 1
+                part['src'] += ''.join(wrappers)
 
         synthesize_all_resume_wrappers(static_parts)
         existing_entries = {
@@ -6854,17 +7197,15 @@ def main():
                                'captured dispatch entry with no compiled body/owner')
 
         all_variants = []
-        combined = '/* Auto-generated overlay dispatch — do not edit.\n'
-        combined += ' * Rebuild: python3 psxrecomp/tools/compile_overlays.py --static ...\n'
-        combined += ' */\n'
         for part in static_parts:
-            combined += part['src']
             all_variants.extend(part['variants'])
-        combined += generate_overlay_dispatch(all_variants)
-        with open(static_out, 'w') as f:
-            f.write(combined)
+        dispatch_src = generate_overlay_dispatch(all_variants)
+        written = write_static_outputs(static_out, static_parts, all_variants,
+                                       dispatch_src,
+                                       single_file=args.static_single_file)
         print(f'Static output: {static_out}  '
-              f'({len(all_variants)} exact function identities total)')
+              f'({len(all_variants)} exact function identities total, '
+              f'{len(written)} translation unit(s))')
 
     # LOUD summary + machine-readable result line, then a non-zero exit when any
     # shard that should have built failed. The runtime's autocompile watcher and

--- a/tools/test_compile_overlays_static_split.py
+++ b/tools/test_compile_overlays_static_split.py
@@ -1,0 +1,213 @@
+"""Static-mode output split + worker contract for compile_overlays.py.
+
+    python tools/test_compile_overlays_static_split.py
+"""
+import os
+import pickle
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import compile_overlays  # noqa: E402
+
+
+def part(ns, body, symbols):
+    return {
+        'src': f'#include "psx_runtime.h"\n{body}\n',
+        'namespace': ns,
+        'variants': [{'addr': 0x80100000 + i * 4, 'symbol': s, 'crc': 1,
+                      'ranges': ((0x00100000, 8),)} for i, s in enumerate(symbols)],
+        'func_addrs': set(), 'symbols': {}, 'ids_by_addr': {},
+        'continuation_owners': {},
+    }
+
+
+class StaticSplitTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.out = os.path.join(self.tmp.name, 'overlays_static.c')
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_split_writes_dispatcher_prototypes_and_parts(self):
+        parts = [part('ov_a', 'void ov_a_func_80100000(CPUState *cpu) {}',
+                      ['ov_a_func_80100000']),
+                 part('ov_b', 'void ov_b_func_80100004(CPUState *cpu) {}',
+                      ['ov_b_func_80100004'])]
+        variants = [v for p in parts for v in p['variants']]
+        written = compile_overlays.write_static_outputs(
+            self.out, parts, variants, '/* dispatch */\n')
+        self.assertEqual([os.path.basename(w) for w in written],
+                         ['overlays_static.c', 'overlays_static_0000.c',
+                          'overlays_static_0001.c'])
+        main = open(self.out, encoding='utf-8').read()
+        self.assertIn('#include "psx_runtime.h"', main)
+        self.assertIn('void ov_a_func_80100000(CPUState *cpu);', main)
+        self.assertIn('void ov_b_func_80100004(CPUState *cpu);', main)
+        self.assertIn('/* dispatch */', main)
+        self.assertNotIn('ov_a_func_80100000(CPUState *cpu) {}', main)
+        p0 = open(written[1], encoding='utf-8').read()
+        self.assertIn('ov_a_func_80100000(CPUState *cpu) {}', p0)
+        self.assertIn('#include "psx_runtime.h"', p0)
+        self.assertNotIn('ov_b_func', p0)
+
+    def test_unchanged_part_keeps_mtime_and_stale_parts_are_removed(self):
+        parts = [part('ov_a', 'int a;', ['ov_a_func_80100000']),
+                 part('ov_b', 'int b;', ['ov_b_func_80100004']),
+                 part('ov_c', 'int c;', ['ov_c_func_80100008'])]
+        variants = [v for p in parts for v in p['variants']]
+        first = compile_overlays.write_static_outputs(
+            self.out, parts, variants, '/* d */\n')
+        self.assertEqual(len(first), 4)
+        old_mtime = os.stat(first[1]).st_mtime_ns
+        os.utime(first[1], ns=(old_mtime - 5_000_000_000,
+                               old_mtime - 5_000_000_000))
+        old_mtime = os.stat(first[1]).st_mtime_ns
+        time.sleep(0.01)
+        # Drop the last part; part 0 unchanged, part 1 changed.
+        parts[1] = part('ov_b', 'int b2;', ['ov_b_func_80100004'])
+        parts = parts[:2]
+        variants = [v for p in parts for v in p['variants']]
+        second = compile_overlays.write_static_outputs(
+            self.out, parts, variants, '/* d */\n')
+        self.assertEqual(len(second), 3)
+        self.assertEqual(os.stat(second[1]).st_mtime_ns, old_mtime,
+                         'unchanged part must not be rewritten')
+        self.assertIn('int b2;', open(second[2], encoding='utf-8').read())
+        self.assertFalse(os.path.exists(first[3]), 'stale part must be deleted')
+        self.assertEqual(sorted(os.listdir(self.tmp.name)),
+                         ['overlays_static.c', 'overlays_static_0000.c',
+                          'overlays_static_0001.c'])
+
+    def test_single_file_mode_is_monolithic_and_cleans_parts(self):
+        parts = [part('ov_a', 'int a;', ['ov_a_func_80100000'])]
+        variants = parts[0]['variants']
+        compile_overlays.write_static_outputs(self.out, parts, variants, '/* d */\n')
+        self.assertTrue(os.path.exists(os.path.join(self.tmp.name,
+                                                    'overlays_static_0000.c')))
+        written = compile_overlays.write_static_outputs(
+            self.out, parts, variants, '/* d */\n', single_file=True)
+        self.assertEqual(written, [self.out])
+        self.assertEqual(os.listdir(self.tmp.name), ['overlays_static.c'])
+        main = open(self.out, encoding='utf-8').read()
+        self.assertIn('int a;', main)
+        self.assertIn('/* d */', main)
+        self.assertNotIn('(CPUState *cpu);', main)
+
+    def test_static_part_paths_only_matches_numbered_siblings(self):
+        for name in ('overlays_static_0000.c', 'overlays_static_0001.c',
+                     'overlays_static.c', 'overlays_static_x.c',
+                     'other_0000.c'):
+            open(os.path.join(self.tmp.name, name), 'w').close()
+        found = [os.path.basename(p)
+                 for p in compile_overlays.static_part_paths(self.out)]
+        self.assertEqual(found, ['overlays_static_0000.c',
+                                 'overlays_static_0001.c'])
+
+
+class StaticWorkerContractTests(unittest.TestCase):
+    def test_worker_is_picklable_for_a_process_pool(self):
+        # ProcessPoolExecutor pickles the callable by qualified name; a nested
+        # closure would fail here. This is the guard for that regression.
+        fn = pickle.loads(pickle.dumps(compile_overlays.static_capture_job))
+        self.assertIs(fn, compile_overlays.static_capture_job)
+
+    def test_data_only_capture_reports_skip_with_captured_log(self):
+        import argparse
+        import base64
+        cap = {
+            'schema': 'psxrecomp overlay capture v2',
+            'load_addr': '0x80100000',
+            'size': 16,
+            'bytes_b64': base64.b64encode(b'\0' * 16).decode('ascii'),
+            'executed_pcs': [], 'dispatch_entry_pcs': [],
+            'function_entry_pcs': [],
+        }
+        args = argparse.Namespace(recompiler='unused', game_toml='unused',
+                                  cps=False, project_root=None)
+        res = compile_overlays.static_capture_job(cap, args, {}, set(),
+                                                  'overlays_static.c')
+        self.assertEqual(res['outcome'], 'skip')
+        self.assertIsNone(res['part'])
+        self.assertIn('SKIP: no walk-root seeds', res['log'])
+        self.assertEqual(res['requested_entries'], set())
+
+
+HOST_SRC = """#include "psx_runtime.h"
+void ov_x_func_80100000(CPUState* cpu);
+void ov_x_func_80100000(CPUState* cpu)
+{
+    debug_server_log_call_entry(0x80100000u);
+block_80100010:
+    cpu->pc = 1;
+block_80100020:
+    cpu->pc = 2;
+block_80100030:
+    cpu->pc = 3;
+}
+void ov_x_func_80100100(CPUState* cpu)
+{
+    if (cpu->pc != 0u) {
+        uint32_t _cont = cpu->pc; cpu->pc = 0;
+        switch (_cont) {
+            case 0x80100100u: break;
+            default: cpu->pc = _cont; psx_native_bad_entry(cpu, 0x80100100u, _cont); return;
+        }
+    }
+    debug_server_log_call_entry(0x80100100u);
+block_80100110:
+    cpu->pc = 4;
+block_80100120:
+    cpu->pc = 5;
+}
+"""
+
+
+class ResumeCaseBatchTests(unittest.TestCase):
+    """add_cps_resume_cases must be byte-identical to looping
+    add_cps_resume_case entry by entry (the pre-batch implementation)."""
+
+    def _sequential(self, src, requests):
+        ok = {}
+        for host_symbol, host, entries in requests:
+            for entry in entries:
+                src, good = compile_overlays.add_cps_resume_case(
+                    src, host_symbol, host, entry)
+                if good:
+                    ok.setdefault(host_symbol, set()).add(entry)
+        return src, ok
+
+    def test_batch_matches_sequential_fresh_switch_and_existing_switch(self):
+        requests = [
+            ('ov_x_func_80100000', 0x80100000,
+             [0x80100010, 0x80100020, 0x80100030, 0x80100999]),   # no such block
+            ('ov_x_func_80100100', 0x80100100, [0x80100110, 0x80100120]),
+            ('ov_x_func_missing', 0x80100200, [0x80100210]),       # no definition
+        ]
+        seq_src, seq_ok = self._sequential(HOST_SRC, requests)
+        bat_src, bat_ok = compile_overlays.add_cps_resume_cases(HOST_SRC, requests)
+        self.assertEqual(bat_src, seq_src)
+        self.assertEqual({k: v for k, v in bat_ok.items() if v}, seq_ok)
+        self.assertIn('case 0x80100010u: goto block_80100010;', bat_src)
+        self.assertIn('case 0x80100120u: goto block_80100120;', bat_src)
+        self.assertNotIn('80100999', bat_src)
+        # Re-applying is a no-op (arms already present).
+        again_src, again_ok = compile_overlays.add_cps_resume_cases(bat_src, requests)
+        self.assertEqual(again_src, bat_src)
+        self.assertEqual(again_ok['ov_x_func_80100000'],
+                         {0x80100010, 0x80100020, 0x80100030})
+
+    def test_batch_edits_are_confined_to_each_host_segment(self):
+        requests = [('ov_x_func_80100100', 0x80100100, [0x80100110])]
+        bat_src, _ = compile_overlays.add_cps_resume_cases(HOST_SRC, requests)
+        marker = 'void ov_x_func_80100100(CPUState* cpu)\n{'
+        head = bat_src[:bat_src.index(marker)]
+        self.assertEqual(head, HOST_SRC[:HOST_SRC.index(marker)])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

`--static` mode was serial end to end and emitted one translation unit, so a whole title compiled on one core twice: once in Python, once in gcc. On BoF3 (339 captures, 79,688 identities) a build-dbg loop spent ~12 min in `compile_overlays.py --static` and ~4 min compiling the resulting 309 MB / 8.6 M-line `overlays_static.c`.

Three changes, each verified byte-identical against the previous output (`diff -r`):

1. **`static_capture_job()`** — the per-capture static work (recompiler subprocess, C audit, range audit, namespacing) is a module-level, picklable job returning its part plus captured log. `--jobs` runs it in a `ProcessPoolExecutor`; results merge in capture order, so `static_parts` / entry sources are order-identical to the sequential loop.
2. **`add_cps_resume_cases()`** — the universal CPS resume-wrapper pass called `add_cps_resume_case()` once per entry, and every call re-scanned and rebuilt the whole part source. cProfile on three bands: 7,386 entries → 22,159 `re.search` calls = 366 s of 424 s. The batch form locates every signature once, edits each host segment in isolation, and rebuilds once. Same three bands: **418 s → 5 s**. The per-entry function is kept; a unit test asserts both agree on fresh-switch, existing-switch, missing-label and missing-host cases.
3. **`write_static_outputs()`** — `overlays_static.c` now holds the dispatcher plus an extern prototype per compiled entry; every part becomes its own unit `overlays_static_NNNN.c` (each already carries its `#include`s and a private namespace). `runtime.cmake` globs the siblings with `CONFIGURE_DEPENDS`, so a changed part count needs no reconfigure. Unchanged units are not rewritten (mtime preserved → not recompiled); stale units are removed. `--static-single-file` restores the monolithic file.

## Measurements (BoF3, 12-core box)

| phase | before | after |
|---|---|---|
| `compile_overlays.py --static` (all bands) | ~12 min | 20 s |
| `psx-runtime` build, build-dbg (-O0) | ~4 min | 69 s (358 units) |
| whole `axis_b_loop.sh --skip-harvest` | ~16 min | 90 s |
| `psx-runtime` build, RelWithDebInfo (`build-relprof`) | 1016 s (one 303 MB unit) | 162 s (358 units) |

Shard summary unchanged (332 ok / 7 benign `[audit]` fails), identity count unchanged. Headless boot of the rebuilt runtime through the LOGO overlay: 485,650 static checks, 485,244 hits (99.92 %), `miss_total` 0, 60 emu fps.

## Notes

- Review with `git diff -w`: the DLL branch of `_do_capture` lost one indentation level when the static branch moved out; the semantic diff is ~330 lines.
- `tools/test_compile_overlays_additive.py` already fails on `master` (references removed functions `compile_and_publish_dll`, `load_additive_captures`, `validated_cached_bundle_ids`); untouched here. New tests: `tools/test_compile_overlays_static_split.py` (8 tests, pass).
- DLL-cache path untouched; only `--static` and the static-C consumer in `runtime.cmake` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
