### PR TITLE
controller: re-clamp lock_mode across the launcher round-trip (defense-in-depth; root cause in recomp-ui)

### DIFF
--- a/recompiler/CMakeLists.txt
+++ b/recompiler/CMakeLists.txt
@@ -590,6 +590,7 @@ if(BUILD_TESTING)
                 fps_telemetry_opt_in
                 frame_interpolation_display_rate
                 hybrid_dev_any_input
+                launcher_pad_mode_wiring
                 launcher_vulkan_option
                 mod_controller_override
                 mod_load_acceleration

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -29,6 +29,17 @@ if(BUILD_TESTING)
     add_test(NAME launcher_device_roundtrip_test
              COMMAND launcher_device_roundtrip_test)
 
+    # Pad-mode resolution at the launcher exit seam: a lock_mode title must
+    # boot the pad type its game.toml declared whatever the launcher hands
+    # back, an active mod controller-mode override must outrank the lock, and
+    # neither may let an unsupported mode reach settings.toml. Header-only, so
+    # it needs nothing but runtime/include.
+    add_executable(launcher_pad_mode_resolve_test
+        tests/test_launcher_pad_mode_resolve.cpp)
+    target_include_directories(launcher_pad_mode_resolve_test PRIVATE include)
+    add_test(NAME launcher_pad_mode_resolve_test
+             COMMAND launcher_pad_mode_resolve_test)
+
     # COP0.CAUSE IP2 must mirror the INTC line combinationally, never latch.
     add_executable(cause_ip2_combinational_test
         tests/test_cause_ip2_combinational.c)

--- a/runtime/include/launcher_device.h
+++ b/runtime/include/launcher_device.h
@@ -44,4 +44,42 @@ inline std::string launcher_device_from_source(
     return "gamepad";
 }
 
+// Pad mode for one seat on the way OUT of the launcher.
+//
+// Three sources of truth have to be reconciled, and they have a strict
+// precedence:
+//
+//   1. A trusted mod's controller-mode override
+//      (psx_mod_set_controller_mode_override, runtime/include/mod_plugins.h).
+//      A game plugin that declared the pad type its patched code needs
+//      outranks everything else. Pass -1 when no override is active.
+//   2. game.toml [controller] lock_mode. A locked title supports exactly one
+//      pad type, and the launcher HIDES its pad-mode selector for such a
+//      title -- so whatever came back in ls.pad_mode[] for that seat was
+//      never a player choice and must not be believed.
+//   3. What the launcher returned.
+//
+// Both launcher-exit readback loops in runtime/src/main.cpp call this, and
+// both call it BEFORE the seat's mode is written to settings.toml, so an
+// unsupported mode can never be persisted either.
+//
+// Note what is deliberately NOT here: a keyboard seat is not forced to
+// DIGITAL. It already behaves as a plain digital pad -- effective_player_mode()
+// reports DIGITAL for any seat whose kind is keyboard, whatever this value
+// says -- so overwriting the stored mode bought nothing and cost a durable
+// corruption. A release install defaults Player 1 to the keyboard, and a
+// locked title has no selector with which to repair the value, so an
+// ANALOG-locked dual-analog game (Ape Escape) reached its DualShock as an
+// SCPH-1080: sio.c took the 4-byte pad_response_len branch, right stick dead
+// and left stick folded onto the D-pad. The matching launcher-side coercion is
+// fixed in recomp-ui's launcher_model.c.
+inline int resolve_player_mode_after_launcher(int launcher_mode,
+                                              bool lock_mode,
+                                              int locked_mode,
+                                              int mod_override_mode) {
+    if (mod_override_mode >= 0) return mod_override_mode;
+    if (lock_mode) return locked_mode;
+    return launcher_mode;
+}
+
 } // namespace PSXRecompV4

--- a/runtime/src/main.cpp
+++ b/runtime/src/main.cpp
@@ -12396,9 +12396,13 @@ int main(int argc, char** argv) {
                      * 5% normalization then silently reduced to 15%. */
                     ls.deadzone[i] =
                         (player_deadzone[i] * 100 + 32767 / 2) / 32767;
-                    ls.pad_mode[i] = (ls.player_src[i] == 1)
-                                        ? PSXRecompV4::PAD_MODE_DIGITAL
-                                        : player_mode[i];
+                    /* The seat's configured mode, verbatim. A keyboard seat
+                     * is NOT rewritten to DIGITAL on the way in: that told the
+                     * launcher a lie about what the seat is configured for,
+                     * and the launcher then handed the lie back for us to
+                     * persist. The keyboard's runtime behaviour does not
+                     * depend on this value (effective_player_mode). */
+                    ls.pad_mode[i] = player_mode[i];
                     ls.player_gamepad_guid[i][0] = '\0';
                     if (ls.player_src[i] == 2 && !d.empty() && d != "auto" &&
                         d != "gamepad" && d != "controller") {
@@ -12674,21 +12678,30 @@ int main(int argc, char** argv) {
                     for (int i = 0; i < n; ++i) {
                         if (ls.player_src[i] == 1) {
                             player_device[i] = "keyboard";
-                            /* Keyboard is always a digital pad at runtime. */
-                            player_mode[i] = PSXRecompV4::PAD_MODE_DIGITAL;
                         } else if (ls.player_src[i] == 0) {
                             player_device[i] = "none";
-                            player_mode[i] = ls.pad_mode[i];
                         } else if (ls.player_gamepad_guid[i][0]) {
                             player_device[i] = ls.player_gamepad_guid[i];
-                            player_mode[i] = ls.pad_mode[i];
                         } else if (PSXRecompV4::launcher_source_from_device(
                                        player_device[i]) <= 1) {
                             player_device[i] = "gamepad";
-                            player_mode[i] = ls.pad_mode[i];
-                        } else {
-                            player_mode[i] = ls.pad_mode[i];
                         }
+                        /* Mode is resolved separately from the device, because
+                         * the launcher round-trip is the SECOND way a locked
+                         * game could boot an unsupported pad type: the clamp at
+                         * the top of main() runs BEFORE the launcher, so
+                         * ls.pad_mode[] (seeded from settings.toml, or from a
+                         * selector the player never saw because lock_mode hides
+                         * it) would otherwise win here -- and then be persisted
+                         * into seed.p_mode[] a few lines down. Defense in depth:
+                         * the launcher itself no longer corrupts a locked mode
+                         * (recomp-ui launcher_model.c), but the host must not
+                         * depend on that to boot the declared pad type. */
+                        player_mode[i] =
+                            PSXRecompV4::resolve_player_mode_after_launcher(
+                                ls.pad_mode[i], ctrl_lock_mode,
+                                ctrl_locked_mode[i],
+                                g_mod_controller_mode_override[i]);
                         player_deadzone[i] = ls.deadzone[i] * 32767 / 100;
                         if (i < un) {
                             seed.p_device[i] = player_device[i];
@@ -14493,9 +14506,8 @@ soft_return_lobby:
                     PSXRecompV4::launcher_source_from_device(d);
                 ls.deadzone[i] =
                     (player_deadzone[i] * 100 + 32767 / 2) / 32767;
-                ls.pad_mode[i] = (ls.player_src[i] == 1)
-                                    ? PSXRecompV4::PAD_MODE_DIGITAL
-                                    : player_mode[i];
+                /* Verbatim, as in the first launcher entry above. */
+                ls.pad_mode[i] = player_mode[i];
                 ls.player_gamepad_guid[i][0] = '\0';
                 if (ls.player_src[i] == 2 && !d.empty() && d != "auto" &&
                     d != "gamepad" && d != "controller") {
@@ -14633,20 +14645,27 @@ soft_return_lobby:
                 for (int i = 0; i < n; ++i) {
                     if (ls.player_src[i] == 1) {
                         player_device[i] = "keyboard";
-                        player_mode[i] = PSXRecompV4::PAD_MODE_DIGITAL;
                     } else if (ls.player_src[i] == 0) {
                         player_device[i] = "none";
-                        player_mode[i] = ls.pad_mode[i];
                     } else if (ls.player_gamepad_guid[i][0]) {
                         player_device[i] = ls.player_gamepad_guid[i];
-                        player_mode[i] = ls.pad_mode[i];
                     } else if (PSXRecompV4::launcher_source_from_device(
                                    player_device[i]) <= 1) {
                         player_device[i] = "gamepad";
-                        player_mode[i] = ls.pad_mode[i];
-                    } else {
-                        player_mode[i] = ls.pad_mode[i];
                     }
+                    /* Same resolution as the first launcher-exit path, and the
+                     * mod-override arm matters HERE specifically: `goto
+                     * session_reboot` re-enters the emulator BELOW the block
+                     * that applies g_mod_controller_mode_override, so a soft
+                     * return from the lobby never re-runs it. Before this
+                     * helper existed, an override survived a rematch only
+                     * because it round-tripped through ls.pad_mode[]; a bare
+                     * lock clamp here would have silently dropped it. */
+                    player_mode[i] =
+                        PSXRecompV4::resolve_player_mode_after_launcher(
+                            ls.pad_mode[i], ctrl_lock_mode,
+                            ctrl_locked_mode[i],
+                            g_mod_controller_mode_override[i]);
                     player_deadzone[i] = ls.deadzone[i] * 32767 / 100;
                 }
             }

--- a/runtime/tests/test_launcher_pad_mode_resolve.cpp
+++ b/runtime/tests/test_launcher_pad_mode_resolve.cpp
@@ -1,0 +1,105 @@
+// Pad-mode resolution at the launcher exit seam
+// (PSXRecompV4::resolve_player_mode_after_launcher, runtime/include/launcher_device.h).
+//
+// What this guards, in order of how it broke:
+//
+// 1. A locked title must boot the pad type its game.toml declared, whatever
+//    the launcher hands back. Ape Escape sets default_mode = "analog" +
+//    lock_mode = true; it booted DIGITAL because the launcher returned 2 for
+//    Player 1 (whose device defaults to keyboard on a release install) and the
+//    old readback loop took ls.pad_mode[] verbatim. sio.c then answered with
+//    the 4-byte digital pad response: right stick dead, left stick folded onto
+//    the D-pad, and lock_mode hides the selector that could have fixed it.
+//
+// 2. An ACTIVE mod controller-mode override outranks the lock. The first
+//    version of the clamp was an unconditional `if (lock) mode = locked`,
+//    which is correct for (1) and silently wrong here: `goto session_reboot`
+//    re-enters the emulator BELOW the block that applies
+//    g_mod_controller_mode_override, so a soft return from the lobby never
+//    re-runs it. The override used to survive a rematch only because it
+//    round-tripped through ls.pad_mode[]; the clamp cut that path.
+//
+// 3. Whatever this returns is what gets persisted (seed.p_mode[] /
+//    us.p_mode[]), so a mode the game does not support must never come out of
+//    here for a locked title -- not even when the launcher returns garbage.
+//
+// PadMode values are the engine's (recompiler/src/config_loader.h:
+// PAD_MODE_ANALOG = 1, PAD_MODE_DIGITAL = 2; 0 is Hybrid, mod-only). They are
+// hard-coded here rather than dragged in through config_loader.h's dependency
+// chain -- tests/test_launcher_pad_mode_wiring.py pins the enum so this cannot
+// drift.
+
+#include "launcher_device.h"
+
+#include <cassert>
+#include <cstdio>
+
+namespace {
+
+constexpr int kAnalog = 1;    // PAD_MODE_ANALOG
+constexpr int kDigital = 2;   // PAD_MODE_DIGITAL
+constexpr int kHybrid = 0;    // mod-only, never selectable
+constexpr int kNoOverride = -1;
+
+int resolve(int launcher_mode, bool lock, int locked, int override_mode) {
+    return PSXRecompV4::resolve_player_mode_after_launcher(
+        launcher_mode, lock, locked, override_mode);
+}
+
+}  // namespace
+
+int main() {
+    // ---- unlocked: the launcher owns the seat ------------------------------
+    assert(resolve(kAnalog, false, kAnalog, kNoOverride) == kAnalog);
+    assert(resolve(kDigital, false, kAnalog, kNoOverride) == kDigital);
+    // The locked mode is ignored entirely when lock_mode is off, even when it
+    // disagrees -- ctrl_locked_mode[] is populated for every title, locked or
+    // not (main.cpp repopulates it outside the has_default_mode guard).
+    assert(resolve(kDigital, false, kAnalog, kNoOverride) == kDigital);
+    assert(resolve(kAnalog, false, kDigital, kNoOverride) == kAnalog);
+
+    // ---- locked: the game owns the seat (the reported bug) -----------------
+    // Ape Escape: ANALOG-locked, launcher returns DIGITAL because Player 1's
+    // device defaulted to keyboard. Must come out ANALOG.
+    assert(resolve(kDigital, true, kAnalog, kNoOverride) == kAnalog);
+    // And the other direction: a digital-only title (X4, Tomba 2) whose
+    // settings.toml predates the lock and still says analog.
+    assert(resolve(kAnalog, true, kDigital, kNoOverride) == kDigital);
+    // Idempotent when the launcher already agrees.
+    assert(resolve(kAnalog, true, kAnalog, kNoOverride) == kAnalog);
+    assert(resolve(kDigital, true, kDigital, kNoOverride) == kDigital);
+
+    // ---- persistence safety: a locked seat NEVER yields the launcher's
+    // value, so seed.p_mode[]/us.p_mode[] cannot receive an unsupported mode
+    // however wrong ls.pad_mode[] is (stale Hybrid, an ABI-width change, a
+    // settings.toml hand-edited to nonsense). -------------------------------
+    for (int bogus = -8; bogus <= 8; ++bogus) {
+        assert(resolve(bogus, true, kAnalog, kNoOverride) == kAnalog);
+        assert(resolve(bogus, true, kDigital, kNoOverride) == kDigital);
+    }
+    // Hybrid specifically: mod-only, and the launcher migrates it away, but a
+    // locked title must not adopt it even if one leaks through.
+    assert(resolve(kHybrid, true, kAnalog, kNoOverride) == kAnalog);
+
+    // ---- an active mod override wins over the lock ------------------------
+    // psx_mod_set_controller_mode_override() only ever stores ANALOG or
+    // DIGITAL (it rejects anything else loudly), so those are the two real
+    // override values.
+    assert(resolve(kDigital, true, kAnalog, kDigital) == kDigital);
+    assert(resolve(kAnalog, true, kDigital, kAnalog) == kAnalog);
+    // ...and over an unlocked launcher value too.
+    assert(resolve(kAnalog, false, kAnalog, kDigital) == kDigital);
+    assert(resolve(kDigital, false, kDigital, kAnalog) == kAnalog);
+
+    // ---- the "no override" sentinel is negative, matching the direct apply
+    // site (`if (g_mod_controller_mode_override[i] >= 0)` in main.cpp). Pinned
+    // so the two cannot drift into disagreeing about what "unset" means: a
+    // mode value of 0 would count as ACTIVE here, exactly as it does there.
+    assert(resolve(kAnalog, true, kDigital, -1) == kDigital);
+    assert(resolve(kAnalog, true, kDigital, -2) == kDigital);
+    assert(resolve(kDigital, false, kAnalog, -1) == kDigital);
+    assert(resolve(kDigital, true, kAnalog, kHybrid) == kHybrid);
+
+    std::puts("launcher pad-mode resolution guard passed");
+    return 0;
+}

--- a/runtime/tests/test_launcher_pad_mode_wiring.py
+++ b/runtime/tests/test_launcher_pad_mode_wiring.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Guard how the launcher-exit pad-mode resolution is WIRED into main().
+
+test_launcher_pad_mode_resolve.cpp proves the helper computes the right mode.
+This proves main() actually uses it, at every site, in an order where a bad
+mode cannot escape into settings.toml.
+
+The bug this exists for: an Analog-locked title (Ape Escape, game.toml
+default_mode = "analog" + lock_mode = true) booted its pad DIGITAL. The
+launcher returned 2 for Player 1 -- whose device defaults to keyboard on a
+release install -- the readback loop took ls.pad_mode[] verbatim, and
+sio_set_pad_analog() then took the 4-byte digital response: right stick dead,
+left stick folded onto the D-pad. lock_mode hides the pad-mode selector, so
+there was no UI with which to correct it, and the readback also PERSISTED the
+wrong mode, making it survive every later launch.
+
+Reading source rather than running a binary is deliberate: the code under test
+lives in the middle of main(), between a launcher round-trip and a settings
+write, and is not reachable from a unit test. What can be checked statically is
+that no call site was left bypassed and that the ordering invariant holds --
+which is the class of mistake that produced the bug.
+"""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+MAIN = (ROOT / "runtime" / "src" / "main.cpp").read_text(encoding="utf-8")
+LAUNCHER_DEVICE = (
+    ROOT / "runtime" / "include" / "launcher_device.h"
+).read_text(encoding="utf-8")
+CONFIG_LOADER = (
+    ROOT / "recompiler" / "src" / "config_loader.h"
+).read_text(encoding="utf-8")
+
+# ---- the helper exists, and is a pure function of its four inputs ----------
+assert "inline int resolve_player_mode_after_launcher(" in LAUNCHER_DEVICE, (
+    "resolve_player_mode_after_launcher() is gone from launcher_device.h"
+)
+for arm in (
+    "if (mod_override_mode >= 0) return mod_override_mode;",
+    "if (lock_mode) return locked_mode;",
+    "return launcher_mode;",
+):
+    assert arm in LAUNCHER_DEVICE, f"missing resolution arm: {arm}"
+
+# Precedence is positional in the helper body: override, then lock, then the
+# launcher's own value. Reordering these silently changes which source of truth
+# wins, and both wrong orders are plausible-looking.
+assert (
+    LAUNCHER_DEVICE.index("if (mod_override_mode >= 0) return mod_override_mode;")
+    < LAUNCHER_DEVICE.index("if (lock_mode) return locked_mode;")
+    < LAUNCHER_DEVICE.index("return launcher_mode;")
+), "resolution precedence must be override > lock > launcher"
+
+# The C++ unit test hard-codes 1/2 rather than dragging config_loader.h's
+# dependency chain into a header-only test. Pin the enum so it cannot drift.
+assert (
+    "enum PadMode { PAD_MODE_ANALOG = 1, PAD_MODE_DIGITAL = 2 };"
+    in CONFIG_LOADER
+), "PadMode values changed; test_launcher_pad_mode_resolve.cpp hard-codes them"
+
+# ---- both launcher-exit readback loops go through it ----------------------
+CALL = "PSXRecompV4::resolve_player_mode_after_launcher("
+calls = [i for i in range(len(MAIN)) if MAIN.startswith(CALL, i)]
+assert len(calls) == 2, (
+    "expected exactly 2 launcher-exit readback sites calling "
+    f"resolve_player_mode_after_launcher(), found {len(calls)}. A third "
+    "readback path must call it too; a missing one is the original bug."
+)
+
+# ---- and none of them still coerces a keyboard seat destructively --------
+# The keyboard seat needs no coercion here: effective_player_mode() reports
+# DIGITAL for kind == 1 whatever the seat's stored mode says. Overwriting the
+# stored mode instead destroyed it durably -- and for a LOCKED title there is
+# no selector left to repair it with.
+assert "return (int)PSXRecompV4::PAD_MODE_DIGITAL;" in MAIN, (
+    "effective_player_mode() no longer short-circuits keyboard seats to "
+    "DIGITAL -- the launcher-exit paths rely on it doing so"
+)
+assert "player_mode[i] = PSXRecompV4::PAD_MODE_DIGITAL;" not in MAIN, (
+    "a launcher-exit path is overwriting a seat's configured mode with "
+    "DIGITAL again"
+)
+assert MAIN.count("ls.pad_mode[i] = player_mode[i];") == 2, (
+    "the host must seed the launcher with the seat's configured mode "
+    "verbatim, at both launcher-entry sites"
+)
+
+# ---- the pre-launcher clamp is still the first line of defence -----------
+# Launcher-less builds (and a settings.toml written before the game declared
+# lock_mode) are covered only by this one.
+assert "player_mode[i] = ctrl_locked_mode[i];" in MAIN, (
+    "the pre-launcher lock_mode clamp is gone"
+)
+assert MAIN.index("player_mode[i] = ctrl_locked_mode[i];") < calls[0], (
+    "the pre-launcher clamp must run before the launcher round-trip"
+)
+
+# ---- resolution happens BEFORE the mode is persisted ---------------------
+# There are exactly two seed.p_mode[] writes. The FIRST is pre-launcher: it
+# seeds the UserSettings snapshot from player_mode[] as the pre-launcher clamp
+# left it, and nothing is on disk yet (save_user_settings runs later). The
+# SECOND is inside the first launcher-exit readback loop and is the one that
+# must follow resolution. us.p_mode[] is written inside the soft-return loop.
+#
+# If either write preceded its resolution, settings.toml would latch a mode the
+# game does not support -- which is how the original defect outlived the
+# session that produced it.
+PERSIST_SEED = "seed.p_mode[i] = player_mode[i];"
+PERSIST_US = "us.p_mode[i] = player_mode[i];"
+assert MAIN.count(PERSIST_SEED) == 2, (
+    f"expected 2 seed.p_mode[] writes, found {MAIN.count(PERSIST_SEED)}"
+)
+assert MAIN.count(PERSIST_US) == 1, (
+    f"expected 1 us.p_mode[] write, found {MAIN.count(PERSIST_US)}"
+)
+seed_writes = [i for i in range(len(MAIN)) if MAIN.startswith(PERSIST_SEED, i)]
+assert seed_writes[0] < calls[0], (
+    "the pre-launcher seed.p_mode[] write moved after the launcher round-trip"
+)
+assert calls[0] < seed_writes[1] < calls[1], (
+    "the first launcher-exit resolution must precede its seed.p_mode[] write, "
+    "and both must precede the soft-return path"
+)
+assert calls[1] < MAIN.index(PERSIST_US), (
+    "the soft-return resolution must precede the us.p_mode[] write"
+)
+
+# ---- the mod override still cannot be lost across a soft return ----------
+# `goto session_reboot` re-enters the emulator BELOW the block that applies
+# g_mod_controller_mode_override, so the soft-return readback is the only place
+# an active override can be re-asserted. That is precisely why the resolution
+# helper takes it as an argument instead of the clamp being unconditional.
+APPLY = "player_mode[i] = g_mod_controller_mode_override[i];"
+assert APPLY in MAIN, "the mod controller-mode override apply block is gone"
+assert "goto session_reboot;" in MAIN
+assert "\nsession_reboot:" in MAIN
+assert MAIN.index("\nsession_reboot:") > MAIN.index(APPLY), (
+    "session_reboot: moved above the override apply; if it is now BELOW it, "
+    "the soft-return re-assert in the readback loop may be redundant -- "
+    "re-derive before deleting it"
+)
+assert MAIN.count("g_mod_controller_mode_override[i])") == 2, (
+    "both launcher-exit resolutions must be passed the live override; found "
+    f"{MAIN.count('g_mod_controller_mode_override[i])')} such argument(s)"
+)
+# The direct apply block reads it twice (the >= 0 test and the assignment).
+assert MAIN.count("g_mod_controller_mode_override[i]") == 4, (
+    "expected 4 g_mod_controller_mode_override[i] reads: the apply block's "
+    "guard + assignment, plus one argument per launcher-exit resolution; "
+    f"found {MAIN.count('g_mod_controller_mode_override[i]')}"
+)
+
+print("launcher pad-mode wiring guard passed")


### PR DESCRIPTION
## Read this first

**The root cause of the reported bug is NOT here.** It is in recomp-ui and is fixed by mstan/recomp-ui#45 (linked at the bottom). What this PR adds on the host side is **defense in depth** — plus the removal of three host-side coercions that were destroying a seat's configured pad mode independently of the launcher bug, and the first test coverage this area has ever had.

## The bug

Ape Escape declares `default_mode = "analog"` + `lock_mode = true` (`ApeEscapeRecomp/game.toml:208-209`) and shipped with the left stick acting as camera and the right stick doing nothing — the pad booted DIGITAL on a dual-analog title, and `lock_mode` hides the pad-mode selector, so there was no UI with which to correct it.

End to end:

1. recomp-ui's `launcher_model.c` honours the lock at line 545-546 (`if (!pad_mode_selectable) pad_mode[p] = locked_pad_mode`) and clobbers it fifteen lines later with an ungated keyboard coercion. Player 1's device defaults to `"keyboard"` in a release build (`main.cpp:11164`), so `pad_mode[0]` came back as `2` (D-Pad) from every fresh install. **← root cause, fixed in the companion PR**
2. `launcher_model_set_pad_mode` and the default-for-source helper both early-return when the mode is not selectable — correctly, since the mode is locked — so once the value was `2` nothing could move it back. Attaching a real DualShock did not help.
3. **Here:** the launcher-exit readback took `player_mode[i] = ls.pad_mode[i]` verbatim and then persisted it into `settings.toml`, so DIGITAL beat the lock and kept beating it on every later launch.
4. `sio_set_pad_analog(slot, 0, …)` leaves `pad_analog[lp] == 0`, so `runtime/src/sio.c:1423-1430` takes the `pad_response_len = 4` branch — the pad reports no analog bytes. Right stick dead, left stick folded onto the D-pad. Exactly the reported symptom.

The clamp at `main.cpp:11869` already existed and already covered two holes (launcher-less builds, and a `settings.toml` written before the game declared `lock_mode`). It runs **before** the launcher, which is why the launcher round-trip was a third hole it could not see.

## What changed

`runtime/include/launcher_device.h` gains one pure function:

```cpp
inline int resolve_player_mode_after_launcher(int launcher_mode,
                                              bool lock_mode,
                                              int locked_mode,
                                              int mod_override_mode);
```

It fixes the precedence of the three sources of truth for a seat's pad mode: **an active mod controller-mode override → `game.toml` `lock_mode` → whatever the launcher returned.** Both launcher-exit readback loops call it, and both call it *before* their persistence write, so an unsupported mode can no longer be latched into `settings.toml`.

### The mod-override arm is not decoration

A bare `if (ctrl_lock_mode) player_mode[i] = ctrl_locked_mode[i];` — the obvious fix, and the first version of this change — **breaks mod controller-mode overrides on locked titles after a lobby soft return:**

- `g_mod_controller_mode_override` is applied at `main.cpp:13084-13085`,
- the `session_reboot:` label sits **below** it at `13159`,
- `goto session_reboot` (`14914`) therefore never re-runs the override block,
- but the soft-return readback loop *does* run.

Before this change an override survived a rematch only because it round-tripped through `ls.pad_mode[i]`, seeded at the soft-return entry from the post-override `player_mode[i]`. An unconditional clamp cuts that path and silently drops the override.

`psx_mod_set_controller_mode_override` is public plugin API (`runtime/include/mod_plugins.h:229`) **with no shipped caller today**, so this is latent, not live. Fixed anyway — the next caller would have had no way to tell why their override stopped applying to a locked title after a rematch.

### Three destructive coercions removed

All the same shape — a keyboard seat having its configured mode overwritten with DIGITAL:

- the two launcher-**entry** seeds (`ls.pad_mode[i] = (src == 1) ? DIGITAL : player_mode[i]`) told the launcher a lie about what the seat is configured for, and the launcher handed the lie straight back to be persisted;
- the launcher-**exit** readback did the same in the other direction.

None was load-bearing. `effective_player_mode()` (`main.cpp:4359-4362`) already returns DIGITAL for any seat whose kind is keyboard, whatever the stored mode says, and every consumer of a seat mode goes through it or through `effective_player_mode_for_sio()` — `refresh_player_devices`, `capture_pad_slot` and the netplay sample path were each checked. A keyboard seat still presents as a plain SCPH-1080 while the keyboard drives it; the difference is that its stored mode is no longer corrupted for the pad that arrives later.

### Why the unlocked case was never as bad

Worth writing down, because it is what made the bug look title-specific: for a **selectable** title, `launcher_model_set_source` → `apply_default_pad_mode_for_source` re-defaults a gamepad seat to Analog, so picking a device in the launcher repairs the value. That is precisely the repair a locked title cannot perform, because both of those functions refuse to touch a locked mode.

## Tests

There was **zero** coverage for any of this. (ApeEscapeRecomp's own `ape_stick_response_test` covers the stick *response curve*, not mode or axis routing, and lives in the title repo — it cannot see this.)

- `runtime/tests/test_launcher_pad_mode_resolve.cpp` → `launcher_pad_mode_resolve_test`. Behaviour of the resolver: a locked title yields its declared mode for **every** launcher value including out-of-range ones (so persistence can never receive an unsupported mode), an active override outranks the lock, and the "no override" sentinel stays negative to match the direct apply site.
- `runtime/tests/test_launcher_pad_mode_wiring.py` → `launcher_pad_mode_wiring`, alongside the other source-invariant guards in `recompiler/CMakeLists.txt`. How it is *wired*: exactly two readback sites call the resolver, resolution precedes each persistence write, the pre-launcher clamp still runs first, and `player_mode[i] = PSXRecompV4::PAD_MODE_DIGITAL;` appears nowhere. Verified to go red when the coercion is re-introduced at either site — not just when the helper is deleted.

Both call sites were confirmed to be **live code, not preprocessed out**, by injecting a bad symbol name and reading the errors back:

```
main.cpp:12701:42: error: 'resolve_player_mode_after_launcher_PROBE' ...
main.cpp:14665:38: error: 'resolve_player_mode_after_launcher_PROBE' ...
```

`12701` compiles under `-DRECOMP_LAUNCHER`; `14665` additionally needs `PSX_HAS_LOBBY_CLIENT`, i.e. `-DPSX_NETPLAY=ON`, so the soft-return site only exists in a netplay build — and was verified in one.

## Verification

```
$ cmake -G Ninja -S runtime -B build-fw-runtime -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ \
        -DBUILD_TESTING=ON -DRECOMP_UI_ROOT=.../recomp-ui
-- test-registration guard: 124 test file(s), all registered

$ ctest -R "launcher_pad_mode_resolve_test|launcher_device_roundtrip_test|host_keymap_test|keyboard_pad_chord_test|sio_dualshock_rumble_test|sio_card_protocol_test" --output-on-failure
1/6 Test  #1: launcher_device_roundtrip_test ...   Passed    0.02 sec
2/6 Test  #2: launcher_pad_mode_resolve_test ...   Passed    0.02 sec
3/6 Test  #8: host_keymap_test .................   Passed    0.08 sec
4/6 Test  #9: keyboard_pad_chord_test ..........   Passed    0.08 sec
5/6 Test #11: sio_dualshock_rumble_test ........***Not Run (Disabled)   0.00 sec
6/6 Test #64: sio_card_protocol_test ...........   Passed    0.06 sec
100% tests passed, 0 tests failed out of 5

$ cd build-fw-recompiler && ctest -R "launcher_pad_mode_wiring|mod_controller_override|launcher_vulkan_option|hybrid_dev_any_input|mod_owned_display_controls" --output-on-failure
3/5 Test #39: launcher_pad_mode_wiring .........   Passed    0.11 sec
4/5 Test #40: launcher_vulkan_option ...........***Failed    0.26 sec
5/5 Test #41: mod_controller_override ..........   Passed    0.15 sec
80% tests passed, 1 tests failed out of 5
```

`psx-runtime`'s `main.cpp` object compiles clean in both the plain and the `-DPSX_NETPLAY=ON` configuration. Every python guard that reads `main.cpp` (19 of them) was run individually; all pass except two that were **already red before this branch**:

- `runtime_perf_diag_guards` — registered `DISABLED`, known-failing.
- `launcher_vulkan_option` — dies in `Path.read_text()` with no `encoding=` on a cp1252 console (`UnicodeDecodeError … byte 0x9d in position 352300`, which is the `’` in a `main.cpp` comment at line 7836). Reproduced byte-identically against `git show HEAD:runtime/src/main.cpp`, so it is not from this change. **It is a real latent break in 13 guard scripts** (`runtime/tests/test_vk_*.py`, `recompiler/tests/test_aot_*.py`, `tools/tests/test_{duckstation_oracle,gpu_frame}.py`, 55 bare `read_text()` calls) and wants its own change rather than being folded in here.

## Companion PR

- **mstan/recomp-ui#45** (`fix/locked-pad-mode-keyboard-coercion`) — the root cause: gates the launcher's keyboard→D-Pad presentation default on `pad_mode_selectable` so it cannot overwrite `locked_pad_mode`, with a `recomp-ui-launcher-pad-mode` test proven to reproduce the owner's symptom before the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
