### PR TITLE
Make packaged overlay toolchain self-contained

### DIFF
--- a/runtime/src/main.cpp
+++ b/runtime/src/main.cpp
@@ -12134,6 +12134,7 @@ int main(int argc, char** argv) {
                     game_config_path ? game_config_path : "game.toml")) +
                 " --recompiler " + cmd_quote((tk_dir / tk_recompiler).string()) +
                 " --runtime-include " + cmd_quote((tk_dir / "include").string()) +
+                " --project-root " + cmd_quote(tk_dir.string()) +
                 " --out-dir " + cmd_quote((tk_xd / "cache").string()) +
                 (g_psx_cps_mode ? " --cps" : "") +
                 " --compiler " + compiler;

--- a/runtime/tests/test_release_stage_cache.py
+++ b/runtime/tests/test_release_stage_cache.py
@@ -321,15 +321,18 @@ class ToolchainStagingTest(unittest.TestCase):
         self.tmp = tempfile.mkdtemp(prefix='psx_reltool_')
         self.stage = os.path.join(self.tmp, 'stage')
         self.tools = os.path.join(self.tmp, 'tools')
-        self.include = os.path.join(self.tmp, 'include')
+        self.framework = os.path.join(self.tmp, 'framework')
+        self.include = os.path.join(self.framework, 'runtime', 'include')
+        self.bios = os.path.join(self.framework, 'bios')
         self.recomp = os.path.join(self.tmp, 'recompiler')
         self.mingw = os.path.join(self.tmp, 'mingw')
         self.cache = os.path.join(self.tmp, 'dl')
-        for d in (self.tools, self.include, self.recomp, self.mingw):
+        for d in (self.tools, self.include, self.bios, self.recomp, self.mingw):
             os.makedirs(d, exist_ok=True)
         touch(os.path.join(self.tools, 'compile_overlays.py'))
         touch(os.path.join(self.include, 'overlay_api.h'))
         touch(os.path.join(self.include, 'overlay_dispatch_preamble.c.inc'))
+        touch(os.path.join(self.bios, 'SCPH1001.toml'))
         touch(os.path.join(self.recomp, 'psxrecomp-game.exe'))
         for d in ('libgcc_s_seh-1.dll', 'libstdc++-6.dll',
                   'libwinpthread-1.dll'):
@@ -364,6 +367,8 @@ class ToolchainStagingTest(unittest.TestCase):
         self.assertTrue(os.path.isfile(os.path.join(
             self.stage, 'overlay_toolchain', 'include',
             'overlay_dispatch_preamble.c.inc')))
+        self.assertTrue(os.path.isfile(os.path.join(
+            self.stage, 'overlay_toolchain', 'bios', 'SCPH1001.toml')))
 
 
 if __name__ == '__main__':

--- a/tools/release_stage.py
+++ b/tools/release_stage.py
@@ -646,6 +646,13 @@ def stage_toolchain(stage, recomp_dir, recomp_tools, recomp_include, dl_cache,
     for h in os.listdir(recomp_include):
         if h.endswith(('.h', '.c.inc')):
             shutil.copy2(os.path.join(recomp_include, h), tool_inc)
+    recomp_root = os.path.abspath(os.path.join(recomp_include, '..', '..'))
+    bios_src = os.path.join(recomp_root, 'bios')
+    bios_dest = _mkdirs(os.path.join(toolchain, 'bios'))
+    for profile in ('SCPH1001.toml', 'OpenBIOS.toml'):
+        src = os.path.join(bios_src, profile)
+        if os.path.isfile(src):
+            shutil.copy2(src, bios_dest)
 
     # The runtime gates autocompile on this exact file. If the layout ever
     # changes, fail here rather than shipping a toolchain the runtime ignores.
@@ -656,6 +663,12 @@ def stage_toolchain(stage, recomp_dir, recomp_tools, recomp_include, dl_cache,
              'stay interpreted forever'
              % os.path.relpath(probe, toolchain))
     os.chmod(probe, 0o755)
+    for required in (os.path.join('include', 'overlay_dispatch_preamble.c.inc'),
+                     os.path.join('bios', 'SCPH1001.toml')):
+        path = os.path.join(toolchain, required)
+        if not os.path.isfile(path):
+            _die('staged overlay_toolchain is missing %s; bundled shard '
+                 'autocompile would fail at runtime' % required)
 
     # lstat, and skip symlinks. os.path.getsize() follows them, and a
     # relocatable CPython is dense with them -- the staged Linux toolchain has


### PR DESCRIPTION
Stages the BIOS profile TOMLs into overlay_toolchain and passes the staged toolchain root to runtime autocompile so release artifacts can generate shards without relying on the source checkout.\n\nValidation:\n- py -3 runtime\\tests\\test_release_stage_cache.py