### PR TITLE
mods: the framework stages the title's catalog too (5 titles could not package)

### DIFF
--- a/docs/GAME_PROJECT_SETUP.md
+++ b/docs/GAME_PROJECT_SETUP.md
@@ -267,8 +267,14 @@ YourGameRecomp/                 # your git repo
 │   ├── boxart.tga              # optional: --fetch-boxart (libretro Named_Boxarts)
 │   └── BOXART_SOURCE.txt       # attribution URL
 ├── mods/preloaded/             # scaffold: empty catalog for shipped .psxmod packages
-│   ├── README.md
+│   ├── README.md               # staged to <exe>/mods/README.md
 │   └── packages/               # packages/<id>/<version>/manifest.toml …
+│                               # declared to the framework as
+│                               #   PRELOADED_MODS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/mods/preloaded"
+│                               # which stages it into <exe>/mods/bundled beside
+│                               # the framework's builtins. NEVER copy it with
+│                               # your own POST_BUILD command — see
+│                               # docs/MOD_PACKAGES.md ("How bundled/ gets staged").
 ├── scripts/
 │   └── package_setup_release.sh   # scaffold fills from package_setup_release.sh.in
 ├── .github/workflows/

--- a/docs/MOD_PACKAGES.md
+++ b/docs/MOD_PACKAGES.md
@@ -47,6 +47,68 @@ could not be moved is left exactly where it is and reported.
 A manifest that fails to parse is never skipped silently: it is reported by
 `scan_errors()` and logged, naming the path and the reason.
 
+## How `bundled/` gets staged (titles: read this)
+
+**The framework owns the layout. A title declares a directory, never a path
+shape.** Hand the title's catalog to `psxrecomp_add_runtime_target()`:
+
+```cmake
+set(MYGAME_PRELOADED_MODS "${CMAKE_CURRENT_SOURCE_DIR}/mods/preloaded")
+
+psxrecomp_add_runtime_target(psx-runtime
+    ...
+    PRELOADED_MODS_DIR "${MYGAME_PRELOADED_MODS}"
+)
+```
+
+`PRELOADED_MODS_DIR` names a directory shaped like
+`<dir>/packages/<package-id>/<version>/manifest.toml`, optionally with a
+`README.md` beside `packages/`. On every build of that target the framework:
+
+1. wipes `<exe-dir>/mods/bundled` (build output only — never `installed/` or
+   `state.toml`),
+2. removes exactly the ids it is about to stage from any pre-existing
+   `mods/packages`, which migrates a build directory made before the split
+   while leaving a player's own legacy packages for `migrate_legacy_root()`,
+3. copies the framework's `mods/builtin/packages/<id>` then the title's
+   `<dir>/packages/<id>` into `mods/bundled/<id>` — in that order, so a title
+   may deliberately OVERRIDE a builtin at the same id and version (Tomba 2's
+   Italian runtime ships localized `psx.*` manifests exactly this way),
+4. copies `<dir>/README.md` to `mods/README.md`, and
+5. verifies the result with `runtime/psx_check_mod_catalog.cmake`.
+
+Pass `PRELOADED_MODS_DIR NONE` to declare that a target intentionally ships no
+game catalog. A target built with `COSIM` stages nothing: it has no launcher,
+and it shares an output directory with the real runtime.
+
+**Do NOT write your own `copy_directory` into `<exe-dir>/mods`.** Five titles
+did, and the reason it is now a build error is worth stating: a hand-written
+copy names the destination as a *string*, so when framework commit `4cc04be3`
+renamed the staged catalog from `mods/packages` to `mods/bundled`, all five
+kept staging into a directory nothing reads. Nothing failed to configure,
+compile or link — the coupling has no compile-time or link-time consumer — and
+the defect surfaced only when a release packager ran, in a different
+repository, on a later day. Two guards now close that window:
+
+* **configure time** — a project with packages under
+  `mods/preloaded/packages` that does not declare `PRELOADED_MODS_DIR` is a
+  `FATAL_ERROR`, naming the packages and the argument to add.
+* **build time** — `psx_check_mod_catalog.cmake` runs as the *last* `POST_BUILD`
+  step (registered through `cmake_language(DEFER)`, so it lands after anything
+  the title registered) and fails the build if a declared package did not reach
+  `mods/bundled`, or if any package this build stages turned up under
+  `mods/packages`. It is also registered as the ctest
+  `psx_staged_mod_catalog_test`.
+
+Both are exercised by `runtime/tests/test_mod_catalog_layout.py`.
+
+The release packagers assert the same invariant one layer out:
+`Add-ModCatalog` in `tools/release_overlay_stage.ps1` reads `mods/bundled` and
+refuses to package when a package the *sources* define is missing from it. It
+asserts that invariant rather than a hard-coded count, because a count
+describes only one side of a catalog two repositories contribute to and goes
+stale the moment either side gains a mod.
+
 ## Feature manifest
 
 Write new manifests at the current format version, which is **6**. Older

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -527,6 +527,14 @@ if(BUILD_TESTING)
         add_test(NAME bios_registry_zero_entry_guard_test
                  COMMAND ${Python3_EXECUTABLE}
                          ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_bios_registry_zero_entry.py)
+        # Exercises runtime/psx_check_mod_catalog.cmake -- the build-time guard
+        # that fails a build when a title's mod packages land in the legacy
+        # mods/packages layout instead of mods/bundled (bead beads-eio.3.101).
+        # Needs the cmake executable, since the guard is a cmake -P script.
+        add_test(NAME mod_catalog_layout_test
+                 COMMAND ${Python3_EXECUTABLE}
+                         ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_mod_catalog_layout.py
+                         --cmake ${CMAKE_COMMAND})
     endif()
 
     # Full card protocol regression: read, write, address echo, per-slot state,

--- a/runtime/psx_check_mod_catalog.cmake
+++ b/runtime/psx_check_mod_catalog.cmake
@@ -1,0 +1,317 @@
+# Build-time guard over the staged mod catalog (mods/bundled).
+#
+# WHY THIS FILE EXISTS
+# --------------------
+# 4cc04be3 renamed the staged catalog directory from mods/packages to
+# mods/bundled so that a rebuild could wipe build output without deleting the
+# player's own installed mods. The framework's staging followed the rename and
+# the shared release module (tools/release_overlay_stage.ps1, Add-ModCatalog)
+# followed it. NO TITLE CMakeLists followed it, because the coupling between
+# them is a `cmake -E copy_directory` DESTINATION STRING -- not a symbol, not a
+# header, not a link dependency. Nothing breaks at configure time, nothing
+# breaks at compile time, nothing breaks at link time. The five affected titles
+# kept copying their own packages into mods/packages, where the launcher and
+# the packager no longer look, and the failure surfaced only when a release
+# packager ran, in a different repository, on a later day.
+#
+# The framework now stages both catalogs itself (see PRELOADED_MODS_DIR in
+# psxrecomp_add_runtime_target), so a title never names the layout. This script
+# is the tripwire that makes the remaining failure mode loud instead of silent:
+#
+#   * a title that still hand-rolls its own copy re-creates mods/packages, and
+#   * a title whose declared packages did not reach mods/bundled at all
+#
+# both fail the BUILD, naming the ids and the fix, rather than producing a
+# quietly incomplete Mods page that only a packager notices.
+#
+# USAGE
+# -----
+#   cmake -DPSX_MODS_DIR=<build>/mods
+#         -DPSX_CATALOG_MANIFEST=<file>            # ids this target must stage
+#        [-DPSX_CATALOG_ALT_MANIFESTS=<f>|<f>]     # sibling targets' id sets
+#        [-DPSX_REQUIRE_STAGED=1]                  # mods/ MUST already exist
+#        [-DPSX_LABEL=psx-runtime]
+#         -P <framework>/runtime/psx_check_mod_catalog.cmake
+#
+# A manifest is one package id per line; blank lines and #-comments ignored.
+# PSX_CATALOG_ALT_MANIFESTS is "|"-separated rather than ";"-separated on
+# purpose: a ";" inside an add_custom_command argument is a cmake list
+# separator and would silently split the -D into two arguments.
+#
+# PSX_REQUIRE_STAGED distinguishes the two callers. The POST_BUILD invocation
+# runs immediately after staging, so "nothing is staged" is itself a defect and
+# passes 1. The registered ctest may run in a tree where the runtime target was
+# never built, so it passes 0 and reports a skip instead of a spurious failure.
+#
+# PSX_CATALOG_ALT_MANIFESTS exists for titles with two runtime targets that
+# share one output directory (Tomba 2: the US psx-runtime and the Italian
+# psx-runtime-ita both land in the build root and therefore share one mods/).
+# Each target's POST_BUILD stages its OWN complete catalog, so after a full
+# build the directory holds whichever target linked last. That is correct for
+# the packager -- it builds exactly one target per variant -- but it means a
+# ctest running after the whole build must accept any one target's catalog
+# rather than demand a particular one.
+
+cmake_minimum_required(VERSION 3.20)
+
+if(NOT DEFINED PSX_MODS_DIR OR PSX_MODS_DIR STREQUAL "")
+    message(FATAL_ERROR "psx_check_mod_catalog: PSX_MODS_DIR is required")
+endif()
+if(NOT DEFINED PSX_LABEL OR PSX_LABEL STREQUAL "")
+    set(PSX_LABEL "runtime")
+endif()
+if(NOT DEFINED PSX_REQUIRE_STAGED)
+    set(PSX_REQUIRE_STAGED 0)
+endif()
+
+# ---- helpers ---------------------------------------------------------------
+
+function(_psx_read_manifest path out_var)
+    set(_ids "")
+    if(EXISTS "${path}")
+        file(STRINGS "${path}" _lines)
+        foreach(_line IN LISTS _lines)
+            string(STRIP "${_line}" _line)
+            if(_line STREQUAL "" OR _line MATCHES "^#")
+                continue()
+            endif()
+            list(APPEND _ids "${_line}")
+        endforeach()
+    endif()
+    list(REMOVE_DUPLICATES _ids)
+    set(${out_var} "${_ids}" PARENT_SCOPE)
+endfunction()
+
+# Immediate subdirectory names of `root`, sorted. Empty when root is absent.
+function(_psx_child_dirs root out_var)
+    set(_names "")
+    if(IS_DIRECTORY "${root}")
+        file(GLOB _entries LIST_DIRECTORIES true "${root}/*")
+        foreach(_e IN LISTS _entries)
+            if(IS_DIRECTORY "${_e}")
+                get_filename_component(_n "${_e}" NAME)
+                list(APPEND _names "${_n}")
+            endif()
+        endforeach()
+    endif()
+    list(SORT _names)
+    set(${out_var} "${_names}" PARENT_SCOPE)
+endfunction()
+
+# TRUE when <root>/<id> holds at least one <version>/manifest.toml.
+function(_psx_id_has_manifest root id out_var)
+    set(_ok FALSE)
+    _psx_child_dirs("${root}/${id}" _versions)
+    foreach(_v IN LISTS _versions)
+        if(EXISTS "${root}/${id}/${_v}/manifest.toml")
+            set(_ok TRUE)
+            break()
+        endif()
+    endforeach()
+    set(${out_var} "${_ok}" PARENT_SCOPE)
+endfunction()
+
+# ---- inputs ----------------------------------------------------------------
+
+_psx_read_manifest("${PSX_CATALOG_MANIFEST}" _expected)
+list(SORT _expected)
+
+set(_alt_sets "")
+set(_all_known "${_expected}")
+if(DEFINED PSX_CATALOG_ALT_MANIFESTS AND NOT PSX_CATALOG_ALT_MANIFESTS STREQUAL "")
+    string(REPLACE "|" ";" _alt_manifest_list "${PSX_CATALOG_ALT_MANIFESTS}")
+    foreach(_alt IN LISTS _alt_manifest_list)
+        if(_alt STREQUAL "")
+            continue()
+        endif()
+        _psx_read_manifest("${_alt}" _alt_ids)
+        list(SORT _alt_ids)
+        if(_alt_ids)
+            # Encoded as one "|"-joined string per set: a cmake list cannot
+            # nest, and these ids never contain "|".
+            list(JOIN _alt_ids "|" _alt_joined)
+            list(APPEND _alt_sets "${_alt_joined}")
+            list(APPEND _all_known ${_alt_ids})
+        endif()
+    endforeach()
+endif()
+list(REMOVE_DUPLICATES _all_known)
+
+set(_bundled "${PSX_MODS_DIR}/bundled")
+set(_legacy  "${PSX_MODS_DIR}/packages")
+
+# ---- 1. nothing staged at all ----------------------------------------------
+
+if(NOT IS_DIRECTORY "${PSX_MODS_DIR}")
+    if(PSX_REQUIRE_STAGED)
+        message(FATAL_ERROR
+            "[${PSX_LABEL}] no mod catalog was staged: ${PSX_MODS_DIR} does not "
+            "exist. psxrecomp_add_runtime_target() stages the framework's "
+            "mods/builtin/packages plus the title's PRELOADED_MODS_DIR into "
+            "mods/bundled on every build, so an absent directory means that "
+            "POST_BUILD step did not run.")
+    endif()
+    message(STATUS
+        "[${PSX_LABEL}] mod-catalog check skipped: ${PSX_MODS_DIR} does not "
+        "exist (the runtime target has not been built in this tree)")
+    return()
+endif()
+
+# ---- 2. the legacy mods/packages tripwire ----------------------------------
+#
+# Anything the CURRENT build staged lives in mods/bundled. The staging step
+# additionally removes exactly the ids it stages from any pre-existing
+# mods/packages, so a stale build directory from before the split is migrated
+# silently and is NOT reported here. An id reappearing under mods/packages
+# after that therefore means something in THIS build wrote it there -- i.e. a
+# title CMakeLists still carries its own `copy_directory ... /mods` block.
+#
+# Ids that are NOT part of this build are left alone and merely noted: on a
+# self-compiling setup release mods/packages can legitimately hold packages the
+# player installed under the pre-split layout, and the runtime's
+# migrate_legacy_root() (runtime/src/mod_packages.cpp) relocates those into
+# mods/installed on the next launch. Deleting them here, or failing the build
+# over them, would both be wrong.
+
+set(_strays "")
+set(_foreign "")
+_psx_child_dirs("${_legacy}" _legacy_ids)
+foreach(_id IN LISTS _legacy_ids)
+    if("${_id}" IN_LIST _all_known)
+        list(APPEND _strays "${_id}")
+    else()
+        list(APPEND _foreign "${_id}")
+    endif()
+endforeach()
+
+if(_strays)
+    list(JOIN _strays "\n    " _pretty)
+    message(FATAL_ERROR
+        "[${PSX_LABEL}] package(s) were staged into the LEGACY mods/packages "
+        "layout:\n    ${_pretty}\n"
+        "  at ${_legacy}\n\n"
+        "mods/packages is no longer read by the launcher or by the release "
+        "packager (tools/release_overlay_stage.ps1's Add-ModCatalog reads "
+        "mods/bundled and throws when a source-defined package is missing "
+        "from it). A package landing there does not appear on the Mods page "
+        "and does not ship.\n\n"
+        "This means a CMakeLists still stages its own catalog by hand. The fix "
+        "is to delete that add_custom_command and declare the directory "
+        "instead, so the framework owns the layout:\n\n"
+        "    psxrecomp_add_runtime_target(psx-runtime\n"
+        "        ...\n"
+        "        PRELOADED_MODS_DIR \"\${CMAKE_CURRENT_SOURCE_DIR}/mods/preloaded\"\n"
+        "    )\n\n"
+        "See docs/MOD_PACKAGES.md and bead beads-eio.3.101.")
+endif()
+
+if(_foreign)
+    list(JOIN _foreign ", " _pretty_foreign)
+    message(STATUS
+        "[${PSX_LABEL}] note: ${_legacy} holds package(s) this build does not "
+        "stage (${_pretty_foreign}). Those are pre-split player-installed "
+        "packages; the runtime migrates them into mods/installed on next "
+        "launch. Left untouched.")
+endif()
+
+# ---- 3. mods/bundled must exist once anything is staged --------------------
+
+if(NOT IS_DIRECTORY "${_bundled}")
+    if(PSX_REQUIRE_STAGED)
+        message(FATAL_ERROR
+            "[${PSX_LABEL}] ${_bundled} does not exist after staging. The "
+            "framework's POST_BUILD mod-catalog step did not run or failed.")
+    endif()
+    message(STATUS
+        "[${PSX_LABEL}] mod-catalog check skipped: ${_bundled} does not exist "
+        "(the runtime target has not been built in this tree)")
+    return()
+endif()
+
+_psx_child_dirs("${_bundled}" _staged)
+
+# ---- 4. every declared id must have reached mods/bundled -------------------
+
+set(_missing "")
+set(_manifestless "")
+foreach(_id IN LISTS _expected)
+    if(NOT "${_id}" IN_LIST _staged)
+        list(APPEND _missing "${_id}")
+    else()
+        _psx_id_has_manifest("${_bundled}" "${_id}" _has)
+        if(NOT _has)
+            list(APPEND _manifestless "${_id}")
+        endif()
+    endif()
+endforeach()
+
+if(_missing)
+    # A sibling runtime target sharing this output directory may have staged
+    # its own catalog last. Accept an exact match against any sibling set.
+    list(JOIN _staged "|" _staged_joined)
+    foreach(_set IN LISTS _alt_sets)
+        if(_staged_joined STREQUAL "${_set}")
+            string(REPLACE "|" ", " _pretty_set "${_set}")
+            message(STATUS
+                "[${PSX_LABEL}] mod-catalog check deferred: ${_bundled} "
+                "currently holds a sibling runtime target's catalog "
+                "(${_pretty_set}). Two runtime targets share one output "
+                "directory here, so the last one built owns mods/bundled; each "
+                "one's own POST_BUILD guard already verified it at stage time.")
+            return()
+        endif()
+    endforeach()
+
+    list(JOIN _missing "\n    " _pretty)
+    message(FATAL_ERROR
+        "[${PSX_LABEL}] declared mod package(s) never reached the staged "
+        "catalog:\n    ${_pretty}\n"
+        "  expected at ${_bundled}/<id>/<version>/manifest.toml\n\n"
+        "The release packager asserts the same invariant and would refuse to "
+        "package (Add-ModCatalog: \"Mod catalog is missing package(s) the "
+        "sources define\"), so this is the same defect caught one repository "
+        "and several days earlier.")
+endif()
+
+if(_manifestless)
+    list(JOIN _manifestless "\n    " _pretty)
+    message(FATAL_ERROR
+        "[${PSX_LABEL}] staged package(s) have no <version>/manifest.toml:\n"
+        "    ${_pretty}\n  under ${_bundled}\n\n"
+        "A package directory without a manifest is not loadable; the launcher "
+        "will silently ignore it.")
+endif()
+
+# Extra ids are reported but not fatal: mods/bundled is wiped and re-staged on
+# every build, so an unexpected id is either a sibling target's package or
+# something staged by a mechanism the framework does not know about. Worth
+# seeing, not worth failing a build over.
+set(_extra "")
+foreach(_id IN LISTS _staged)
+    if(NOT "${_id}" IN_LIST _expected)
+        list(APPEND _extra "${_id}")
+    endif()
+endforeach()
+if(_extra)
+    list(JOIN _extra ", " _pretty)
+    message(STATUS
+        "[${PSX_LABEL}] note: staged catalog also holds ${_pretty} (not "
+        "declared by this target)")
+endif()
+
+set(_fw "")
+set(_game "")
+foreach(_id IN LISTS _staged)
+    if(_id MATCHES "^psx\\.")
+        list(APPEND _fw "${_id}")
+    else()
+        list(APPEND _game "${_id}")
+    endif()
+endforeach()
+list(LENGTH _staged _n_all)
+list(LENGTH _game _n_game)
+list(LENGTH _fw _n_fw)
+message(STATUS
+    "[${PSX_LABEL}] staged mod catalog OK: ${_n_all} package(s) = ${_n_game} "
+    "game-owned + ${_n_fw} framework-owned, all under mods/bundled, no "
+    "mods/packages")

--- a/runtime/runtime.cmake
+++ b/runtime/runtime.cmake
@@ -836,6 +836,339 @@ function(psxrecomp_ensure_zlib)
         "(expected zlibstatic or zlib).")
 endfunction()
 
+# ---------------------------------------------------------------------------
+# Mod catalog staging -- THE FRAMEWORK OWNS THE LAYOUT
+# ---------------------------------------------------------------------------
+# docs/MOD_PACKAGES.md defines <exe-dir>/mods/bundled as "build output -- the
+# framework's mods/builtin/packages plus the title's mods/preloaded/packages".
+# Until now only the first half of that sentence was implemented here, and the
+# second half was implemented five times, once per title, as a hand-written
+#
+#     add_custom_command(TARGET psx-runtime POST_BUILD
+#         COMMAND ${CMAKE_COMMAND} -E copy_directory
+#             "${<TITLE>_PRELOADED_MODS}" "$<TARGET_FILE_DIR:psx-runtime>/mods")
+#
+# in ApeEscapeRecomp, Tomba2Recomp, MegaManX4/5/6Recomp. Because those blocks
+# name the destination as a STRING, framework commit 4cc04be3 -- which renamed
+# the staged directory from mods/packages to mods/bundled so a rebuild could
+# stop deleting the player's installed mods -- broke all five without breaking
+# anything a compiler, linker or configure step can see. The titles kept
+# writing mods/packages; the launcher and the release packager had moved to
+# mods/bundled. Discovery was deferred to whichever title next ran a release
+# packager (bead beads-eio.3.101).
+#
+# So the layout string now appears in exactly one place. A title declares WHERE
+# its packages live (PRELOADED_MODS_DIR) and never HOW they are laid out, and a
+# future rename touches this file only.
+#
+# Two guards keep it that way:
+#   * configure time -- a title that has mods/preloaded/packages in its source
+#     tree but did not declare it is a hard configure error, because that is
+#     exactly the missed-title state, and it is detectable before any build.
+#   * build time -- runtime/psx_check_mod_catalog.cmake runs as the LAST
+#     POST_BUILD step (registered via cmake_language(DEFER), so it lands after
+#     anything the title itself registered) and fails the build if a declared
+#     package did not reach mods/bundled, or if any package this build stages
+#     turned up in the legacy mods/packages instead.
+
+# Immediate subdirectory names of `root` (package ids), sorted.
+function(_psxrt_package_ids root out_var)
+    set(_ids "")
+    file(GLOB _entries CONFIGURE_DEPENDS LIST_DIRECTORIES true "${root}/*")
+    foreach(_e IN LISTS _entries)
+        if(IS_DIRECTORY "${_e}")
+            get_filename_component(_n "${_e}" NAME)
+            list(APPEND _ids "${_n}")
+        endif()
+    endforeach()
+    list(SORT _ids)
+    set(${out_var} "${_ids}" PARENT_SCOPE)
+endfunction()
+
+# Write `content` to `path` only when it differs, so re-configuring does not
+# churn the mtime of a file the build depends on.
+function(_psxrt_write_if_changed path content)
+    set(_prev "")
+    if(EXISTS "${path}")
+        file(READ "${path}" _prev)
+    endif()
+    if(NOT _prev STREQUAL "${content}")
+        file(WRITE "${path}" "${content}")
+    endif()
+endfunction()
+
+# Registered via cmake_language(DEFER) so it runs at the END of the directory
+# that created the runtime targets. POST_BUILD commands execute in registration
+# order, so deferring is what puts this check AFTER any add_custom_command a
+# title registered after its psxrecomp_add_runtime_target() call -- including
+# the stray legacy copy this check exists to catch.
+#
+# Takes NO arguments and reads the pending targets out of global properties:
+# cmake_language(DEFER CALL <fn> <arg>) does not carry a function-local
+# variable through (measured with cmake 4.2.2 -- the callee receives an empty
+# argument, and an add_custom_command built from it fails at directory end
+# with "CMakeLists.txt:DEFERRED"), so nothing may be passed positionally here.
+function(_psxrt_finalize_mod_catalog_guards)
+    get_property(_targets   GLOBAL PROPERTY PSXRECOMP_MOD_CATALOG_TARGETS)
+    get_property(_manifests GLOBAL PROPERTY PSXRECOMP_MOD_CATALOG_MANIFESTS)
+    get_property(_dirs      GLOBAL PROPERTY PSXRECOMP_MOD_CATALOG_DIRS)
+    list(LENGTH _targets _n)
+    if(_n EQUAL 0)
+        return()
+    endif()
+    math(EXPR _last "${_n} - 1")
+
+    # add_custom_command(TARGET) only accepts a target created in the current
+    # directory, and a deferred call runs in the directory that scheduled it,
+    # so a project with runtime targets in several directories gets one
+    # deferred pass per directory and each pass handles only its own.
+    set(_here_targets "")
+    set(_here_manifests "")
+    foreach(_i RANGE 0 ${_last})
+        list(GET _dirs ${_i} _d)
+        if(_d STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
+            list(GET _targets ${_i} _t)
+            list(GET _manifests ${_i} _m)
+            list(APPEND _here_targets "${_t}")
+            list(APPEND _here_manifests "${_m}")
+        endif()
+    endforeach()
+    list(LENGTH _here_targets _n_here)
+    if(_n_here EQUAL 0)
+        return()
+    endif()
+    math(EXPR _last_here "${_n_here} - 1")
+
+    foreach(_i RANGE 0 ${_last_here})
+        list(GET _here_targets ${_i} _t)
+        list(GET _here_manifests ${_i} _own)
+
+        # Sibling runtime targets in this directory. Two of them can share one
+        # output directory (Tomba 2's US and Italian runtimes both land in the
+        # build root), in which case mods/bundled holds whichever linked last.
+        set(_alts "")
+        foreach(_j RANGE 0 ${_last_here})
+            if(NOT _j EQUAL _i)
+                list(GET _here_manifests ${_j} _m)
+                list(APPEND _alts "${_m}")
+            endif()
+        endforeach()
+        # "|" not ";": a semicolon inside an add_custom_command argument is a
+        # cmake list separator and would split the -D into two arguments.
+        list(JOIN _alts "|" _alts_joined)
+
+        add_custom_command(TARGET ${_t} POST_BUILD
+            COMMAND ${CMAKE_COMMAND}
+                "-DPSX_MODS_DIR=$<TARGET_FILE_DIR:${_t}>/mods"
+                "-DPSX_CATALOG_MANIFEST=${_own}"
+                "-DPSX_CATALOG_ALT_MANIFESTS=${_alts_joined}"
+                "-DPSX_REQUIRE_STAGED=1"
+                "-DPSX_LABEL=${_t}"
+                -P "${PSXRECOMP_ROOT}/runtime/psx_check_mod_catalog.cmake"
+            COMMENT "Verifying staged mod catalog for ${_t}"
+            VERBATIM)
+    endforeach()
+
+    # One ctest, registered against the first staging target's output
+    # directory. REQUIRE_STAGED is 0 here: `ctest` may run in a tree where the
+    # runtime was never built, and a skip is more useful there than a spurious
+    # failure. The POST_BUILD invocations above pass 1, since they run
+    # immediately after staging where an absent catalog IS the defect.
+    get_property(_test_done GLOBAL PROPERTY PSXRECOMP_MOD_CATALOG_TEST_ADDED)
+    if(BUILD_TESTING AND NOT _test_done)
+        set_property(GLOBAL PROPERTY PSXRECOMP_MOD_CATALOG_TEST_ADDED TRUE)
+        list(GET _here_targets 0 _first)
+        list(GET _here_manifests 0 _first_manifest)
+        set(_first_alts "")
+        foreach(_j RANGE 0 ${_last_here})
+            if(NOT _j EQUAL 0)
+                list(GET _here_manifests ${_j} _m)
+                list(APPEND _first_alts "${_m}")
+            endif()
+        endforeach()
+        list(JOIN _first_alts "|" _first_alts_joined)
+        add_test(NAME psx_staged_mod_catalog_test
+            COMMAND ${CMAKE_COMMAND}
+                "-DPSX_MODS_DIR=$<TARGET_FILE_DIR:${_first}>/mods"
+                "-DPSX_CATALOG_MANIFEST=${_first_manifest}"
+                "-DPSX_CATALOG_ALT_MANIFESTS=${_first_alts_joined}"
+                "-DPSX_REQUIRE_STAGED=0"
+                "-DPSX_LABEL=${_first}"
+                -P "${PSXRECOMP_ROOT}/runtime/psx_check_mod_catalog.cmake")
+    endif()
+endfunction()
+
+# Stage the framework's builtin packages and the title's own packages into
+# <exe-dir>/mods/bundled, and register the guards described above.
+function(_psxrt_stage_mod_catalog target preloaded_dir)
+    set(_out "$<TARGET_FILE_DIR:${target}>")
+    set(_ids "")
+    set(_copy "")
+
+    # ---- framework-owned builtins (psx.*) ---------------------------------
+    # These target game_id "*" -- emulated-hardware features rather than
+    # per-disc content -- so every game gets them without carrying a copy of
+    # the manifests.
+    set(_builtin_root "${PSXRECOMP_ROOT}/mods/builtin/packages")
+    if(EXISTS "${_builtin_root}")
+        if(DEFINED PSX_BUILTIN_MOD_ALLOWLIST AND NOT
+           "${PSX_BUILTIN_MOD_ALLOWLIST}" STREQUAL "")
+            set(_builtin_ids ${PSX_BUILTIN_MOD_ALLOWLIST})
+            foreach(_id IN LISTS _builtin_ids)
+                if(NOT EXISTS "${_builtin_root}/${_id}")
+                    message(FATAL_ERROR
+                        "PSX_BUILTIN_MOD_ALLOWLIST names missing package: ${_id}")
+                endif()
+            endforeach()
+        else()
+            _psxrt_package_ids("${_builtin_root}" _builtin_ids)
+        endif()
+        foreach(_id IN LISTS _builtin_ids)
+            list(APPEND _ids "${_id}")
+            list(APPEND _copy
+                COMMAND ${CMAKE_COMMAND} -E copy_directory
+                    "${_builtin_root}/${_id}"
+                    "${_out}/mods/bundled/${_id}")
+        endforeach()
+    endif()
+
+    # ---- title-owned packages ---------------------------------------------
+    set(_readme_copy "")
+    if(preloaded_dir STREQUAL "")
+        # The missed-title tripwire. A title whose source tree carries a mod
+        # catalog but does not declare it used to stage it itself into the
+        # wrong directory and find out at release time; now it cannot configure.
+        #
+        # Requires at least one package: the project scaffold creates an EMPTY
+        # mods/preloaded/packages (with a .gitkeep), and a title that has not
+        # written a mod yet must still configure.
+        set(_undeclared_ids "")
+        if(IS_DIRECTORY "${CMAKE_SOURCE_DIR}/mods/preloaded/packages")
+            _psxrt_package_ids(
+                "${CMAKE_SOURCE_DIR}/mods/preloaded/packages" _undeclared_ids)
+        endif()
+        if(_undeclared_ids)
+            list(JOIN _undeclared_ids "\n    " _undeclared_pretty)
+            message(FATAL_ERROR
+                "This project has a mod catalog at "
+                "${CMAKE_SOURCE_DIR}/mods/preloaded/packages:\n"
+                "    ${_undeclared_pretty}\n"
+                "but target '${target}' did not declare it, so those packages "
+                "would not be staged into <exe-dir>/mods/bundled and would not "
+                "appear on the Mods page or in a release.\n\n"
+                "Add it to the psxrecomp_add_runtime_target() call:\n\n"
+                "    psxrecomp_add_runtime_target(${target}\n"
+                "        ...\n"
+                "        PRELOADED_MODS_DIR \"\${CMAKE_CURRENT_SOURCE_DIR}/mods/preloaded\"\n"
+                "    )\n\n"
+                "and DELETE any add_custom_command(TARGET ${target} POST_BUILD "
+                "... copy_directory ... /mods) block: the framework now stages "
+                "both its own mods/builtin/packages and the title's packages, "
+                "so the layout lives in one place instead of six repositories. "
+                "Pass PRELOADED_MODS_DIR NONE if this target genuinely ships "
+                "no game catalog.\n\n"
+                "See docs/MOD_PACKAGES.md and bead beads-eio.3.101.")
+        endif()
+    elseif(NOT preloaded_dir STREQUAL "NONE")
+        if(NOT IS_DIRECTORY "${preloaded_dir}")
+            message(FATAL_ERROR
+                "PRELOADED_MODS_DIR for target '${target}' is not a directory: "
+                "${preloaded_dir}")
+        endif()
+        # An empty (or not-yet-created) packages/ subdirectory is the project
+        # scaffold's initial state and must still configure -- only a bad path
+        # is an error, because a wrong path is exactly how a title ends up
+        # shipping an empty Mods page.
+        set(_game_ids "")
+        if(IS_DIRECTORY "${preloaded_dir}/packages")
+            _psxrt_package_ids("${preloaded_dir}/packages" _game_ids)
+        endif()
+        if(NOT _game_ids)
+            message(STATUS
+                "psxrecomp: ${target} declares an empty mod catalog at "
+                "${preloaded_dir}/packages; staging framework packages only")
+        endif()
+        foreach(_id IN LISTS _game_ids)
+            list(APPEND _ids "${_id}")
+            list(APPEND _copy
+                COMMAND ${CMAKE_COMMAND} -E copy_directory
+                    "${preloaded_dir}/packages/${_id}"
+                    "${_out}/mods/bundled/${_id}")
+        endforeach()
+        # mods/README.md used to arrive only as a side effect of copying the
+        # whole mods/preloaded tree into mods/. Now that only packages/ is
+        # staged, it has to be copied on purpose or it silently disappears.
+        if(EXISTS "${preloaded_dir}/README.md")
+            set(_readme_copy
+                COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                    "${preloaded_dir}/README.md"
+                    "${_out}/mods/README.md")
+        endif()
+    endif()
+
+    # The COPY commands above may legitimately name an id twice -- a title's
+    # catalog is allowed to OVERRIDE a framework builtin at the same id and
+    # version, and Tomba 2's Italian catalog does exactly that with localized
+    # psx.* manifests. Order carries that: the framework's copy runs first and
+    # the title's overwrites it. The id LIST, though, is an identity set used
+    # for the legacy purge, the staged-catalog assertion and the reported
+    # count, so it must be deduplicated or the build claims to stage 11
+    # packages when the catalog holds 7.
+    list(REMOVE_DUPLICATES _ids)
+    if(NOT _ids)
+        return()
+    endif()
+
+    # Removing the ids THIS build stages from any pre-existing mods/packages
+    # migrates a build directory made before the bundled/ split, so the
+    # build-time guard's "an id turned up in mods/packages" report can only
+    # mean a stray copy made by this build. Ids the build does not stage are
+    # deliberately left alone: on a self-compiling setup release they can be
+    # packages the player installed under the old layout, and the runtime's
+    # migrate_legacy_root() relocates those into mods/installed on next launch.
+    set(_purge "")
+    foreach(_id IN LISTS _ids)
+        list(APPEND _purge "${_out}/mods/packages/${_id}")
+    endforeach()
+
+    list(LENGTH _ids _n_ids)
+    add_custom_command(TARGET ${target} POST_BUILD
+        # Wipe first: copy_directory MERGES, so a package deleted from source
+        # would otherwise survive in the build output forever and keep
+        # appearing on the Mods page (and inflate release catalog assertions).
+        #
+        # Scoped to mods/bundled, which is build output and nothing else.
+        # mods/installed/ is the launcher's (player-installed .psxmod archives)
+        # and mods/state.toml is user selection state; a build must never touch
+        # either. Before the split this wipe was scoped to mods/packages, which
+        # ALSO held everything the player had installed -- so a rebuild,
+        # including the one a self-compiling setup release runs on the player's
+        # own machine, deleted their mods without a word.
+        COMMAND ${CMAKE_COMMAND} -E rm -rf "${_out}/mods/bundled"
+        COMMAND ${CMAKE_COMMAND} -E rm -rf ${_purge}
+        ${_copy}
+        ${_readme_copy}
+        COMMENT "Staging mod catalog for ${target} (${_n_ids} package(s) -> mods/bundled)"
+        VERBATIM)
+
+    # The id list the build-time guard and the ctest assert against.
+    set(_manifest "${CMAKE_CURRENT_BINARY_DIR}/psx_mod_catalog_${target}.txt")
+    list(SORT _ids)
+    string(JOIN "\n" _manifest_text ${_ids})
+    _psxrt_write_if_changed("${_manifest}" "${_manifest_text}\n")
+
+    set_property(GLOBAL APPEND PROPERTY PSXRECOMP_MOD_CATALOG_TARGETS "${target}")
+    set_property(GLOBAL APPEND PROPERTY PSXRECOMP_MOD_CATALOG_MANIFESTS "${_manifest}")
+    set_property(GLOBAL APPEND PROPERTY PSXRECOMP_MOD_CATALOG_DIRS
+        "${CMAKE_CURRENT_SOURCE_DIR}")
+    # Schedule the guard pass once per directory, not once per target.
+    get_property(_scheduled DIRECTORY PROPERTY PSXRECOMP_MOD_CATALOG_DEFERRED)
+    if(NOT _scheduled)
+        set_property(DIRECTORY PROPERTY PSXRECOMP_MOD_CATALOG_DEFERRED TRUE)
+        cmake_language(DEFER CALL _psxrt_finalize_mod_catalog_guards)
+    endif()
+endfunction()
+
 function(psxrecomp_add_runtime_target target)
     # PGXP: build this target's objects with -DPSX_PGXP=1 so the PGXP_*()
     # hook macros the emitter writes into ALL generated C become real calls
@@ -863,6 +1196,14 @@ function(psxrecomp_add_runtime_target target)
         GAME_VERSION
         MAX_PLAYERS
         APP_ICON
+        # The title's own mod catalog source directory -- the one shaped like
+        # <repo>/mods/preloaded, holding packages/<id>/<version>/manifest.toml
+        # and an optional README.md. The FRAMEWORK stages it, together with its
+        # own mods/builtin/packages, into <exe-dir>/mods/bundled. Titles must
+        # not stage it themselves; see _psxrt_stage_mod_catalog below for why
+        # that is now a build error rather than a convention. Pass the literal
+        # NONE to declare, explicitly, that this target ships no game catalog.
+        PRELOADED_MODS_DIR
     )
     # GAME_GENERATED_FULL_C is a list (not a single value): the split-TU build
     # writes the recompiled game as N full_NN.c shards instead of one
@@ -1368,49 +1709,14 @@ function(psxrecomp_add_runtime_target target)
                 "${PSXRECOMP_BUNDLED_BIOS_LICENSE}")
         endif()
 
-    # Framework-owned mod catalog (loading speed). These target game_id "*" and
-    # are emulator features rather than per-disc content, so every game gets
-    # them without carrying a copy of the manifests. Staged BEFORE the game's
-    # own POST_BUILD copy so a title may still override an id if it ever needs
-    # to; copy_directory merges rather than replacing the tree.
-    if(EXISTS "${PSXRECOMP_ROOT}/mods/builtin/packages")
-        # Clear first: copy_directory MERGES, so a mod deleted from source
-        # would otherwise survive in the build output forever and keep
-        # appearing on the Mods page (and inflate release catalog assertions).
-        #
-        # Scoped to mods/bundled, which is build output and nothing else.
-        # mods/installed/ is the launcher's (player-installed .psxmod archives)
-        # and mods/state.toml is user selection state; a build must never touch
-        # either. Before that split this wipe was scoped to mods/packages,
-        # which ALSO held everything the player had installed -- so a rebuild,
-        # including the one a self-compiling setup release runs on the player's
-        # own machine, deleted their mods without a word.
-        set(_psx_builtin_mod_copy_commands "")
-        if(DEFINED PSX_BUILTIN_MOD_ALLOWLIST AND NOT
-           "${PSX_BUILTIN_MOD_ALLOWLIST}" STREQUAL "")
-            foreach(_psx_builtin_mod IN LISTS PSX_BUILTIN_MOD_ALLOWLIST)
-                if(NOT EXISTS "${PSXRECOMP_ROOT}/mods/builtin/packages/${_psx_builtin_mod}")
-                    message(FATAL_ERROR
-                        "PSX_BUILTIN_MOD_ALLOWLIST names missing package: ${_psx_builtin_mod}")
-                endif()
-                list(APPEND _psx_builtin_mod_copy_commands
-                    COMMAND ${CMAKE_COMMAND} -E copy_directory
-                        "${PSXRECOMP_ROOT}/mods/builtin/packages/${_psx_builtin_mod}"
-                        "$<TARGET_FILE_DIR:${target}>/mods/bundled/${_psx_builtin_mod}")
-            endforeach()
-        else()
-            list(APPEND _psx_builtin_mod_copy_commands
-                COMMAND ${CMAKE_COMMAND} -E copy_directory
-                    "${PSXRECOMP_ROOT}/mods/builtin/packages"
-                    "$<TARGET_FILE_DIR:${target}>/mods/bundled")
-        endif()
-        add_custom_command(TARGET ${target} POST_BUILD
-            COMMAND ${CMAKE_COMMAND} -E rm -rf
-                "$<TARGET_FILE_DIR:${target}>/mods/bundled"
-            ${_psx_builtin_mod_copy_commands}
-            COMMENT "Staging framework-owned mod catalog"
-            VERBATIM)
-        unset(_psx_builtin_mod_copy_commands)
+    # Mod catalog: the framework's builtin packages AND the title's own, both
+    # staged into mods/bundled by _psxrt_stage_mod_catalog (see its header).
+    # Skipped for cosim oracles: they have no launcher and no Mods page, and
+    # because a cosim exe lands in the same output directory as the runtime,
+    # letting it stage would have it wipe and re-stage the runtime's catalog
+    # with only the framework half.
+    if(NOT PSXRT_COSIM)
+        _psxrt_stage_mod_catalog("${target}" "${PSXRT_PRELOADED_MODS_DIR}")
     endif()
     endif()
 

--- a/runtime/tests/test_mod_catalog_layout.py
+++ b/runtime/tests/test_mod_catalog_layout.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+"""Guard the staged mod-catalog layout (<exe-dir>/mods/bundled).
+
+WHY THIS TEST EXISTS
+--------------------
+Framework commit 4cc04be3 renamed the staged mod catalog from mods/packages to
+mods/bundled. The framework's own staging followed, and the shared release
+module (tools/release_overlay_stage.ps1, Add-ModCatalog) followed. Five title
+CMakeLists did not, because the only thing coupling them to the framework was a
+`cmake -E copy_directory` DESTINATION STRING -- no symbol, no header, no link
+dependency. Nothing failed to configure, compile or link. The five titles kept
+writing their packages into mods/packages, where nothing reads them, and the
+defect surfaced only when a release packager ran, in a different repository, on
+a later day (bead beads-eio.3.101).
+
+runtime/psx_check_mod_catalog.cmake is the tripwire that makes that state a
+build failure. This test exercises it against on-disk fixtures, including a
+byte-for-byte reproduction of the broken state as it actually appeared in Ape
+Escape's build output: mods/bundled holding the four framework psx.* packages
+and mods/packages holding the four game-owned ape.* ones.
+
+It also pins two source invariants in runtime.cmake, so the layout cannot drift
+back into per-title copies:
+  * the framework declares PRELOADED_MODS_DIR and stages the title's catalog,
+  * the build-time guard is registered through cmake_language(DEFER), which is
+    what makes it run AFTER any POST_BUILD command a title registered later.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+GUARD = REPO / "runtime" / "psx_check_mod_catalog.cmake"
+RUNTIME_CMAKE = REPO / "runtime" / "runtime.cmake"
+
+FW_IDS = [
+    "psx.enhancement.cd-speed",
+    "psx.enhancement.fast-loading",
+    "psx.enhancement.pgxp",
+    "psx.presentation.bezel",
+]
+GAME_IDS = [
+    "ape.enhancement.frame-smoothing",
+    "ape.enhancement.widescreen",
+    "ape.experimental.interpolated-frame-rate",
+    "ape.presentation.crt",
+]
+
+_failures: list[str] = []
+
+
+def check(cond: bool, what: str) -> None:
+    if cond:
+        print(f"  ok   {what}")
+    else:
+        print(f"  FAIL {what}")
+        _failures.append(what)
+
+
+def make_package(root: Path, pkg_id: str, version: str = "1.0.0") -> None:
+    d = root / pkg_id / version
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "manifest.toml").write_text(
+        f'format_version = 5\nid = "{pkg_id}"\nversion = "{version}"\n',
+        encoding="utf-8",
+    )
+
+
+def write_manifest(path: Path, ids: list[str]) -> Path:
+    path.write_text("\n".join(ids) + "\n", encoding="utf-8")
+    return path
+
+
+def run_guard(
+    cmake: str,
+    mods_dir: Path,
+    manifest: Path,
+    *,
+    require_staged: int = 1,
+    alt_manifests: list[Path] | None = None,
+    label: str = "psx-runtime",
+) -> subprocess.CompletedProcess[str]:
+    argv = [
+        cmake,
+        f"-DPSX_MODS_DIR={mods_dir.as_posix()}",
+        f"-DPSX_CATALOG_MANIFEST={manifest.as_posix()}",
+        f"-DPSX_REQUIRE_STAGED={require_staged}",
+        f"-DPSX_LABEL={label}",
+    ]
+    if alt_manifests:
+        joined = "|".join(p.as_posix() for p in alt_manifests)
+        argv.append(f"-DPSX_CATALOG_ALT_MANIFESTS={joined}")
+    argv += ["-P", str(GUARD)]
+    return subprocess.run(argv, capture_output=True, text=True)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--cmake", default=shutil.which("cmake") or "cmake")
+    args = ap.parse_args()
+
+    if not GUARD.is_file():
+        print(f"FAIL: guard script missing: {GUARD}")
+        return 1
+    if shutil.which(args.cmake) is None and not Path(args.cmake).is_file():
+        print(f"SKIP: no cmake executable available ({args.cmake})")
+        return 0
+
+    with tempfile.TemporaryDirectory(prefix="psx_mod_catalog_") as tmpdir:
+        tmp = Path(tmpdir)
+        all_ids = sorted(FW_IDS + GAME_IDS)
+        manifest = write_manifest(tmp / "expected.txt", all_ids)
+
+        # ---- 1. correct layout: everything under mods/bundled -------------
+        print("[1] correct layout (framework + game under mods/bundled)")
+        mods = tmp / "good" / "mods"
+        for pid in all_ids:
+            make_package(mods / "bundled", pid)
+        (mods / "README.md").write_text("mods\n", encoding="utf-8")
+        r = run_guard(args.cmake, mods, manifest)
+        check(r.returncode == 0, "accepts a complete mods/bundled catalog")
+        check(
+            "staged mod catalog OK: 8 package(s) = 4 game-owned + 4 framework-owned"
+            in (r.stdout + r.stderr),
+            "reports the derived 4 game-owned + 4 framework-owned breakdown",
+        )
+
+        # ---- 2. THE BUG: game packages under the legacy mods/packages ----
+        # This is exactly what a framework-master build of Ape Escape produced
+        # before the fix: the framework staged its own four into mods/bundled,
+        # and the title's own copy_directory put the game's four into
+        # mods/packages, where Add-ModCatalog cannot see them.
+        print("[2] the regression: game packages under legacy mods/packages")
+        mods = tmp / "regression" / "mods"
+        for pid in FW_IDS:
+            make_package(mods / "bundled", pid)
+        for pid in GAME_IDS:
+            make_package(mods / "packages", pid)
+        r = run_guard(args.cmake, mods, manifest)
+        out = r.stdout + r.stderr
+        check(r.returncode != 0, "FAILS the build when packages land in mods/packages")
+        check("LEGACY mods/packages" in out, "names the legacy layout as the cause")
+        for pid in GAME_IDS:
+            check(pid in out, f"names the stranded package {pid}")
+        check(
+            "PRELOADED_MODS_DIR" in out,
+            "tells the reader the fix is to declare PRELOADED_MODS_DIR",
+        )
+
+        # ---- 3. a declared package simply never staged --------------------
+        print("[3] a declared package never reached mods/bundled")
+        mods = tmp / "missing" / "mods"
+        for pid in FW_IDS + GAME_IDS[:-1]:
+            make_package(mods / "bundled", pid)
+        r = run_guard(args.cmake, mods, manifest)
+        out = r.stdout + r.stderr
+        check(r.returncode != 0, "FAILS when a declared package is absent")
+        check(GAME_IDS[-1] in out, "names the absent package")
+        check(
+            "never reached the staged catalog" in out,
+            "says the package never reached the catalog",
+        )
+
+        # ---- 4. a package directory with no manifest ----------------------
+        print("[4] staged package directory without a manifest.toml")
+        mods = tmp / "manifestless" / "mods"
+        for pid in all_ids:
+            make_package(mods / "bundled", pid)
+        broken = mods / "bundled" / GAME_IDS[0] / "1.0.0" / "manifest.toml"
+        broken.unlink()
+        r = run_guard(args.cmake, mods, manifest)
+        out = r.stdout + r.stderr
+        check(r.returncode != 0, "FAILS when a staged package has no manifest.toml")
+        check(GAME_IDS[0] in out, "names the manifest-less package")
+
+        # ---- 5. player-installed legacy packages must NOT fail -----------
+        # mods/packages can legitimately hold packages a player installed under
+        # the pre-split layout; the runtime's migrate_legacy_root() relocates
+        # those into mods/installed. Failing a build over them would be wrong.
+        print("[5] foreign (player-installed) packages under mods/packages")
+        mods = tmp / "foreign" / "mods"
+        for pid in all_ids:
+            make_package(mods / "bundled", pid)
+        make_package(mods / "packages", "someone.else.mod")
+        r = run_guard(args.cmake, mods, manifest)
+        out = r.stdout + r.stderr
+        check(r.returncode == 0, "does NOT fail over a package this build never staged")
+        check("someone.else.mod" in out, "still reports the legacy package it found")
+        check("mods/installed" in out, "points at the runtime's own migration path")
+
+        # ---- 6. nothing staged: require_staged distinguishes the callers --
+        print("[6] nothing staged at all")
+        mods = tmp / "empty" / "mods"
+        r = run_guard(args.cmake, mods, manifest, require_staged=0)
+        check(r.returncode == 0, "ctest invocation SKIPS an unbuilt tree")
+        check("skipped" in (r.stdout + r.stderr), "says it skipped")
+        r = run_guard(args.cmake, mods, manifest, require_staged=1)
+        check(
+            r.returncode != 0,
+            "POST_BUILD invocation FAILS when staging produced nothing",
+        )
+
+        # ---- 7. sibling runtime target sharing one output directory ------
+        # Tomba 2's US and Italian runtimes both land in the build root, so
+        # mods/bundled holds whichever linked last. A ctest run after a full
+        # build must accept either, not demand one.
+        print("[7] sibling target's catalog in a shared output directory")
+        ita_ids = sorted(
+            [
+                "psx.enhancement.cd-speed",
+                "psx.enhancement.fast-loading",
+                "psx.enhancement.pgxp",
+                "psx.presentation.bezel",
+                "tombi2.enhancement.skip-fmvs",
+                "tombi2.enhancement.widescreen",
+                "tombi2.experimental.interpolated-frame-rate",
+            ]
+        )
+        ita_manifest = write_manifest(tmp / "expected_ita.txt", ita_ids)
+        mods = tmp / "sibling" / "mods"
+        for pid in ita_ids:
+            make_package(mods / "bundled", pid)
+        r = run_guard(args.cmake, mods, manifest, alt_manifests=[ita_manifest])
+        out = r.stdout + r.stderr
+        check(r.returncode == 0, "accepts a sibling target's complete catalog")
+        check("sibling runtime target" in out, "says which case it took")
+        # ...but an INCOMPLETE sibling catalog is still a failure.
+        (mods / "bundled" / ita_ids[-1]).rename(
+            mods / "bundled" / "unexpected.leftover"
+        )
+        r = run_guard(args.cmake, mods, manifest, alt_manifests=[ita_manifest])
+        check(
+            r.returncode != 0,
+            "does NOT accept a catalog matching neither target's id set",
+        )
+
+    # ---- 8. source invariants in runtime.cmake ---------------------------
+    print("[8] runtime.cmake source invariants")
+    text = RUNTIME_CMAKE.read_text(encoding="utf-8", errors="replace")
+    check(
+        "PRELOADED_MODS_DIR" in text,
+        "runtime.cmake accepts PRELOADED_MODS_DIR so titles never name the layout",
+    )
+    check(
+        "cmake_language(DEFER CALL _psxrt_finalize_mod_catalog_guards" in text,
+        "the build-time guard is deferred, so it runs after a title's POST_BUILD",
+    )
+    check(
+        "psx_check_mod_catalog.cmake" in text,
+        "runtime.cmake wires the guard script into the build",
+    )
+    # The only mods/packages reference left in the staging code must be the
+    # legacy purge -- never a copy destination.
+    bad = [
+        line.strip()
+        for line in text.splitlines()
+        if "mods/bundled" not in line
+        and "mods/packages" in line
+        and "copy_directory" in line
+    ]
+    check(not bad, f"no copy_directory targets mods/packages (found {bad})")
+
+    print()
+    if _failures:
+        print(f"FAILED: {len(_failures)} check(s)")
+        for f in _failures:
+            print(f"  - {f}")
+        return 1
+    print("mod catalog layout guard: all checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/new_project_layout/templates/CMakeLists.txt.in
+++ b/tools/new_project_layout/templates/CMakeLists.txt.in
@@ -20,7 +20,18 @@ project(@PROJECT_CMAKE_NAME@ LANGUAGES C CXX)
 @WIZARD_CMAKE_BLOCK@
 include("${PSXRECOMP_ROOT}/runtime/runtime.cmake")
 
+# This project's own mod catalog. The FRAMEWORK stages it -- together with its
+# builtin psx.* packages -- into <exe-dir>/mods/bundled, and refuses to
+# configure if a catalog exists here but is not declared. Never copy it by
+# hand: five titles did, and framework 4cc04be3's rename of the staged
+# directory broke all five silently (bead beads-eio.3.101).
+set(PSX_PRELOADED_MODS "${CMAKE_CURRENT_SOURCE_DIR}/mods/preloaded")
+if(NOT IS_DIRECTORY "${PSX_PRELOADED_MODS}")
+    set(PSX_PRELOADED_MODS "NONE")
+endif()
+
 psxrecomp_add_game_runtime(psx-runtime
+    PRELOADED_MODS_DIR "${PSX_PRELOADED_MODS}"
 @NETPLAY_RUNTIME_ARG@
 @NETPLAY_LOBBY_URL_ARG@
 @WIZARD_RUNTIME_ARG@


### PR DESCRIPTION
## What

`4cc04be3` ("rebump") renamed the staged mod catalog from `<exe>/mods/packages` to `<exe>/mods/bundled`. `runtime.cmake` followed. `tools/release_overlay_stage.ps1`'s `Add-ModCatalog` followed. `docs/MOD_PACKAGES.md` already described the destination as "the framework's `mods/builtin/packages` **plus the title's `mods/preloaded/packages`**".

**No title CMakeLists followed**, because the second half of that sentence was implemented five times — once per repository — as a hand-written `copy_directory` whose destination is a *string*. No symbol, no header, no link dependency: renaming a staged output directory breaks nothing a configure, compile or link step can see. Five titles went on staging their whole Mods page into a directory neither the launcher nor any packager reads, and discovery was deferred to whichever title next ran a release packager, in a different repository, on a later day.

Bead `beads-eio.3.101`.

## Measured, on real build output

Framework `origin/master` 22fbbfca + Tomba2Recomp `origin/master` cdf00af, both unmodified, both built:

```
build-dir mods/
  bundled/psx.enhancement.cd-speed          <- framework, correct
  bundled/psx.enhancement.fast-loading
  bundled/psx.enhancement.pgxp
  bundled/psx.presentation.bezel
  packages/tomba2.debug.debug-menu          <- title, stranded
  packages/tomba2.enhancement.skip-fmvs
  packages/tomba2.enhancement.widescreen
  packages/tomba2.experimental.interpolated-frame-rate
```

`Add-ModCatalog` on that tree, from this branch's merge base:

```
Mod catalog is missing package(s) the sources define: tomba2.debug.debug-menu,
tomba2.enhancement.skip-fmvs, tomba2.enhancement.widescreen,
tomba2.experimental.interpolated-frame-rate. They exist in the source tree but
did not reach ...\mods\bundled, so the release would ship a Mods page the dev
build does not have.
```

## The fix

`psxrecomp_add_runtime_target()` gains a one-value keyword **`PRELOADED_MODS_DIR`**. A title declares *where* its packages live and never *how* they are laid out; the framework stages both catalogs itself.

A keyword argument, not a positional one and not a variable read out of the caller's scope, because: it matches the fourteen one-value arguments already there; a pre-set variable would be invisible at the call site and silently do nothing if set after the call (the same "fails quietly in the caller's repo" shape as the bug); and it is **per target**, which a global cannot be — Tomba 2 has two runtime targets needing two different catalogs. Both existing wrappers (`psxrecomp_v4_add_runtime_target`, `psxrecomp_add_game_runtime`) forward their remaining arguments, so it reaches through unchanged.

Per runtime target, one POST_BUILD sequence: wipe `mods/bundled` → remove exactly the ids about to be staged from any pre-existing `mods/packages` → copy framework builtins → copy the title's packages → copy `README.md` → verify. A title may still **override** a builtin at the same id and version (Tomba 2's Italian catalog ships localized `psx.*` manifests, and does). `COSIM` targets stage nothing — they have no Mods page and share the runtime's output directory.

## Two guards, because the failure mode is silence

* **Configure time** — a project with packages under `mods/preloaded/packages` that does not declare `PRELOADED_MODS_DIR` is a `FATAL_ERROR` naming the packages and the argument to add. Empty `packages/` is fine (the scaffold makes one); `PRELOADED_MODS_DIR NONE` is the explicit opt-out.
* **Build time** — `runtime/psx_check_mod_catalog.cmake` fails the build if a declared package did not reach `mods/bundled`, or if any package this build stages turned up under `mods/packages` (which can now only mean a CMakeLists still stages by hand). It runs as the **last** POST_BUILD step via `cmake_language(DEFER)`, because POST_BUILD commands run in registration order and the framework's block registers *before* anything a title adds. Verified in `build.ninja`: the deferred command lands after a title-registered POST_BUILD.

Also registered as the ctest `psx_staged_mod_catalog_test` in every project that stages a catalog.

Two findings recorded in the code so they are not re-derived: `cmake_language(DEFER CALL <fn> "${var}")` does **not** carry a function-local variable through (cmake 4.2.2 — the callee gets an empty argument and the resulting `add_custom_command` fails at directory end with `CMakeLists.txt:DEFERRED`); and ids the build does *not* stage are deliberately left in `mods/packages` for `migrate_legacy_root()`, which is what keeps the guard free of false positives on a self-compiling setup release.

## Tests

`runtime/tests/test_mod_catalog_layout.py`, registered in `runtime/CMakeLists.txt`. Fixtures cover: a reproduction of the broken state exactly as it appeared, a declared package absent, a package directory with no `manifest.toml`, a **foreign** legacy package that must *not* fail the build, the require-staged split between the two callers, and the shared-output-directory sibling case. It also pins two source invariants in `runtime.cmake`.

Shown failing without the fix (guard script absent → exit 1; guard present but `runtime.cmake` at merge base → the three source-invariant checks fail), and passing with it.

```
-- test-registration guard: 123 test file(s), all registered
100% tests passed, 0 tests failed out of 59      (2 pre-existing DISABLED)
```

Verified downstream against real build output in all five affected titles: Ape 8 packages, Tomba 2 8 (US) / 7 (ITA), MMX6 19, MMX5 6, MMX4 8 — every one under `mods/bundled/<id>/<version>/manifest.toml`, `mods/README.md` present, no `mods/packages`, no `state.toml`/`installed/`. Ape's release packager now runs to completion and its extracted zip carries 8 manifests under `mods\bundled` and zero `mods\packages` entries.

## Scope notes

`docs/MOD_PACKAGES.md` gains a "How `bundled/` gets staged" section aimed at titles, and the project scaffold template now passes `PRELOADED_MODS_DIR` — it staged no catalog at all before, so a scaffolded project with `mods/preloaded/packages` shipped none.

## Shipped releases are not affected

Tomba 2 v0.0.9 pins framework `04d9184b`, an ancestor of `4cc04be3` with zero occurrences of `migrate_legacy_root` and `bundled_root`; its artifact is a self-consistent `mods/packages` layout. **This is a forward break only.**

## Merge order

**This PR must merge BEFORE the five title PRs.** They reference `PRELOADED_MODS_DIR`, which does not exist until this lands.

| repo | PR |
| --- | --- |
| ApeEscapeRecomp | `fix/mods-bundled-staging` |
| Tomba2Recomp | `fix/mods-bundled-staging` |
| MegaManX6Recomp | `fix/mods-bundled-staging` |
| MegaManX5Recomp | `fix/mods-bundled-staging` |
| MegaManX4Recomp | `fix/mods-bundled-staging` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
