### PR TITLE
dma: expose GPU linked-list observability

### DIFF
--- a/runtime/include/dma.h
+++ b/runtime/include/dma.h
@@ -113,9 +113,49 @@ typedef struct DMACDROMHistoryEntry {
     uint32_t last_words[DMA_CDROM_HISTORY_WORDS];
 } DMACDROMHistoryEntry;
 
+/* GPU (CH2) linked-list / ordering-table walk observability.
+ *
+ * These counters make DMA2 geometry loss countable without screenshots:
+ *   - starts_dropped: the guest asked for a new OT transfer while the previous
+ *     walk was still running. start_async_gpu_linked_list() returns early in
+ *     that case, so a whole ordering table is never sent to GP0.
+ *   - chcr_reads_in_walk: guest polls of CHCR(2) while the linked-list walk is
+ *     still active, useful for distinguishing timeout loops from blind aborts.
+ */
+typedef struct {
+    uint32_t pc;      /* guest PC of the CHCR store that aborted the walk */
+    uint32_t chcr;    /* CHCR value after that store */
+    uint32_t nodes;   /* ordering-table nodes walked before the abort */
+    uint32_t words;   /* DMA words read before the abort, including headers */
+    uint32_t cycles;  /* guest cycles the walk had been running */
+    uint32_t polls;   /* guest reads of CHCR(2) during this walk */
+} DMAGpuOtCancel;
+
+#define DMA_GPU_OT_CANCEL_RING 8
+
+typedef struct {
+    uint64_t starts;
+    uint64_t starts_dropped;
+    uint64_t completes;
+    uint64_t cancels;
+    uint32_t nodes_last;
+    uint32_t nodes_max;
+    uint32_t words_last;
+    uint32_t words_max;
+    uint64_t cycles_last;
+    uint64_t cycles_max;
+    uint8_t  active;
+    uint64_t chcr_reads_total;
+    uint64_t chcr_reads_in_walk;
+    uint32_t initiator_pc;
+    uint32_t cancel_ring_count;
+    DMAGpuOtCancel cancel_ring[DMA_GPU_OT_CANCEL_RING];
+} DMAGpuOtStats;
+
 uint64_t dma_debug_get_trace(const DMATraceEntry** out_entries);
 void dma_debug_clear_trace(void);
 void dma_debug_get_state(DMADebugState* out);
+void dma_debug_get_gpu_ot_stats(DMAGpuOtStats* out);
 uint64_t dma_debug_get_cdrom_history(const DMACDROMHistoryEntry** out_entries);
 void dma_debug_clear_cdrom_history(void);
 

--- a/runtime/src/debug_server.c
+++ b/runtime/src/debug_server.c
@@ -5871,7 +5871,7 @@ static void handle_dma_state(int id, const char *json)
     DMADebugState s;
     dma_debug_get_state(&s);
 
-    char buf[2048];
+    char buf[4096];
     size_t pos = 0;
     pos += snprintf(buf + pos, sizeof(buf) - pos,
                     "{\"id\":%d,\"ok\":true,\"dpcr\":\"0x%08X\","
@@ -5889,7 +5889,54 @@ static void handle_dma_state(int id, const char *json)
                         s.channels[i].remaining_words,
                         s.channels[i].cycles_accum);
     }
-    snprintf(buf + pos, sizeof(buf) - pos, "]}");
+    pos += snprintf(buf + pos, sizeof(buf) - pos, "]");
+
+    {
+        DMAGpuOtStats ot;
+        dma_debug_get_gpu_ot_stats(&ot);
+        pos += snprintf(buf + pos, sizeof(buf) - pos,
+                        ",\"gpu_ot\":{\"starts\":%llu,\"starts_dropped\":%llu,"
+                        "\"completes\":%llu,\"cancels\":%llu,"
+                        "\"nodes_last\":%u,\"nodes_max\":%u,"
+                        "\"words_last\":%u,\"words_max\":%u,"
+                        "\"cycles_last\":%llu,\"cycles_max\":%llu,"
+                        "\"active\":%u}",
+                        (unsigned long long)ot.starts,
+                        (unsigned long long)ot.starts_dropped,
+                        (unsigned long long)ot.completes,
+                        (unsigned long long)ot.cancels,
+                        ot.nodes_last, ot.nodes_max,
+                        ot.words_last, ot.words_max,
+                        (unsigned long long)ot.cycles_last,
+                        (unsigned long long)ot.cycles_max,
+                        ot.active);
+        pos += snprintf(buf + pos, sizeof(buf) - pos,
+                        ",\"gpu_ot_chcr\":{\"reads_total\":%llu,"
+                        "\"reads_in_walk\":%llu,\"cancel_ring_count\":%u,"
+                        "\"initiator_pc\":\"0x%08X\"},"
+                        "\"gpu_ot_cancels\":[",
+                        (unsigned long long)ot.chcr_reads_total,
+                        (unsigned long long)ot.chcr_reads_in_walk,
+                        ot.cancel_ring_count,
+                        ot.initiator_pc);
+        unsigned n = ot.cancel_ring_count < DMA_GPU_OT_CANCEL_RING
+                   ? ot.cancel_ring_count : DMA_GPU_OT_CANCEL_RING;
+        uint32_t first = ot.cancel_ring_count > DMA_GPU_OT_CANCEL_RING
+                       ? ot.cancel_ring_count - DMA_GPU_OT_CANCEL_RING : 0u;
+        for (unsigned k = 0; k < n && pos < sizeof(buf) - 192; k++) {
+            const DMAGpuOtCancel *c = &ot.cancel_ring[(first + k) %
+                                                      DMA_GPU_OT_CANCEL_RING];
+            pos += snprintf(buf + pos, sizeof(buf) - pos,
+                            "%s{\"pc\":\"0x%08X\",\"chcr\":\"0x%08X\","
+                            "\"nodes\":%u,\"words\":%u,\"cycles\":%u,"
+                            "\"polls\":%u}",
+                            k ? "," : "", c->pc, c->chcr,
+                            c->nodes, c->words, c->cycles, c->polls);
+        }
+        pos += snprintf(buf + pos, sizeof(buf) - pos, "]");
+    }
+
+    snprintf(buf + pos, sizeof(buf) - pos, "}");
     debug_server_send_line(buf);
 }
 

--- a/runtime/src/dma.c
+++ b/runtime/src/dma.c
@@ -21,6 +21,7 @@
 #include "mdec.h"
 #include "mod_memory.h"
 #include "overlay_capture.h"
+#include "psx_cycles.h"
 #include "spu.h"
 #include "audio_trace.h"
 #include "event_ring.h"
@@ -63,6 +64,9 @@ typedef struct {
 static DMAAsyncChannel mdec_async[2];
 static DMAAsyncChannel cdrom_async;
 static DMAGPULinkedList gpu_linked_list;
+static DMAGpuOtStats gpu_ot_stats;
+static uint64_t gpu_ot_start_cycle;
+static uint32_t gpu_ot_polls_this_walk;
 
 /* ---- CD DMA transfer log ---- */
 /* Every forward CH3 DMA that lands below 0x1C0000 (game data region) records
@@ -200,6 +204,18 @@ static void trace_dma_reg_write(uint32_t addr, uint32_t val, uint32_t mask,
     e->i_stat_after = i_stat;
     e->func = g_debug_current_func_addr;
     e->pc = g_debug_last_store_pc;
+}
+
+static void gpu_ot_record_walk_stats(uint64_t cycles) {
+    gpu_ot_stats.nodes_last = gpu_linked_list.nodes_processed;
+    gpu_ot_stats.words_last = gpu_linked_list.total_words;
+    gpu_ot_stats.cycles_last = cycles;
+    if (gpu_ot_stats.nodes_last > gpu_ot_stats.nodes_max)
+        gpu_ot_stats.nodes_max = gpu_ot_stats.nodes_last;
+    if (gpu_ot_stats.words_last > gpu_ot_stats.words_max)
+        gpu_ot_stats.words_max = gpu_ot_stats.words_last;
+    if (gpu_ot_stats.cycles_last > gpu_ot_stats.cycles_max)
+        gpu_ot_stats.cycles_max = gpu_ot_stats.cycles_last;
 }
 
 /* ---- Helpers ---- */
@@ -392,6 +408,18 @@ static void cancel_async_transfer(int ch) {
         cdrom_async.cycles_accum = 0;
     }
     if (ch == 2 && gpu_linked_list.active) {
+        uint64_t cycles = psx_cycle_count - gpu_ot_start_cycle;
+        gpu_ot_record_walk_stats(cycles);
+        DMAGpuOtCancel *c = &gpu_ot_stats.cancel_ring[
+            gpu_ot_stats.cancel_ring_count % DMA_GPU_OT_CANCEL_RING];
+        c->pc     = g_debug_last_store_pc;
+        c->chcr   = channels[2].chcr;
+        c->nodes  = gpu_linked_list.nodes_processed;
+        c->words  = gpu_linked_list.total_words;
+        c->cycles = cycles > UINT32_MAX ? UINT32_MAX : (uint32_t)cycles;
+        c->polls  = gpu_ot_polls_this_walk;
+        gpu_ot_stats.cancel_ring_count++;
+        gpu_ot_stats.cancels++;
         gpu_ws_end_linked_list();
         dma_gpu_ll_cancel(&gpu_linked_list);
     }
@@ -691,6 +719,8 @@ static void gpu_ll_emit_word(void *opaque, uint32_t address, uint32_t word) {
 
 static void gpu_ll_complete(void *opaque, int hit_limit) {
     (void)opaque;
+    gpu_ot_stats.completes++;
+    gpu_ot_record_walk_stats(psx_cycle_count - gpu_ot_start_cycle);
     channels[2].madr = hit_limit ? gpu_linked_list.current_addr
                                  : 0x00FFFFFFu;
     gpu_ws_end_linked_list();
@@ -707,7 +737,10 @@ static const DMAGPULinkedListOps gpu_ll_ops = {
 };
 
 static void start_async_gpu_linked_list(void) {
-    if (gpu_linked_list.active) return;
+    if (gpu_linked_list.active) {
+        gpu_ot_stats.starts_dropped++;
+        return;
+    }
     uint32_t start_addr = psx_mod_gpu_dma_resolve_address(channels[2].madr);
     gpu_ws_begin_linked_list();
     /* This scan only prepares optional widescreen grouping. It does not send
@@ -716,6 +749,9 @@ static void start_async_gpu_linked_list(void) {
     gpu_ws_prepass_linked_list(start_addr);
     dma_gpu_ll_start(&gpu_linked_list, start_addr, 0x40000u);
     event_ring_record_aux(EV_DMA_SCHED, 2u, channels[2].chcr);
+    gpu_ot_stats.starts++;
+    gpu_ot_start_cycle = psx_cycle_count;
+    gpu_ot_polls_this_walk = 0;
 }
 
 static uint32_t execute_ch2_gpu(void) {
@@ -1181,7 +1217,15 @@ uint32_t dma_read(uint32_t addr) {
         switch (reg) {
             case 0x00: return channels[ch].madr;
             case 0x04: return channels[ch].bcr;
-            case 0x08: return channels[ch].chcr;
+            case 0x08:
+                if (ch == 2) {
+                    gpu_ot_stats.chcr_reads_total++;
+                    if (gpu_linked_list.active) {
+                        gpu_ot_stats.chcr_reads_in_walk++;
+                        gpu_ot_polls_this_walk++;
+                    }
+                }
+                return channels[ch].chcr;
             case 0x0C: return 0;
             default: goto bad;
         }
@@ -1266,6 +1310,13 @@ bad:
 
 void dma_write(uint32_t addr, uint32_t val) {
     dma_write_masked(addr, val, 0xFFFFFFFFu);
+}
+
+void dma_debug_get_gpu_ot_stats(DMAGpuOtStats* out) {
+    if (!out) return;
+    *out = gpu_ot_stats;
+    out->initiator_pc = s_dma_ch_initiator_pc[2];
+    out->active = gpu_linked_list.active;
 }
 
 uint64_t dma_debug_get_trace(const DMATraceEntry** out_entries) {


### PR DESCRIPTION
## Summary
- add passive DMA2 ordering-table telemetry to dma_state
- report starts, dropped starts, completes, cancels, CHCR poll counts, initiator PC, last/max walk nodes/words/cycles, and the last 8 cancel records
- leave PR #304's linked-list walker/timing behavior intact; this does not port PR #302's superseded walker changes or PSX_GPU_LL_SYNC

## Validation
- git diff --check
- cmake -S runtime -B build-native -G Ninja -DBUILD_TESTING=ON -DPSX_REWIND=OFF -DPSXRECOMP_ALLOW_NO_BIOS=ON -DPSX_RECOMP_UI=OFF using the native retcomm toolchain
- cmake --build build-native --target dma_gpu_linked_list_timing_test
- cmake --build build-native --target psx-runtime
- build-native/dma_gpu_linked_list_timing_test.exe: PASS

Context: salvages the counters-only part called out in https://github.com/mstan/psxrecomp/pull/302#issuecomment-5533469175 after #304 superseded the walker fix.