### PR TITLE
Vulkan header staging and netplay diagnostic

### DIFF
--- a/runtime/runtime.cmake
+++ b/runtime/runtime.cmake
@@ -1907,6 +1907,35 @@ function(psxrecomp_add_game_runtime target)
         endif()
     endif()
 
+    # ENABLE_NETPLAY_IF_PRESENT is nearly always a no-op, and used to be one
+    # silently. By the time this function runs, runtime.cmake has already been
+    # INCLUDED, and the include resolved recomp-net and decided whether the
+    # netplay TUs compile for real or as stubs (see the PSX_NETPLAY block near
+    # the top of this file). The option(PSX_NETPLAY ... OFF) up there has also
+    # already made the `NOT DEFINED` test above false. So the flag can only
+    # ever matter to a caller that set PSX_NETPLAY before the include -- which
+    # is exactly what the scaffold's pre-include block does, and that block is
+    # the real switch. Say so instead of leaving the caller to discover from a
+    # stubbed binary that the flag they passed did nothing.
+    if(PSXG_ENABLE_NETPLAY_IF_PRESENT AND NOT PSX_NETPLAY)
+        if(EXISTS "${PSXRECOMP_ROOT}/lib/recomp-net/CMakeLists.txt")
+            message(WARNING
+                "ENABLE_NETPLAY_IF_PRESENT was passed but PSX_NETPLAY is OFF, so "
+                "netplay stays stubbed. This argument is read after "
+                "runtime.cmake has already been included and wired netplay, so "
+                "it cannot turn it on by itself. Set it BEFORE the include:\n"
+                "  if(EXISTS \"\${PSXRECOMP_ROOT}/lib/recomp-net/CMakeLists.txt\")\n"
+                "      set(PSX_NETPLAY ON CACHE BOOL \"\" FORCE)\n"
+                "  endif()")
+        else()
+            message(WARNING
+                "ENABLE_NETPLAY_IF_PRESENT was passed but recomp-net is not "
+                "checked out (${PSXRECOMP_ROOT}/lib/recomp-net), so netplay "
+                "stays stubbed. Run: git -C psxrecomp submodule update --init "
+                "lib/recomp-net")
+        endif()
+    endif()
+
     # Title default lobby WebSocket URL (compile-time; env PSX_NET_LOBBY_URL wins).
     if(PSXG_NETPLAY_LOBBY_URL)
         set(PSX_NET_LOBBY_DEFAULT_URL "${PSXG_NETPLAY_LOBBY_URL}" CACHE STRING

--- a/runtime/runtime.cmake
+++ b/runtime/runtime.cmake
@@ -1634,20 +1634,49 @@ function(psxrecomp_add_runtime_target target)
     # the -I never reaches the compiler, and a sysroot toolchain never had it
     # on the search path to begin with. Verify, then fall back to the inert
     # stub this block already knows how to build.
+    set(_vk_stage "")
     if(_vk_inc AND GLSLC_EXE)
         _psx_header_compiles(_psx_vk_ok "vulkan/vulkan.h" INCLUDES "${_vk_inc}")
         if(NOT _psx_vk_ok)
-            message(STATUS
-                "Vulkan backend: headers at ${_vk_inc} are not reachable from "
-                "${CMAKE_C_COMPILER} - gpu_vk_renderer.c builds as a software "
-                "stub. Set VULKAN_SDK to a copy the compiler can see to enable it.")
-            set(_vk_inc "")
+            # Unreachable as given. Rather than give up the renderer, stage a
+            # private include dir holding ONLY the Vulkan subtrees and try that:
+            # it is not /usr/include, so CMake will emit it, and it pulls none
+            # of the rest of the host include root ahead of the sysroot's own
+            # libc headers -- which is what makes this safe where adding
+            # ${_vk_inc} itself would not be. vk_video/ has to come along too;
+            # vulkan_core.h includes the H.264/H.265 codec headers from it, so
+            # staging vulkan/ alone still fails to compile.
+            set(_vk_stage "${CMAKE_CURRENT_BINARY_DIR}/${target}_vkinc")
+            file(MAKE_DIRECTORY "${_vk_stage}")
+            foreach(_vk_sub vulkan vk_video)
+                if(EXISTS "${_vk_inc}/${_vk_sub}")
+                    file(CREATE_LINK "${_vk_inc}/${_vk_sub}"
+                         "${_vk_stage}/${_vk_sub}" SYMBOLIC COPY_ON_ERROR)
+                endif()
+            endforeach()
+            _psx_header_compiles(_psx_vk_ok "vulkan/vulkan.h" INCLUDES "${_vk_stage}")
+            if(_psx_vk_ok)
+                message(STATUS
+                    "Vulkan backend: ${_vk_inc} is not reachable directly; "
+                    "staged ${_vk_stage} instead.")
+            else()
+                message(STATUS
+                    "Vulkan backend: headers at ${_vk_inc} are not reachable from "
+                    "${CMAKE_C_COMPILER} - gpu_vk_renderer.c builds as a software "
+                    "stub. Set VULKAN_SDK to a copy the compiler can see to enable it.")
+                set(_vk_inc "")
+                set(_vk_stage "")
+            endif()
         endif()
         unset(_psx_vk_ok)
     endif()
     if(_vk_inc AND GLSLC_EXE)
         message(STATUS "Vulkan backend: headers ${_vk_inc}, glslc ${GLSLC_EXE}")
-        target_include_directories(${target} PRIVATE "${_vk_inc}")
+        if(_vk_stage)
+            target_include_directories(${target} PRIVATE "${_vk_stage}")
+        else()
+            target_include_directories(${target} PRIVATE "${_vk_inc}")
+        endif()
         target_compile_definitions(${target} PRIVATE PSX_HAVE_VULKAN=1)
         # Compile every shader under runtime/shaders/ to SPIR-V (glslc) and embed
         # them into one generated header (vk_shaders_spv.h) of uint32_t arrays, so

--- a/runtime/runtime.cmake
+++ b/runtime/runtime.cmake
@@ -1646,12 +1646,17 @@ function(psxrecomp_add_runtime_target target)
             # ${_vk_inc} itself would not be. vk_video/ has to come along too;
             # vulkan_core.h includes the H.264/H.265 codec headers from it, so
             # staging vulkan/ alone still fails to compile.
-            set(_vk_stage "${CMAKE_CURRENT_BINARY_DIR}/${target}_vkinc")
+            string(SHA256 _vk_stage_key "${_vk_inc}")
+            string(SUBSTRING "${_vk_stage_key}" 0 12 _vk_stage_key)
+            set(_vk_stage "${CMAKE_CURRENT_BINARY_DIR}/${target}_vkinc_${_vk_stage_key}")
             file(MAKE_DIRECTORY "${_vk_stage}")
             foreach(_vk_sub vulkan vk_video)
                 if(EXISTS "${_vk_inc}/${_vk_sub}")
-                    file(CREATE_LINK "${_vk_inc}/${_vk_sub}"
-                         "${_vk_stage}/${_vk_sub}" SYMBOLIC COPY_ON_ERROR)
+                    if(NOT EXISTS "${_vk_stage}/${_vk_sub}" AND
+                       NOT IS_SYMLINK "${_vk_stage}/${_vk_sub}")
+                        file(CREATE_LINK "${_vk_inc}/${_vk_sub}"
+                             "${_vk_stage}/${_vk_sub}" SYMBOLIC COPY_ON_ERROR)
+                    endif()
                 endif()
             endforeach()
             _psx_header_compiles(_psx_vk_ok "vulkan/vulkan.h" INCLUDES "${_vk_stage}")


### PR DESCRIPTION
Replacement for #293 with an idempotent Vulkan staging fix.\n\nValidation:\n- Reproduced the CMake reconfigure failure from the original staging loop.\n- Verified the hashed staging directory + create-if-missing loop can run twice without failing.