### PR TITLE
host_keymap: hide labels for explicit unbinds

### DIFF
--- a/runtime/src/host_keymap.c
+++ b/runtime/src/host_keymap.c
@@ -314,6 +314,8 @@ const char *host_keymap_label(HostKeymapAction action, char *out, size_t cap) {
     if (action < 0 || action >= HOST_KEYMAP_ACTION_COUNT) return out;
     a = &s_actions[action];
     if (a->count <= 0) {
+        if (a->explicit_unbound)
+            return out;
 #if defined(PSX_HAS_RBENGINE_SNAP)
         if (action == HOST_KEYMAP_REWIND)
             snprintf(out, cap, "F8");

--- a/runtime/tests/test_host_keymap.c
+++ b/runtime/tests/test_host_keymap.c
@@ -18,6 +18,7 @@ static int mod_alt(void) { return (int)KMOD_ALT; }
 
 int main(int argc, char **argv) {
     uint8_t keys[SDL_NUM_SCANCODES];
+    char label[32];
     const char *cfg = "host_keymap_test.ini";
     FILE *f;
     (void)argc;
@@ -85,6 +86,26 @@ int main(int argc, char **argv) {
                                   (int)SDLK_UNKNOWN,
                                   (int)SDL_SCANCODE_F10, 0),
           "display perf rebind accepts the F10 scancode");
+
+    f = fopen(cfg, "wb");
+    check(f != NULL, "create temporary explicit-unbind config.ini");
+    if (!f) return 1;
+    fputs("[KeyMap]\n"
+          "SaveStateMenu = None\n",
+          f);
+    fclose(f);
+
+    host_keymap_load(cfg);
+    check(!host_keymap_match_event(HOST_KEYMAP_SAVE_STATE_MENU,
+                                   (int)SDLK_UNKNOWN,
+                                   (int)SDL_SCANCODE_F7, 0),
+          "explicit save-state-menu unbind disables F7");
+    check(host_keymap_label(HOST_KEYMAP_SAVE_STATE_MENU, label,
+                            sizeof(label))[0] == 0,
+          "explicit save-state-menu unbind has no fallback label");
+    check(host_keymap_match(HOST_KEYMAP_FULLSCREEN, (int)SDLK_RETURN,
+                            mod_alt()),
+          "missing fullscreen line still keeps default after explicit unbind");
 
     remove(cfg);
     if (failures) {


### PR DESCRIPTION
Follow-up to #319.

When a `[KeyMap]` action is explicitly cleared, `host_keymap_label()` should not synthesize the historic fallback label. This matters for actions like `SaveStateMenu` and `Rewind`, where the label helper had a fallback for an empty bind list.

Validation:
- built `host_keymap_test`
- ran `host_keymap_test.exe`
- ran `runtime/tests/test_rewind_toggle_combo.py` with native Python
