### PR TITLE
dma: preserve live linked-list reads with word-cost timing

### DIFF
--- a/docs/internal/FAITHFUL_TIMING_PLAN.md
+++ b/docs/internal/FAITHFUL_TIMING_PLAN.md
@@ -214,13 +214,18 @@ on a fixed region -> next.
 ## 5. Status / Log (update every session)
 
 - **2026-08-31 (GPU DMA2 review correction — source gate passed):**
-  Fork review found two valid timing defects in the DMA2 candidate. The
+  The first fork review found two valid timing defects in the DMA2 candidate. The
   linked-list engine now reads and emits one live payload word at each
   one-clock boundary. A CPU rewrite after an earlier word transfers can now
   affect a later word. The optional widescreen prepass now fingerprints its
   cached nodes and commands. It discards all cached transform metadata if live
-  RAM differs. The focused regressions pass, and all 55 enabled runtime tests
-  pass. Two pre-existing tests remain disabled. Retail checks and a new fork
+  RAM differs. The second fork review found three more valid issues. Late
+  service now consumes every elapsed DMA boundary. Header and link rewrites
+  now invalidate cached prepass topology at the exact header-read boundary.
+  The obsolete opt-in polygon-drop filter was removed. The focused regressions,
+  full build, and all 55 enabled runtime tests pass. Two pre-existing tests
+  remain disabled. Fresh Spot and Vampire Hunter D builds also pass their
+  600-frame headless gates. Visible software-renderer routes and another fork
   review are still required before the public branch can change.
 
 - **2026-07-28 (per-game host audio cushion — implemented, parser validated):**

--- a/docs/internal/FAITHFUL_TIMING_PLAN.md
+++ b/docs/internal/FAITHFUL_TIMING_PLAN.md
@@ -222,9 +222,11 @@ on a fixed region -> next.
   RAM differs. The second fork review found three more valid issues. Late
   service now consumes every elapsed DMA boundary. Header and link rewrites
   now invalidate cached prepass topology at the exact header-read boundary.
-  The obsolete opt-in polygon-drop filter was removed. The focused regressions,
-  full build, and all 55 enabled runtime tests pass. Two pre-existing tests
-  remain disabled. Fresh Spot and Vampire Hunter D builds also pass their
+  The obsolete opt-in polygon-drop filter was removed. The focused regressions
+  and full build pass. The runtime suite passes 61 of 62 enabled tests. The
+  remaining `mod_runtime_test` crash reproduces on the unchanged upstream base,
+  and two pre-existing tests remain disabled. Fresh Spot and Vampire Hunter D
+  builds also pass their
   600-frame headless gates. Visible software-renderer routes and another fork
   review are still required before the public branch can change.
 

--- a/docs/internal/FAITHFUL_TIMING_PLAN.md
+++ b/docs/internal/FAITHFUL_TIMING_PLAN.md
@@ -213,6 +213,16 @@ on a fixed region -> next.
 
 ## 5. Status / Log (update every session)
 
+- **2026-08-31 (GPU DMA2 review correction — source gate passed):**
+  Fork review found two valid timing defects in the DMA2 candidate. The
+  linked-list engine now reads and emits one live payload word at each
+  one-clock boundary. A CPU rewrite after an earlier word transfers can now
+  affect a later word. The optional widescreen prepass now fingerprints its
+  cached nodes and commands. It discards all cached transform metadata if live
+  RAM differs. The focused regressions pass, and all 55 enabled runtime tests
+  pass. Two pre-existing tests remain disabled. Retail checks and a new fork
+  review are still required before the public branch can change.
+
 - **2026-07-28 (per-game host audio cushion — implemented, parser validated):**
   Added `[audio] buffer_ms` as a runtime-only developer setting with a guarded
   30–500 ms range. The compatibility default remains 180 ms, preserving the

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -161,6 +161,11 @@ if(BUILD_TESTING)
     target_include_directories(ws_ui_group_test PRIVATE include)
     add_test(NAME ws_ui_group_test COMMAND ws_ui_group_test)
 
+    add_executable(ws_prepass_guard_test
+        tests/test_ws_prepass_guard.c)
+    target_include_directories(ws_prepass_guard_test PRIVATE include)
+    add_test(NAME ws_prepass_guard_test COMMAND ws_prepass_guard_test)
+
     add_executable(mod_gpu_dma_aperture_test
         tests/test_mod_gpu_dma_aperture.c)
     target_include_directories(mod_gpu_dma_aperture_test PRIVATE include)

--- a/runtime/include/boot_state.h
+++ b/runtime/include/boot_state.h
@@ -39,10 +39,12 @@ extern "C" {
 /* v1 = incomplete RAM-only; v2 = full machine but host-struct memcpy (padding);
  * v3 = little-endian field wire (portable Win/Linux/macOS ARM);
  * v4 = v3 + optional zlib on large sections (section pad bit0 = compressed);
- * v5 = v4 + CD-ROM Sub-Q replacement state. */
-#define BOOT_STATE_VERSION 5u
-/* v5 intentionally breaks older savestates after the CD-ROM wire grew. */
-#define BOOT_STATE_VERSION_MIN_READ 5u
+ * v5 = v4 + CD-ROM Sub-Q replacement state;
+ * v6 = v5 + per-word GPU DMA2 linked-list progress. */
+#define BOOT_STATE_VERSION 6u
+/* v6 intentionally breaks older savestates after the DMA wire grew. Reject
+ * them at the header before any section changes the live machine. */
+#define BOOT_STATE_VERSION_MIN_READ 6u
 /* Section pad bit0: payload is u32 LE uncompressed_len + zlib deflate bytes. */
 #define BOOT_STATE_SEC_ZLIB 1u
 

--- a/runtime/include/dma_gpu_ll.h
+++ b/runtime/include/dma_gpu_ll.h
@@ -34,6 +34,7 @@ typedef struct {
 typedef struct {
     uint32_t (*resolve_address)(void *opaque, uint32_t address);
     uint32_t (*read_word)(void *opaque, uint32_t address);
+    void (*observe_header)(void *opaque, uint32_t address, uint32_t header);
     int (*begin_node)(void *opaque, uint32_t address, uint32_t word_count);
     void (*emit_word)(void *opaque, uint32_t address, uint32_t word);
     void (*complete)(void *opaque, int hit_limit);

--- a/runtime/include/dma_gpu_ll.h
+++ b/runtime/include/dma_gpu_ll.h
@@ -10,8 +10,8 @@ extern "C" {
 enum {
     DMA_GPU_LL_PHASE_IDLE = 0,
     DMA_GPU_LL_PHASE_HEADER = 1,
-    DMA_GPU_LL_PHASE_PAYLOAD = 2,
-    DMA_GPU_LL_PHASE_COMPLETE = 3
+    DMA_GPU_LL_PHASE_SETUP = 2,
+    DMA_GPU_LL_PHASE_PAYLOAD = 3
 };
 
 typedef struct {
@@ -23,6 +23,7 @@ typedef struct {
     uint32_t current_addr;
     uint32_t next_addr;
     uint32_t word_count;
+    uint32_t payload_index;
     uint32_t cycles_remaining;
     uint32_t nodes_processed;
     uint32_t max_nodes;

--- a/runtime/include/gpu.h
+++ b/runtime/include/gpu.h
@@ -354,6 +354,7 @@ void gpu_ws_set_nw_left_hud_packet_range(uint32_t lo, uint32_t hi);
 void gpu_ws_begin_linked_list(void);
 void gpu_ws_end_linked_list(void);
 void gpu_ws_prepass_linked_list(uint32_t start_addr);
+void gpu_ws_validate_linked_list_header(uint32_t addr, uint32_t header);
 void gpu_ws_validate_linked_list_node(uint32_t addr, uint32_t num_words);
 void gpu_ws_restore_linked_list_rank(uint32_t rank);
 /* Native-wide full-frame 2D backdrop stretch ([widescreen] nw_backdrop):

--- a/runtime/include/gpu.h
+++ b/runtime/include/gpu.h
@@ -354,6 +354,7 @@ void gpu_ws_set_nw_left_hud_packet_range(uint32_t lo, uint32_t hi);
 void gpu_ws_begin_linked_list(void);
 void gpu_ws_end_linked_list(void);
 void gpu_ws_prepass_linked_list(uint32_t start_addr);
+void gpu_ws_validate_linked_list_node(uint32_t addr, uint32_t num_words);
 void gpu_ws_restore_linked_list_rank(uint32_t rank);
 /* Native-wide full-frame 2D backdrop stretch ([widescreen] nw_backdrop):
  * stretch a screen-space quad that covers the whole 4:3 framebuffer (sky

--- a/runtime/include/ws_prepass_guard.h
+++ b/runtime/include/ws_prepass_guard.h
@@ -1,0 +1,50 @@
+#ifndef PSXRECOMP_WS_PREPASS_GUARD_H
+#define PSXRECOMP_WS_PREPASS_GUARD_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    uint32_t word_count;
+    uint64_t fingerprint;
+} WsPrepassPacketGuard;
+
+static inline uint64_t ws_prepass_packet_fingerprint(const uint32_t *words,
+                                                     uint32_t word_count) {
+    uint64_t hash = UINT64_C(1469598103934665603);
+    for (uint32_t i = 0; i < word_count; i++) {
+        uint32_t word = words[i];
+        for (unsigned shift = 0; shift < 32; shift += 8) {
+            hash ^= (uint8_t)(word >> shift);
+            hash *= UINT64_C(1099511628211);
+        }
+    }
+    hash ^= word_count;
+    hash *= UINT64_C(1099511628211);
+    return hash;
+}
+
+static inline WsPrepassPacketGuard ws_prepass_packet_guard(
+        const uint32_t *words, uint32_t word_count) {
+    WsPrepassPacketGuard guard;
+    guard.word_count = word_count;
+    guard.fingerprint = ws_prepass_packet_fingerprint(words, word_count);
+    return guard;
+}
+
+static inline int ws_prepass_packet_matches(const WsPrepassPacketGuard *guard,
+                                            const uint32_t *words,
+                                            uint32_t word_count) {
+    return guard && guard->word_count == word_count &&
+           guard->fingerprint ==
+               ws_prepass_packet_fingerprint(words, word_count);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/runtime/src/dma.c
+++ b/runtime/src/dma.c
@@ -659,18 +659,6 @@ static void execute_ch1_mdec_out(void) {
     complete_transfer(1);
 }
 
-static int gpu_ll_nd_flap_last(void) {
-    static int enabled = -1;
-    if (enabled < 0) {
-        const char *e = getenv("PSX_ND_SIB_FLAP_LAST");
-        if (!e || !*e) e = getenv("PSX_ND_OT_OPAQUE_LAST");
-        enabled = (e && *e && *e != '0') ? 1 : 0;
-        if (enabled)
-            fprintf(stdout, "psxrecomp: PSX_ND_SIB_FLAP_LAST enabled\n");
-    }
-    return enabled;
-}
-
 static uint32_t gpu_ll_resolve_address(void *opaque, uint32_t address) {
     (void)opaque;
     return psx_mod_gpu_dma_resolve_address(address);
@@ -681,33 +669,18 @@ static uint32_t gpu_ll_read_word(void *opaque, uint32_t address) {
     return psx_read_word(address);
 }
 
+static void gpu_ll_observe_header(void *opaque, uint32_t addr,
+                                  uint32_t header) {
+    (void)opaque;
+    gpu_ws_validate_linked_list_header(addr, header);
+}
+
 static int gpu_ll_begin_node(void *opaque, uint32_t addr, uint32_t num_words) {
     (void)opaque;
-    int emit = 1;
-    uint32_t ot_rank = gpu_linked_list.empty_rank;
 
     gpu_ws_validate_linked_list_node(addr, num_words);
-
-    if (gpu_ll_nd_flap_last() && num_words >= 6u &&
-        ot_rank >= 1600u && ot_rank < 2100u) {
-        uint32_t word_addr = psx_mod_gpu_dma_resolve_address(addr + 4u);
-        uint32_t cmd = psx_read_word(word_addr);
-        uint32_t op = (cmd >> 24) & 0xFFu;
-        if (op == 0x36u) {
-            int32_t sx_max = -0x8000;
-            for (uint32_t vi = 1; vi <= 5; vi += 2) {
-                uint32_t xy = psx_read_word(psx_mod_gpu_dma_resolve_address(
-                    word_addr + vi * 4u));
-                int32_t sx = (int32_t)(xy & 0x7FFu);
-                if (sx & 0x400) sx -= 0x800;
-                if (sx > sx_max) sx_max = sx;
-            }
-            if (sx_max >= 280) emit = 0;
-        }
-    }
-
-    if (emit) gpu_set_gp0_linked_list_node(addr, num_words);
-    return emit;
+    gpu_set_gp0_linked_list_node(addr, num_words);
+    return 1;
 }
 
 static void gpu_ll_emit_word(void *opaque, uint32_t address, uint32_t word) {
@@ -727,6 +700,7 @@ static void gpu_ll_complete(void *opaque, int hit_limit) {
 static const DMAGPULinkedListOps gpu_ll_ops = {
     gpu_ll_resolve_address,
     gpu_ll_read_word,
+    gpu_ll_observe_header,
     gpu_ll_begin_node,
     gpu_ll_emit_word,
     gpu_ll_complete

--- a/runtime/src/dma.c
+++ b/runtime/src/dma.c
@@ -686,6 +686,8 @@ static int gpu_ll_begin_node(void *opaque, uint32_t addr, uint32_t num_words) {
     int emit = 1;
     uint32_t ot_rank = gpu_linked_list.empty_rank;
 
+    gpu_ws_validate_linked_list_node(addr, num_words);
+
     if (gpu_ll_nd_flap_last() && num_words >= 6u &&
         ot_rank >= 1600u && ot_rank < 2100u) {
         uint32_t word_addr = psx_mod_gpu_dma_resolve_address(addr + 4u);
@@ -1329,7 +1331,8 @@ void dma_debug_get_state(DMADebugState* out) {
             delayed_complete[i].active;
         out->channels[i].remaining_words =
             (i < 2 && mdec_async[i].active) ? mdec_async[i].remaining_words :
-            (i == 2 && gpu_linked_list.active) ? gpu_linked_list.word_count :
+            (i == 2 && gpu_linked_list.active)
+                ? gpu_linked_list.word_count - gpu_linked_list.payload_index :
             (i == 3 && cdrom_async.active) ? cdrom_async.remaining_words :
             delayed_complete[i].total_words;
         out->channels[i].cycles_accum =
@@ -1346,7 +1349,7 @@ void dma_debug_get_state(DMADebugState* out) {
 /* DMAChannel = 3×u32 (no pad). Async/delayed structs have host padding — field LE. */
 #define DMA_ASYNC_WIRE (1u + 1u + 4u + 4u + 4u + 4u) /* 18 */
 #define DMA_DELAY_WIRE (1u + 4u + 4u)                 /* 9 */
-#define DMA_GPU_LL_WIRE (4u + (9u * 4u))              /* 40 */
+#define DMA_GPU_LL_WIRE (4u + (10u * 4u))             /* 44 */
 #define DMA_SNAP_WIRE_BYTES ( \
     (7u * 12u) + 4u + 4u + (2u * DMA_ASYNC_WIRE) + DMA_ASYNC_WIRE + \
     DMA_GPU_LL_WIRE + (7u * DMA_DELAY_WIRE))
@@ -1366,18 +1369,22 @@ static int dma_w_gpu_ll(PstW *w, const DMAGPULinkedList *s) {
            pst_w_u8(w, s->emit_node) && pst_w_u8(w, s->hit_limit) &&
            pst_w_u32(w, s->start_addr) && pst_w_u32(w, s->current_addr) &&
            pst_w_u32(w, s->next_addr) && pst_w_u32(w, s->word_count) &&
+           pst_w_u32(w, s->payload_index) &&
            pst_w_u32(w, s->cycles_remaining) &&
            pst_w_u32(w, s->nodes_processed) && pst_w_u32(w, s->max_nodes) &&
            pst_w_u32(w, s->total_words) && pst_w_u32(w, s->empty_rank);
 }
 static int dma_r_gpu_ll(PstR *r, DMAGPULinkedList *s) {
-    return pst_r_u8(r, &s->active) && pst_r_u8(r, &s->phase) &&
+    int ok = pst_r_u8(r, &s->active) && pst_r_u8(r, &s->phase) &&
            pst_r_u8(r, &s->emit_node) && pst_r_u8(r, &s->hit_limit) &&
            pst_r_u32(r, &s->start_addr) && pst_r_u32(r, &s->current_addr) &&
            pst_r_u32(r, &s->next_addr) && pst_r_u32(r, &s->word_count) &&
+           pst_r_u32(r, &s->payload_index) &&
            pst_r_u32(r, &s->cycles_remaining) &&
            pst_r_u32(r, &s->nodes_processed) && pst_r_u32(r, &s->max_nodes) &&
            pst_r_u32(r, &s->total_words) && pst_r_u32(r, &s->empty_rank);
+    return ok && s->payload_index <= s->word_count &&
+           s->phase <= DMA_GPU_LL_PHASE_PAYLOAD;
 }
 static int dma_w_delay(PstW *w, const DMADelayedComplete *d) {
     return pst_w_u8(w, d->active) && pst_w_u32(w, d->total_words) &&

--- a/runtime/src/dma_gpu_ll.c
+++ b/runtime/src/dma_gpu_ll.c
@@ -48,89 +48,88 @@ uint32_t dma_gpu_ll_cycles_to_event(const DMAGPULinkedList *state) {
 void dma_gpu_ll_advance(DMAGPULinkedList *state, uint32_t cycles,
                         const DMAGPULinkedListOps *ops, void *opaque) {
     if (!state->active || cycles == 0 || !ops || !ops->read_word) return;
-    if (cycles < state->cycles_remaining) {
-        state->cycles_remaining -= cycles;
-        return;
-    }
+    for (;;) {
+        if (cycles < state->cycles_remaining) {
+            state->cycles_remaining -= cycles;
+            return;
+        }
+        cycles -= state->cycles_remaining;
+        state->cycles_remaining = 0;
 
-    /* The runtime's deadline scheduler lands on each advertised boundary. If a
-     * caller reaches us late, process one boundary only. This preserves the
-     * same one-event-per-service contract as SIO, CD-ROM, and MDEC. */
-    state->cycles_remaining = 0;
+        if (state->phase == DMA_GPU_LL_PHASE_HEADER) {
+            if (state->nodes_processed >= state->max_nodes) {
+                state->hit_limit = 1;
+                finish(state, ops, opaque);
+                return;
+            }
 
-    if (state->phase == DMA_GPU_LL_PHASE_HEADER) {
-        if (state->nodes_processed >= state->max_nodes) {
+            state->current_addr = resolve_address(
+                ops, opaque, state->current_addr);
+            uint32_t header = ops->read_word(opaque, state->current_addr);
+            if (ops->observe_header)
+                ops->observe_header(opaque, state->current_addr, header);
+            state->word_count = header >> 24;
+            state->payload_index = 0;
+            state->next_addr = header & 0x00FFFFFFu;
+            state->nodes_processed++;
+            state->total_words++;
+            if (state->word_count == 0)
+                state->empty_rank = state->empty_rank == UINT32_MAX
+                    ? 0u : state->empty_rank + 1u;
+            if (state->word_count != 0) {
+                state->emit_node = 1u;
+                state->phase = DMA_GPU_LL_PHASE_SETUP;
+                state->cycles_remaining = DMA_GPU_LL_SETUP_CYCLES;
+            } else {
+                state->emit_node = ops->begin_node
+                    ? (uint8_t)(ops->begin_node(
+                          opaque, state->current_addr, 0u) != 0)
+                    : 1u;
+
+                if (state->next_addr == 0x00FFFFFFu) {
+                    finish(state, ops, opaque);
+                    return;
+                }
+                state->current_addr = resolve_address(
+                    ops, opaque, state->next_addr);
+                state->cycles_remaining = DMA_GPU_LL_HEADER_CYCLES;
+            }
+        } else if (state->phase == DMA_GPU_LL_PHASE_SETUP) {
+            state->emit_node = ops->begin_node
+                ? (uint8_t)(ops->begin_node(
+                      opaque, state->current_addr, state->word_count) != 0)
+                : 1u;
+            state->phase = DMA_GPU_LL_PHASE_PAYLOAD;
+            state->cycles_remaining = 1u;
+        } else if (state->phase == DMA_GPU_LL_PHASE_PAYLOAD) {
+            uint32_t word_addr = resolve_address(
+                ops, opaque, state->current_addr + 4u +
+                             state->payload_index * 4u);
+            if (state->emit_node) {
+                uint32_t word = ops->read_word(opaque, word_addr);
+                if (ops->emit_word)
+                    ops->emit_word(opaque, word_addr, word);
+            }
+            state->payload_index++;
+            state->total_words++;
+
+            if (state->payload_index < state->word_count) {
+                state->cycles_remaining = 1u;
+            } else if (state->next_addr == 0x00FFFFFFu) {
+                finish(state, ops, opaque);
+                return;
+            } else {
+                state->phase = DMA_GPU_LL_PHASE_HEADER;
+                state->current_addr = resolve_address(
+                    ops, opaque, state->next_addr);
+                state->cycles_remaining = DMA_GPU_LL_HEADER_CYCLES;
+            }
+        } else {
             state->hit_limit = 1;
             finish(state, ops, opaque);
             return;
         }
 
-        state->current_addr = resolve_address(ops, opaque, state->current_addr);
-        uint32_t header = ops->read_word(opaque, state->current_addr);
-        state->word_count = header >> 24;
-        state->payload_index = 0;
-        state->next_addr = header & 0x00FFFFFFu;
-        state->nodes_processed++;
-        state->total_words++;
-        if (state->word_count == 0)
-            state->empty_rank = state->empty_rank == UINT32_MAX
-                ? 0u : state->empty_rank + 1u;
-        if (state->word_count != 0) {
-            state->emit_node = 1u;
-            state->phase = DMA_GPU_LL_PHASE_SETUP;
-            state->cycles_remaining = DMA_GPU_LL_SETUP_CYCLES;
-            return;
-        }
-
-        state->emit_node = ops->begin_node
-            ? (uint8_t)(ops->begin_node(opaque, state->current_addr, 0u) != 0)
-            : 1u;
-
-        if (state->next_addr == 0x00FFFFFFu) {
-            finish(state, ops, opaque);
-            return;
-        }
-        state->current_addr = resolve_address(ops, opaque, state->next_addr);
-        state->cycles_remaining = DMA_GPU_LL_HEADER_CYCLES;
-        return;
+        if (!state->active || cycles == 0) return;
     }
-
-    if (state->phase == DMA_GPU_LL_PHASE_SETUP) {
-        state->emit_node = ops->begin_node
-            ? (uint8_t)(ops->begin_node(opaque, state->current_addr,
-                                        state->word_count) != 0)
-            : 1u;
-        state->phase = DMA_GPU_LL_PHASE_PAYLOAD;
-        state->cycles_remaining = 1u;
-        return;
-    }
-
-    if (state->phase == DMA_GPU_LL_PHASE_PAYLOAD) {
-        uint32_t word_addr = resolve_address(
-            ops, opaque, state->current_addr + 4u +
-                         state->payload_index * 4u);
-        if (state->emit_node) {
-            uint32_t word = ops->read_word(opaque, word_addr);
-            if (ops->emit_word) ops->emit_word(opaque, word_addr, word);
-        }
-        state->payload_index++;
-        state->total_words++;
-
-        if (state->payload_index < state->word_count) {
-            state->cycles_remaining = 1u;
-            return;
-        }
-
-        if (state->next_addr == 0x00FFFFFFu) {
-            finish(state, ops, opaque);
-            return;
-        }
-        state->phase = DMA_GPU_LL_PHASE_HEADER;
-        state->current_addr = resolve_address(ops, opaque, state->next_addr);
-        state->cycles_remaining = DMA_GPU_LL_HEADER_CYCLES;
-        return;
-    }
-
-    state->hit_limit = 1;
-    finish(state, ops, opaque);
 }

--- a/runtime/src/dma_gpu_ll.c
+++ b/runtime/src/dma_gpu_ll.c
@@ -68,6 +68,7 @@ void dma_gpu_ll_advance(DMAGPULinkedList *state, uint32_t cycles,
         state->current_addr = resolve_address(ops, opaque, state->current_addr);
         uint32_t header = ops->read_word(opaque, state->current_addr);
         state->word_count = header >> 24;
+        state->payload_index = 0;
         state->next_addr = header & 0x00FFFFFFu;
         state->nodes_processed++;
         state->total_words++;
@@ -76,7 +77,7 @@ void dma_gpu_ll_advance(DMAGPULinkedList *state, uint32_t cycles,
                 ? 0u : state->empty_rank + 1u;
         if (state->word_count != 0) {
             state->emit_node = 1u;
-            state->phase = DMA_GPU_LL_PHASE_PAYLOAD;
+            state->phase = DMA_GPU_LL_PHASE_SETUP;
             state->cycles_remaining = DMA_GPU_LL_SETUP_CYCLES;
             return;
         }
@@ -94,35 +95,39 @@ void dma_gpu_ll_advance(DMAGPULinkedList *state, uint32_t cycles,
         return;
     }
 
-    if (state->phase == DMA_GPU_LL_PHASE_PAYLOAD) {
-        uint32_t word_addr = resolve_address(
-            ops, opaque, state->current_addr + 4u);
+    if (state->phase == DMA_GPU_LL_PHASE_SETUP) {
         state->emit_node = ops->begin_node
             ? (uint8_t)(ops->begin_node(opaque, state->current_addr,
                                         state->word_count) != 0)
             : 1u;
+        state->phase = DMA_GPU_LL_PHASE_PAYLOAD;
+        state->cycles_remaining = 1u;
+        return;
+    }
+
+    if (state->phase == DMA_GPU_LL_PHASE_PAYLOAD) {
+        uint32_t word_addr = resolve_address(
+            ops, opaque, state->current_addr + 4u +
+                         state->payload_index * 4u);
         if (state->emit_node) {
-            for (uint32_t i = 0; i < state->word_count; i++) {
-                uint32_t word = ops->read_word(opaque, word_addr);
-                if (ops->emit_word) ops->emit_word(opaque, word_addr, word);
-                word_addr = resolve_address(ops, opaque, word_addr + 4u);
-            }
+            uint32_t word = ops->read_word(opaque, word_addr);
+            if (ops->emit_word) ops->emit_word(opaque, word_addr, word);
         }
-        state->total_words += state->word_count;
+        state->payload_index++;
+        state->total_words++;
+
+        if (state->payload_index < state->word_count) {
+            state->cycles_remaining = 1u;
+            return;
+        }
 
         if (state->next_addr == 0x00FFFFFFu) {
-            state->phase = DMA_GPU_LL_PHASE_COMPLETE;
-            state->cycles_remaining = state->word_count;
+            finish(state, ops, opaque);
             return;
         }
         state->phase = DMA_GPU_LL_PHASE_HEADER;
         state->current_addr = resolve_address(ops, opaque, state->next_addr);
-        state->cycles_remaining = state->word_count + DMA_GPU_LL_HEADER_CYCLES;
-        return;
-    }
-
-    if (state->phase == DMA_GPU_LL_PHASE_COMPLETE) {
-        finish(state, ops, opaque);
+        state->cycles_remaining = DMA_GPU_LL_HEADER_CYCLES;
         return;
     }
 

--- a/runtime/src/dma_gpu_ll.c
+++ b/runtime/src/dma_gpu_ll.c
@@ -2,13 +2,12 @@
 
 #include <string.h>
 
-/* PSX DMA2 linked-list timing used by the clean-room state machine. The header
- * read costs eight guest clocks. A non-empty node then has five setup clocks,
- * followed by one clock per payload word. Keeping these as separate events is
- * important: the guest CPU can change a packet after it starts DMA and before
- * DMA reaches that packet. */
-#define DMA_GPU_LL_HEADER_CYCLES 8u
-#define DMA_GPU_LL_SETUP_CYCLES  5u
+/* Charge one guest clock for each 32-bit word read: one header per node and
+ * one clock per payload word. There is no separate setup charge. Header and
+ * payload reads remain separate events so guest writes can affect an active
+ * transfer before DMA reaches the changed word. */
+#define DMA_GPU_LL_HEADER_CYCLES 1u
+#define DMA_GPU_LL_SETUP_CYCLES  0u
 
 static uint32_t resolve_address(const DMAGPULinkedListOps *ops, void *opaque,
                                 uint32_t address) {
@@ -130,6 +129,9 @@ void dma_gpu_ll_advance(DMAGPULinkedList *state, uint32_t cycles,
             return;
         }
 
-        if (!state->active || cycles == 0) return;
+        if (!state->active) return;
+        /* Consume a zero-cost phase transition in this service call. A later
+         * read still waits for its own non-zero event. */
+        if (cycles == 0 && state->cycles_remaining != 0) return;
     }
 }

--- a/runtime/src/gpu.c
+++ b/runtime/src/gpu.c
@@ -29,6 +29,7 @@
 #include "ws_cull_detect.h"
 #include "ws_aspect_cone_math.h"
 #include "ws_ui_group.h"
+#include "ws_prepass_guard.h"
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -103,10 +104,19 @@ typedef struct {
     int32_t  y;
     int32_t  h;
     uint8_t  op;
+    WsPrepassPacketGuard packet_guard;
 } WsUiPrepassItem;
 static WsUiPrepassItem ws_ui_prepass[WS_UI_PREPASS_MAX];
 static uint32_t ws_ui_prepass_count;
 static uint16_t ws_ui_prepass_rank = 0xFFFFu;
+
+#define WS_UI_PREPASS_NODE_MAX 8192u
+typedef struct {
+    uint32_t addr;
+    WsPrepassPacketGuard payload_guard;
+} WsUiPrepassNode;
+static WsUiPrepassNode ws_ui_prepass_nodes[WS_UI_PREPASS_NODE_MAX];
+static uint32_t ws_ui_prepass_node_count;
 
 /* Why a UI-looking primitive did NOT reach the squash partition.
  *
@@ -124,6 +134,7 @@ static struct {
     uint32_t too_big;     /* full-screen or large-primitive reject         */
     uint32_t cap;         /* WS_UI_PREPASS_MAX reached                     */
     uint32_t rank;        /* admitted, then dropped by the max_rank filter */
+    uint32_t stale;       /* live packet no longer matches cached bytes    */
 } ws_ui_reject;
 
 /* Geometry of the primitives the max_rank filter discarded. A count alone
@@ -183,6 +194,7 @@ void gpu_ws_set_full_2d(int on) { ws_full_2d = on ? 1 : 0; }
 void gpu_ws_set_auto_ui_squash(int on) {
     ws_auto_ui_squash = on ? 1 : 0;
     ws_ui_prepass_count = 0;
+    ws_ui_prepass_node_count = 0;
     ws_ui_prepass_rank = 0xFFFFu;
     ws_auto_ui_dense = 0;
     ws_auto_ui_candidate_count = 0;
@@ -1640,13 +1652,14 @@ int psx_ws_ui_groups_json(char *buf, int cap) {
         "\"active\":%d,\"squash\":%d,\"dense\":%d,\"rank\":%d,"
         "\"disp_x\":%d,\"disp_w\":%d,\"join_gap\":%d,"
         "\"rejected\":{\"opcode\":%u,\"not_axis\":%u,\"degenerate\":%u,"
-        "\"too_big\":%u,\"cap\":%u,\"rank\":%u},"
+        "\"too_big\":%u,\"cap\":%u,\"rank\":%u,\"stale\":%u},"
         "\"n\":%u,",
         ws_active(), ws_auto_ui_squash, ws_auto_ui_dense,
         ws_ui_prepass_rank != 0xFFFFu ? (int)ws_ui_prepass_rank : -1,
         ws_disp_x(), ws_disp_w(), WS_UI_GROUP_JOIN_GAP,
         ws_ui_reject.opcode, ws_ui_reject.not_axis, ws_ui_reject.degenerate,
         ws_ui_reject.too_big, ws_ui_reject.cap, ws_ui_reject.rank,
+        ws_ui_reject.stale,
         ws_ui_prepass_count);
     off += snprintf(buf + off, (size_t)(cap - off), "\"rank_dropped\":[");
     for (uint32_t i = 0; i < ws_ui_rankdrop_count && off < cap - 120; i++) {
@@ -2042,6 +2055,14 @@ static int32_t ws_hud_pivot(int32_t x, int32_t w) {
  * before the list streams through GP0. This excludes CPU-built characters (the
  * source of the old squashed-Spike regression) even when their packets are
  * axis-aligned, and gives animated glyphs a shared anchor on their first frame. */
+static void ws_ui_prepass_invalidate_stale(void) {
+    ws_ui_prepass_count = 0;
+    ws_ui_prepass_node_count = 0;
+    ws_ui_prepass_rank = 0xFFFFu;
+    ws_auto_ui_dense = 0;
+    ws_ui_reject.stale++;
+}
+
 static int ws_auto_ui_anchor(int32_t *out_anchor) {
     if (!ws_auto_ui_squash || !ws_active() ||
         gp0_cmd_source_addr == 0xFFFFFFFFu)
@@ -2049,6 +2070,12 @@ static int ws_auto_ui_anchor(int32_t *out_anchor) {
     uint32_t src = gp0_cmd_source_addr & 0x1FFFFCu;
     for (uint32_t i = 0; i < ws_ui_prepass_count; i++) {
         if (ws_ui_prepass[i].src_addr != src) continue;
+        if (!ws_prepass_packet_matches(&ws_ui_prepass[i].packet_guard,
+                                       gp0_cmd_buf,
+                                       (uint32_t)gp0_words_needed)) {
+            ws_ui_prepass_invalidate_stale();
+            return 0;
+        }
         if (out_anchor) *out_anchor = ws_ui_prepass[i].group.anchor;
         ws_auto_ui_candidate_count++;
         return 1;
@@ -4622,8 +4649,8 @@ static int gp0_command_word_count(uint8_t opcode) {
     }
 }
 
-static void ws_ui_prepass_add(const uint32_t *words, uint32_t source_addr,
-                              uint16_t rank) {
+static void ws_ui_prepass_add(const uint32_t *words, uint32_t word_count,
+                              uint32_t source_addr, uint16_t rank) {
     if (rank == 0xFFFFu) return;
     if (ws_ui_prepass_count >= WS_UI_PREPASS_MAX) { ws_ui_reject.cap++; return; }
     uint32_t op = words[0] >> 24;
@@ -4710,14 +4737,17 @@ static void ws_ui_prepass_add(const uint32_t *words, uint32_t source_addr,
     item->y  = min_y;
     item->h  = height;
     item->op = (uint8_t)op;
+    item->packet_guard = ws_prepass_packet_guard(words, word_count);
 }
 
 void gpu_ws_prepass_linked_list(uint32_t start_addr) {
     ws_ui_prepass_count = 0;
+    ws_ui_prepass_node_count = 0;
     ws_ui_prepass_rank = 0xFFFFu;
     ws_auto_ui_dense = 0;
     ws_ui_reject.opcode = ws_ui_reject.not_axis = ws_ui_reject.degenerate =
-        ws_ui_reject.too_big = ws_ui_reject.cap = ws_ui_reject.rank = 0;
+        ws_ui_reject.too_big = ws_ui_reject.cap = ws_ui_reject.rank =
+        ws_ui_reject.stale = 0;
     ws_ui_rankdrop_count = 0;
     if (!ws_auto_ui_squash || !ws_active()) return;
 
@@ -4729,10 +4759,28 @@ void gpu_ws_prepass_linked_list(uint32_t start_addr) {
     for (;;) {
         if (safety++ > max_nodes) {
             ws_ui_prepass_count = 0;
+            ws_ui_prepass_node_count = 0;
             return;
         }
         uint32_t header = psx_read_word(addr);
         uint32_t num_words = (header >> 24) & 0xFFu;
+        if (ws_ui_prepass_node_count >= WS_UI_PREPASS_NODE_MAX) {
+            ws_ui_reject.cap++;
+            ws_ui_prepass_count = 0;
+            ws_ui_prepass_node_count = 0;
+            return;
+        }
+        uint32_t payload[255];
+        uint32_t first_addr = psx_mod_gpu_dma_resolve_address(addr + 4u);
+        for (uint32_t i = 0; i < num_words; i++) {
+            payload[i] = psx_read_word(psx_mod_gpu_dma_resolve_address(
+                first_addr + i * 4u));
+        }
+        WsUiPrepassNode *node =
+            &ws_ui_prepass_nodes[ws_ui_prepass_node_count++];
+        node->addr = addr & 0x1FFFFCu;
+        node->payload_guard =
+            ws_prepass_packet_guard(payload, num_words);
         if (num_words == 0) {
             rank = rank == 0xFFFFu ? 0u : (uint16_t)(rank + 1u);
         } else if (rank != 0xFFFFu) {
@@ -4756,7 +4804,7 @@ void gpu_ws_prepass_linked_list(uint32_t start_addr) {
                         psx_mod_gpu_dma_resolve_address(
                             word_addr + (offset + (uint32_t)i) * 4u));
                 }
-                ws_ui_prepass_add(words,
+                ws_ui_prepass_add(words, (uint32_t)count,
                     psx_mod_gpu_dma_resolve_address(
                         word_addr + offset * 4u), rank);
                 offset += (uint32_t)count;
@@ -4820,6 +4868,34 @@ void gpu_ws_prepass_linked_list(uint32_t start_addr) {
                        ws_auto_ui_dense);
     for (uint32_t i = 0; i < ws_ui_prepass_count; i++)
         ws_ui_prepass[i].group.anchor = group_origin + groups[i].anchor;
+}
+
+void gpu_ws_validate_linked_list_node(uint32_t addr, uint32_t num_words) {
+    if (ws_ui_prepass_count == 0) return;
+
+    uint32_t resolved =
+        psx_mod_gpu_dma_resolve_address(addr) & 0x1FFFFCu;
+    const WsUiPrepassNode *node = NULL;
+    for (uint32_t i = 0; i < ws_ui_prepass_node_count; i++) {
+        if (ws_ui_prepass_nodes[i].addr == resolved) {
+            node = &ws_ui_prepass_nodes[i];
+            break;
+        }
+    }
+    if (!node || node->payload_guard.word_count != num_words) {
+        ws_ui_prepass_invalidate_stale();
+        return;
+    }
+
+    uint32_t payload[255];
+    uint32_t first_addr =
+        psx_mod_gpu_dma_resolve_address(resolved + 4u);
+    for (uint32_t i = 0; i < num_words; i++) {
+        payload[i] = psx_read_word(psx_mod_gpu_dma_resolve_address(
+            first_addr + i * 4u));
+    }
+    if (!ws_prepass_packet_matches(&node->payload_guard, payload, num_words))
+        ws_ui_prepass_invalidate_stale();
 }
 
 /* Per-opcode execution counters (exposed via gpu_get_opcode_stats) */

--- a/runtime/src/gpu.c
+++ b/runtime/src/gpu.c
@@ -113,6 +113,7 @@ static uint16_t ws_ui_prepass_rank = 0xFFFFu;
 #define WS_UI_PREPASS_NODE_MAX 8192u
 typedef struct {
     uint32_t addr;
+    uint32_t header;
     WsPrepassPacketGuard payload_guard;
 } WsUiPrepassNode;
 static WsUiPrepassNode ws_ui_prepass_nodes[WS_UI_PREPASS_NODE_MAX];
@@ -4779,6 +4780,7 @@ void gpu_ws_prepass_linked_list(uint32_t start_addr) {
         WsUiPrepassNode *node =
             &ws_ui_prepass_nodes[ws_ui_prepass_node_count++];
         node->addr = addr & 0x1FFFFCu;
+        node->header = header;
         node->payload_guard =
             ws_prepass_packet_guard(payload, num_words);
         if (num_words == 0) {
@@ -4868,6 +4870,20 @@ void gpu_ws_prepass_linked_list(uint32_t start_addr) {
                        ws_auto_ui_dense);
     for (uint32_t i = 0; i < ws_ui_prepass_count; i++)
         ws_ui_prepass[i].group.anchor = group_origin + groups[i].anchor;
+}
+
+void gpu_ws_validate_linked_list_header(uint32_t addr, uint32_t header) {
+    if (ws_ui_prepass_count == 0) return;
+
+    uint32_t resolved =
+        psx_mod_gpu_dma_resolve_address(addr) & 0x1FFFFCu;
+    for (uint32_t i = 0; i < ws_ui_prepass_node_count; i++) {
+        if (ws_ui_prepass_nodes[i].addr != resolved) continue;
+        if (ws_ui_prepass_nodes[i].header != header)
+            ws_ui_prepass_invalidate_stale();
+        return;
+    }
+    ws_ui_prepass_invalidate_stale();
 }
 
 void gpu_ws_validate_linked_list_node(uint32_t addr, uint32_t num_words) {

--- a/runtime/src/main.cpp
+++ b/runtime/src/main.cpp
@@ -11242,12 +11242,6 @@ int main(int argc, char** argv) {
             game_id   = gc.id;
             game_region = gc.region;
             game_players = gc.players;
-            /* CTR ND intro: an older workaround (PSX_ND_SIB_FLAP_LAST=1) skipped
-             * wide additive 0x36 in OT ranks 1600..2099 to unmask sibling flaps.
-             * After the AVSZ3 MAC0 fix (unshifted product → correct MAC0>>17 OT
-             * indices), flaps/rain sort without that skip — and FLAP_LAST=1
-             * shreds the crate glow fountain. Default is off; opt in via env
-             * (dma.c) only for experiments. */
             apply_offline_pad_count(game_players, multitap_enabled);
             game_has_disc_crc = gc.has_disc_crc;
             game_disc_crc     = gc.disc_crc;

--- a/runtime/tests/test_dma_gpu_linked_list_timing.c
+++ b/runtime/tests/test_dma_gpu_linked_list_timing.c
@@ -72,9 +72,7 @@ int main(void) {
     emitted_count = completed = hit_limit = 0u;
 
     dma_gpu_ll_start(&state, 0x40u, 8u);
-    dma_gpu_ll_advance(&state, 8u, &ops, NULL);
-    CHECK(emitted_count == 0u);
-    dma_gpu_ll_advance(&state, 5u, &ops, NULL);
+    dma_gpu_ll_advance(&state, 1u, &ops, NULL);
     CHECK(emitted_count == 0u);
     CHECK(dma_gpu_ll_cycles_to_event(&state) == 1u);
     dma_gpu_ll_advance(&state, 1u, &ops, NULL);
@@ -96,38 +94,58 @@ int main(void) {
     ram[0x24 / 4] = 0x22222222u;
 
     dma_gpu_ll_start(&state, 0x00u, 8u);
-    CHECK(dma_gpu_ll_cycles_to_event(&state) == 8u);
-    dma_gpu_ll_advance(&state, 7u, &ops, NULL);
+    /* Each header and payload word costs one clock. Setup costs nothing. */
+    CHECK(dma_gpu_ll_cycles_to_event(&state) == 1u);
     CHECK(emitted_count == 0u);
 
-    /* Header becomes visible at cycle 8; payload waits for setup. */
+    /* Setup occurs with the header service. The payload keeps its own event. */
     dma_gpu_ll_advance(&state, 1u, &ops, NULL);
-    CHECK(emitted_count == 0u);
-    CHECK(dma_gpu_ll_cycles_to_event(&state) == 5u);
-    dma_gpu_ll_advance(&state, 5u, &ops, NULL);
     CHECK(emitted_count == 0u);
     CHECK(dma_gpu_ll_cycles_to_event(&state) == 1u);
     dma_gpu_ll_advance(&state, 1u, &ops, NULL);
     CHECK(emitted_count == 1u && emitted[0] == 0x11111111u);
 
-    /* This is the regression: the CPU changes the later packet after DMA has
-     * started. DMA must read the new value when it reaches that packet. */
+    /* This is what the sliced walker exists for, and the cost change must not
+     * weaken it: the CPU changes a later packet after DMA has started, and DMA
+     * must read the NEW value when it reaches that packet. */
     ram[0x24 / 4] = 0xA5A5A5A5u;
-    CHECK(dma_gpu_ll_cycles_to_event(&state) == 8u);
-    dma_gpu_ll_advance(&state, 8u, &ops, NULL);
+    CHECK(dma_gpu_ll_cycles_to_event(&state) == 1u);
+    dma_gpu_ll_advance(&state, 1u, &ops, NULL);
     CHECK(emitted_count == 1u);
-    dma_gpu_ll_advance(&state, 5u, &ops, NULL);
-    CHECK(emitted_count == 1u);
+    CHECK(completed == 0u);
     dma_gpu_ll_advance(&state, 1u, &ops, NULL);
     CHECK(emitted_count == 2u && emitted[1] == 0xA5A5A5A5u);
     CHECK(completed == 1u && hit_limit == 0u && !state.active);
 
+    /* An empty ordering table costs one header clock per node. */
+    {
+        const uint32_t NODES = 12u;
+        memset(ram, 0, sizeof(ram));
+        for (uint32_t i = 0; i < NODES - 1u; i++)
+            ram[i] = ((i + 1u) * 4u);              /* empty node -> next */
+        ram[NODES - 1u] = 0x00FFFFFFu;             /* empty terminator */
+
+        completed = hit_limit = emitted_count = 0u;
+        dma_gpu_ll_start(&state, 0x00u, 64u);
+        uint32_t spent = 0u;
+        while (state.active && spent < 1000u) {
+            uint32_t d = dma_gpu_ll_cycles_to_event(&state);
+            dma_gpu_ll_advance(&state, d, &ops, NULL);
+            spent += d;
+        }
+        CHECK(completed == 1u && hit_limit == 0u);
+        CHECK(state.nodes_processed == NODES);
+        CHECK(state.total_words == NODES);         /* header words only */
+        CHECK(spent == NODES);                     /* nodes + 0 payload words */
+    }
+
     /* A malformed cycle is bounded and reports the safety stop. */
+    memset(ram, 0, sizeof(ram));
     completed = hit_limit = 0u;
     ram[0x00 / 4] = 0x00000000u;
     dma_gpu_ll_start(&state, 0x00u, 1u);
-    dma_gpu_ll_advance(&state, 8u, &ops, NULL);
-    dma_gpu_ll_advance(&state, 8u, &ops, NULL);
+    dma_gpu_ll_advance(&state, 1u, &ops, NULL);
+    dma_gpu_ll_advance(&state, 1u, &ops, NULL);
     CHECK(completed == 1u && hit_limit == 1u && !state.active);
 
     puts("dma_gpu_linked_list_timing_test: PASS");

--- a/runtime/tests/test_dma_gpu_linked_list_timing.c
+++ b/runtime/tests/test_dma_gpu_linked_list_timing.c
@@ -40,7 +40,7 @@ static void complete(void *opaque, int limited) {
 }
 
 static const DMAGPULinkedListOps ops = {
-    resolve, read_word, begin_node, emit_word, complete
+    resolve, read_word, NULL, begin_node, emit_word, complete
 };
 
 #define CHECK(expr) do { \
@@ -61,6 +61,15 @@ int main(void) {
     ram[0x44 / 4] = 0x11111111u;
     ram[0x48 / 4] = 0x22222222u;
     ram[0x4C / 4] = 0x33333333u;
+
+    /* A late service call must consume every elapsed boundary. */
+    dma_gpu_ll_start(&state, 0x40u, 8u);
+    dma_gpu_ll_advance(&state, 16u, &ops, NULL);
+    CHECK(emitted_count == 3u);
+    CHECK(completed == 1u && hit_limit == 0u && !state.active);
+
+    memset(emitted, 0, sizeof(emitted));
+    emitted_count = completed = hit_limit = 0u;
 
     dma_gpu_ll_start(&state, 0x40u, 8u);
     dma_gpu_ll_advance(&state, 8u, &ops, NULL);

--- a/runtime/tests/test_dma_gpu_linked_list_timing.c
+++ b/runtime/tests/test_dma_gpu_linked_list_timing.c
@@ -54,6 +54,32 @@ int main(void) {
     DMAGPULinkedList state;
     memset(ram, 0, sizeof(ram));
 
+    /* A multi-word node must fetch one live RAM word at each DMA word
+     * boundary. In particular, a CPU rewrite after word 0 transfers must be
+     * visible when DMA reaches word 1. */
+    ram[0x40 / 4] = 0x03FFFFFFu;
+    ram[0x44 / 4] = 0x11111111u;
+    ram[0x48 / 4] = 0x22222222u;
+    ram[0x4C / 4] = 0x33333333u;
+
+    dma_gpu_ll_start(&state, 0x40u, 8u);
+    dma_gpu_ll_advance(&state, 8u, &ops, NULL);
+    CHECK(emitted_count == 0u);
+    dma_gpu_ll_advance(&state, 5u, &ops, NULL);
+    CHECK(emitted_count == 0u);
+    CHECK(dma_gpu_ll_cycles_to_event(&state) == 1u);
+    dma_gpu_ll_advance(&state, 1u, &ops, NULL);
+    CHECK(emitted_count == 1u && emitted[0] == 0x11111111u);
+    ram[0x48 / 4] = 0xA5A5A5A5u;
+    dma_gpu_ll_advance(&state, 1u, &ops, NULL);
+    CHECK(emitted_count == 2u && emitted[1] == 0xA5A5A5A5u);
+    dma_gpu_ll_advance(&state, 1u, &ops, NULL);
+    CHECK(emitted_count == 3u && emitted[2] == 0x33333333u);
+    CHECK(completed == 1u && hit_limit == 0u && !state.active);
+
+    memset(emitted, 0, sizeof(emitted));
+    emitted_count = completed = hit_limit = 0u;
+
     /* Node 0 at 0x00 points to node 1 at 0x20. Node 1 terminates. */
     ram[0x00 / 4] = 0x01000020u;
     ram[0x04 / 4] = 0x11111111u;
@@ -70,18 +96,21 @@ int main(void) {
     CHECK(emitted_count == 0u);
     CHECK(dma_gpu_ll_cycles_to_event(&state) == 5u);
     dma_gpu_ll_advance(&state, 5u, &ops, NULL);
+    CHECK(emitted_count == 0u);
+    CHECK(dma_gpu_ll_cycles_to_event(&state) == 1u);
+    dma_gpu_ll_advance(&state, 1u, &ops, NULL);
     CHECK(emitted_count == 1u && emitted[0] == 0x11111111u);
 
     /* This is the regression: the CPU changes the later packet after DMA has
      * started. DMA must read the new value when it reaches that packet. */
     ram[0x24 / 4] = 0xA5A5A5A5u;
-    CHECK(dma_gpu_ll_cycles_to_event(&state) == 9u);
-    dma_gpu_ll_advance(&state, 9u, &ops, NULL);
+    CHECK(dma_gpu_ll_cycles_to_event(&state) == 8u);
+    dma_gpu_ll_advance(&state, 8u, &ops, NULL);
     CHECK(emitted_count == 1u);
     dma_gpu_ll_advance(&state, 5u, &ops, NULL);
-    CHECK(emitted_count == 2u && emitted[1] == 0xA5A5A5A5u);
-    CHECK(completed == 0u);
+    CHECK(emitted_count == 1u);
     dma_gpu_ll_advance(&state, 1u, &ops, NULL);
+    CHECK(emitted_count == 2u && emitted[1] == 0xA5A5A5A5u);
     CHECK(completed == 1u && hit_limit == 0u && !state.active);
 
     /* A malformed cycle is bounded and reports the safety stop. */

--- a/runtime/tests/test_savestate_status_protocol.py
+++ b/runtime/tests/test_savestate_status_protocol.py
@@ -9,6 +9,15 @@ INTERRUPTS_H = (ROOT / "include/interrupts.h").read_text(encoding="utf-8")
 INTERRUPTS = (ROOT / "src/interrupts.c").read_text(encoding="utf-8")
 REWIND = (ROOT / "src/psx_rewind.c").read_text(encoding="utf-8")
 DIRTY = (ROOT / "src/dirty_ram_interp.c").read_text(encoding="utf-8")
+BOOT_STATE_H = (ROOT / "include/boot_state.h").read_text(encoding="utf-8")
+DMA = (ROOT / "src/dma.c").read_text(encoding="utf-8")
+
+# The per-word DMA2 cursor adds four bytes to the v5 DMA wire. Lock the format
+# change to v6 so an old file is rejected before any state section is applied.
+assert "#define DMA_GPU_LL_WIRE (4u + (10u * 4u))" in DMA
+assert "#define BOOT_STATE_VERSION 6u" in BOOT_STATE_H
+assert "#define BOOT_STATE_VERSION_MIN_READ 6u" in BOOT_STATE_H
+assert "Reject\n * them at the header before any section changes the live machine." in BOOT_STATE_H
 
 assert "void savestate_status_json(char* buf, size_t cap);" in HEADER
 assert '\\"generation\\"' in STATE and '\\"pending\\"' in STATE

--- a/runtime/tests/test_ws_prepass_guard.c
+++ b/runtime/tests/test_ws_prepass_guard.c
@@ -1,0 +1,25 @@
+#include "ws_prepass_guard.h"
+
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+
+int main(void) {
+    uint32_t packet[] = {
+        0x64010203u, 0x00100020u, 0x00040008u, 0x00100010u
+    };
+    WsPrepassPacketGuard guard = ws_prepass_packet_guard(packet, 4u);
+
+    assert(ws_prepass_packet_matches(&guard, packet, 4u));
+
+    /* A guest rewrite after the DMA kick must reject the cached geometry. */
+    packet[3] = 0x00200010u;
+    assert(!ws_prepass_packet_matches(&guard, packet, 4u));
+
+    /* A command-length change is stale even when the shared prefix matches. */
+    packet[3] = 0x00100010u;
+    assert(!ws_prepass_packet_matches(&guard, packet, 3u));
+
+    puts("ws_prepass_guard_test: PASS");
+    return 0;
+}


### PR DESCRIPTION
## Summary

Preserve guest-visible GPU DMA2 linked-list slicing while restoring the one-clock cost per transferred 32-bit word.

Each payload word is read from live RAM at its own guest-cycle event. Late service consumes every elapsed boundary. Widescreen prepass metadata is discarded when a live packet or link changes. The obsolete polygon-drop filter is removed.

This combines the reviewed correctness work from Alexbeav/psxrecomp#13 with the FF7-compatible transfer cost demonstrated by #299 and #302.

## Regression

#277 fixed Vampire Hunter D and Spot Goes to Hollywood by allowing a guest to change later ordering-table data while DMA remained active. Its separate 8-clock header and 5-clock setup charges also kept large Final Fantasy VII ordering tables busy long enough to reach the game's timeout path.

This change keeps the sliced reads but charges one clock for each header or payload word. It does not claim to implement complete physical-bus arbitration.

The DMA snapshot now stores the in-flight payload index. Boot-state version 6 rejects version-5 files at the header before any state section changes the live machine.

## Tests

- Runtime and oracle targets build with Clang 22.1.8.
- `dma_gpu_linked_list_timing_test` passes 20 consecutive runs.
- `ws_prepass_guard_test` passes 20 consecutive runs.
- `savestate_status_protocol_test` passes 20 consecutive runs.
- The runtime suite passes 61 of 62 enabled tests.
- The remaining `mod_runtime_test` crash reproduces on unchanged base `22fbbfca`.
- Two pre-existing tests remain disabled.
- `git diff --check` passes.

The earlier correctness head reached frame 616 in fresh Vampire Hunter D and Spot builds. User testing reported correct FF7 geometry after the lower-cost correction. New visible VHD and Spot runs on this exact combined head remain open.

## Review

Fork review: Alexbeav/psxrecomp#20

Cubic reviewed exact head `9dfb4174adea419c259b132eda512525cf9b8dea` and reported no issues across 13 files. Both earlier review threads are resolved.

Developed with AI assistance; validated as described (test evidence in PR body). AI writes the code and the PR, but I always test before I send something up. Happy to iterate on this process with your feedback.