### PR TITLE
runtime: fix starvation watchdog cross-thread wrap; label watchdog and console exits

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -384,6 +384,13 @@ if(BUILD_TESTING)
     target_include_directories(frame_pacing_test PRIVATE include)
     add_test(NAME frame_pacing_test COMMAND frame_pacing_test)
 
+    # Same family of bug as frame_pacing: the starvation watchdog's staleness
+    # gap must not wrap when the (cross-thread) heartbeat is newer than the
+    # clock sample taken by the emu thread.
+    add_executable(starvation_watchdog_test tests/test_starvation_watchdog.c)
+    target_include_directories(starvation_watchdog_test PRIVATE include)
+    add_test(NAME starvation_watchdog_test COMMAND starvation_watchdog_test)
+
     add_executable(freeze_dump_policy_test
         tests/test_freeze_dump_policy.c
         src/freeze_dump_policy.c)

--- a/runtime/include/starvation_ring.h
+++ b/runtime/include/starvation_ring.h
@@ -99,6 +99,25 @@ void starvation_watchdog_heartbeat(void);
 /* Run watchdog check from a hot path (e.g. psx_advance_cycles). */
 void starvation_watchdog_check(void);
 
+/* Pure staleness decision behind starvation_watchdog_check(), exposed so a
+ * unit test can pin it without linking the ring.
+ *
+ * The heartbeat is stamped from two threads (emu thread per vblank, and the
+ * debug-server IO thread on every send() chunk), while the check runs on the
+ * emu thread. A stamp landing between the check's clock sample and its
+ * heartbeat load makes `last > now`; the old open-coded `now - last` wrapped
+ * to ~1.8e19, beat any threshold, and exited a healthy runtime (BoF3
+ * 2026-09-02: 402 us of real staleness tripped a 4 s watchdog). Callers must
+ * therefore load `last` BEFORE sampling `now`, and this function refuses a
+ * negative gap by construction. Returns 1 when the watchdog should fire.
+ * `timeout == 0` disables it; `last == 0` means "no heartbeat yet". */
+static inline int starvation_watchdog_stale(uint64_t last, uint64_t now,
+                                            uint64_t timeout) {
+    if (last == 0 || timeout == 0) return 0;
+    if (now <= last) return 0;
+    return (now - last) > timeout;
+}
+
 /* Manual dump-to-file (for testing / TCP probe). Filename can be NULL. */
 void starvation_ring_dump(const char *path);
 

--- a/runtime/src/crash_trace.c
+++ b/runtime/src/crash_trace.c
@@ -878,7 +878,11 @@ static void psx_signal_handler(int sig) {
  * exit(0) so __gcov_exit / instr-profile writers run. Not async-signal-safe;
  * acceptable for intentional train/Ctrl+C stop. */
 static void psx_soft_exit_handler(int sig) {
-    (void)sig;
+    /* Tag the origin so the report distinguishes a train-script kill or
+     * Ctrl+C from an untagged exit() (which stays "unknown" on purpose). */
+    psx_crash_trace_set_exit_origin(sig == SIGINT  ? "signal_sigint" :
+                                    sig == SIGTERM ? "signal_sigterm" :
+                                                     "signal_soft");
     exit(0);
 }
 
@@ -894,6 +898,12 @@ static LONG WINAPI psx_seh_handler(EXCEPTION_POINTERS *info) {
 static BOOL WINAPI psx_console_ctrl_handler(DWORD type) {
     if (type == CTRL_C_EVENT || type == CTRL_BREAK_EVENT ||
         type == CTRL_CLOSE_EVENT) {
+        /* A console torn down under the game (terminal crash, window X)
+         * used to report as atexit/unknown — indistinguishable from an
+         * SDL window close. Name the event. */
+        psx_crash_trace_set_exit_origin(type == CTRL_CLOSE_EVENT ? "console_close" :
+                                        type == CTRL_BREAK_EVENT ? "console_ctrl_break" :
+                                                                   "console_ctrl_c");
         exit(0);
         return TRUE;
     }

--- a/runtime/src/starvation_ring.c
+++ b/runtime/src/starvation_ring.c
@@ -13,6 +13,8 @@
 #include "psx_bss.h"
 #include "psx_cycles.h"
 #include "psx_netplay.h"
+#include "crash_trace.h"
+#include <stdatomic.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -46,8 +48,15 @@ extern int psx_get_in_exception(void);
 
 static PSX_BSS StarvationEntry s_ring[STARVATION_RING_CAP];
 static uint64_t        s_seq = 0;
-static uint64_t        s_last_heartbeat_us = 0;
+/* Written by the emu thread AND the debug-server IO thread
+ * (send_all_blocking); read by the emu thread's watchdog. Atomic so the
+ * cross-thread store/load is single-copy atomic on every target. */
+static _Atomic uint64_t s_last_heartbeat_us = 0;
 static int             s_dump_done = 0;
+
+static uint64_t heartbeat_load(void) {
+    return atomic_load_explicit(&s_last_heartbeat_us, memory_order_relaxed);
+}
 
 /* Watchdog threshold: 4 seconds of wall-clock without a heartbeat is
  * "TCP died, BIOS still running" territory. Real BIOS pad polling
@@ -70,13 +79,14 @@ static uint64_t starvation_timeout_us(void) {
 }
 
 void starvation_watchdog_heartbeat(void) {
-    s_last_heartbeat_us = host_us_now();
+    atomic_store_explicit(&s_last_heartbeat_us, host_us_now(),
+                          memory_order_relaxed);
 }
 
 void starvation_ring_reset(void) {
     memset(s_ring, 0, sizeof(s_ring));
     s_seq = 0;
-    s_last_heartbeat_us = 0;
+    atomic_store_explicit(&s_last_heartbeat_us, 0, memory_order_relaxed);
     s_dump_done = 0;
 }
 
@@ -204,7 +214,7 @@ void starvation_ring_dump(const char *path) {
                 "\"in_exception\":%u,\"i_stat\":\"0x%08X\",\"i_mask\":\"0x%08X\","
                 "\"net_arch\":\"%s\",\"max_players\":%d,\"player_count\":%d}}\n",
                 (unsigned long long)total, (unsigned long long)avail,
-                (unsigned long long)s_last_heartbeat_us,
+                (unsigned long long)heartbeat_load(),
                 (unsigned long long)host_us_now(),
                 (unsigned long long)psx_get_cycle_count(),
                 g_debug_current_func_addr, g_debug_last_store_pc,
@@ -244,18 +254,25 @@ void starvation_ring_dump(const char *path) {
 
 void starvation_watchdog_check(void) {
     if (s_dump_done) return;
-    if (s_last_heartbeat_us == 0) return;  /* not initialized yet */
+    /* Load the heartbeat BEFORE sampling the clock. The IO thread stamps it
+     * concurrently; with the reads in the other order a stamp landing in
+     * between made now < last and the unsigned gap wrapped past any
+     * threshold (see starvation_watchdog_stale). */
+    uint64_t last = heartbeat_load();
+    if (last == 0) return;                 /* not initialized yet */
     uint64_t timeout = starvation_timeout_us();
     if (timeout == 0) return;              /* watchdog disabled (renderer bring-up) */
     uint64_t now = host_us_now();
-    if (now - s_last_heartbeat_us > timeout) {
+    if (starvation_watchdog_stale(last, now, timeout)) {
         starvation_ring_dump(NULL);
         /* Abort cleanly so the dump file is preserved and the user knows
-         * the runtime starved. */
+         * the runtime starved. Tag the exit so psx_last_run_report.json
+         * says "starvation_watchdog" instead of atexit/unknown. */
         fprintf(stderr, "starvation_watchdog: %llu us without heartbeat — "
                 "ring dumped to starvation_dump.jsonl, aborting\n",
-                (unsigned long long)(now - s_last_heartbeat_us));
+                (unsigned long long)(now - last));
         fflush(stderr);
+        psx_crash_trace_set_exit_origin("starvation_watchdog");
         exit(2);
     }
 }

--- a/runtime/tests/test_starvation_watchdog.c
+++ b/runtime/tests/test_starvation_watchdog.c
@@ -1,0 +1,67 @@
+/*
+ * test_starvation_watchdog.c — pin the race-free staleness decision behind
+ * starvation_watchdog_check().
+ *
+ * Regression test for the false watchdog trip seen on Breath of Fire III
+ * (2026-09-02): the debug-server IO thread stamps the heartbeat on every
+ * send() chunk, the emu thread's check sampled the clock first and the
+ * heartbeat second, so a stamp landing between the two reads made
+ * `last > now`; `now - last` wrapped to ~1.8e19 us, beat the 4 s threshold,
+ * and a healthy 60 fps runtime exited with a dump whose meta line showed the
+ * heartbeat was 402 us old. starvation_watchdog_stale() refuses a negative gap
+ * by construction; this test pins that property.
+ *
+ * Build: gcc -I../include -o test_starvation_watchdog test_starvation_watchdog.c
+ */
+#include <stdio.h>
+#include <stdint.h>
+
+#include "starvation_ring.h"
+
+static int failures = 0;
+#define CHECK(cond, msg) do { \
+    if (!(cond)) { printf("FAIL: %s\n", msg); failures++; } \
+    else         { printf("ok:   %s\n", msg); } \
+} while (0)
+
+int main(void) {
+    const uint64_t TIMEOUT = 4 * 1000000ull;   /* runtime default: 4 s */
+    const uint64_t T       = 322798613022ull;  /* the 2026-09-02 heartbeat */
+
+    /* 1. The false-trip scenario: a heartbeat stamped by the IO thread AFTER
+     *    the emu thread sampled the clock. Old code wrapped here. */
+    CHECK(starvation_watchdog_stale(T + 1, T, TIMEOUT) == 0,
+          "heartbeat 1 us newer than the clock sample does not fire");
+    CHECK(starvation_watchdog_stale(T + 5000, T, TIMEOUT) == 0,
+          "heartbeat 5 ms newer than the clock sample does not fire");
+    CHECK(starvation_watchdog_stale(T, T, TIMEOUT) == 0,
+          "heartbeat equal to the clock sample does not fire");
+
+    /* 2. Fresh heartbeats never fire (the 402 us case from the dump). */
+    CHECK(starvation_watchdog_stale(T, T + 402, TIMEOUT) == 0,
+          "402 us staleness does not fire a 4 s watchdog");
+    CHECK(starvation_watchdog_stale(T, T + TIMEOUT, TIMEOUT) == 0,
+          "staleness exactly at the threshold does not fire");
+
+    /* 3. A genuine stall still fires. */
+    CHECK(starvation_watchdog_stale(T, T + TIMEOUT + 1, TIMEOUT) == 1,
+          "staleness one past the threshold fires");
+    CHECK(starvation_watchdog_stale(T, T + 60 * 1000000ull, TIMEOUT) == 1,
+          "60 s staleness fires");
+
+    /* 4. Disable / not-yet-initialised guards. */
+    CHECK(starvation_watchdog_stale(T, T + 60 * 1000000ull, 0) == 0,
+          "timeout 0 (PSX_STARVATION_TIMEOUT_US=0) never fires");
+    CHECK(starvation_watchdog_stale(0, T, TIMEOUT) == 0,
+          "no heartbeat yet never fires");
+
+    /* 5. Wrap is impossible for any pair, not just the observed one. */
+    CHECK(starvation_watchdog_stale(UINT64_MAX, 1, TIMEOUT) == 0,
+          "max heartbeat vs tiny clock does not fire");
+    CHECK(starvation_watchdog_stale(1, UINT64_MAX, TIMEOUT) == 1,
+          "tiny heartbeat vs max clock fires");
+
+    if (failures) { printf("%d failure(s)\n", failures); return 1; }
+    printf("all starvation watchdog checks passed\n");
+    return 0;
+}


### PR DESCRIPTION
## Problem

Two defects in the starvation watchdog (`runtime/src/starvation_ring.c`), both observed on Breath of Fire III (build-dbg, pin `7ab698ca`, 2026-09-02) with the area poller attached over the debug TCP port.

**1. Cross-thread read race wraps the staleness subtraction.** `s_last_heartbeat_us` is stamped from two threads — the emu thread (`debug_server_poll`, the host pause loops in `main.cpp`) and the debug-server IO thread (`send_all_blocking`, once per `send()` chunk). `starvation_watchdog_check()` on the emu thread sampled `host_us_now()` **first** and loaded the heartbeat **second**. A stamp landing between the two reads made `last > now`; the `uint64_t` subtraction wrapped to ~1.8e19, beat the 4 s threshold, and a healthy 60 fps runtime exited with code 2. The variable was also a plain `uint64_t` with no atomic qualifier.

Evidence from the trip:

| Artifact | What it said |
|---|---|
| `starvation_dump.jsonl` meta | `last_heartbeat_us: 322798613022`, `now_us: 322798613424` — heartbeat **402 µs** old when the dump ran, against a 4 s threshold |
| `psx_freeze_heartbeat.json` | 6 frames per 100 ms sample right up to the last sample (60 fps); `tcp_send_stall_ms` rising — IO thread serving the poller continuously |
| `psx_last_run_report.json` | `reason: "atexit"`, `exit_origin: "unknown"`; native stack `starvation_watchdog_check` → `psx_atexit_handler` |
| Windows Application log | no event 1000/1001 — the runtime exited voluntarily |

With the poller's constant traffic the race hit within ~2 minutes of play. Workaround until now: `PSX_STARVATION_TIMEOUT_US=0`, which also disables the watchdog for real stalls.

**2. Watchdog exits are reported as clean shutdowns.** Only `tcp_quit` and the `sdl_window_close` paths ever set the exit origin, so the watchdog's `exit(2)` — and the `CTRL_C/BREAK/CLOSE` console handler's `exit(0)`, and the SIGINT/SIGTERM soft-exit handler — all reached `psx_atexit_handler` as `atexit` / `unknown`, indistinguishable from a user closing the window. That is why this class of exit kept being chased as an unexplained crash.

## Fix

- `starvation_watchdog_check()` loads the heartbeat **before** sampling the clock and decides through a new pure helper `starvation_watchdog_stale(last, now, timeout)` (in `starvation_ring.h`) that refuses a negative gap by construction. Same shape as the `frame_pacing_sleep_ms` fix for the same family of bug.
- `s_last_heartbeat_us` becomes `_Atomic uint64_t` with relaxed store/load (C11 atomics are already required by the runtime for `audio_trace.c`).
- The watchdog tags `psx_crash_trace_set_exit_origin("starvation_watchdog")` before `exit(2)`; the console-ctrl handler tags `console_close` / `console_ctrl_break` / `console_ctrl_c`; the soft-signal handler tags `signal_sigint` / `signal_sigterm`. Untagged `exit()` calls still read `unknown` on purpose.
- New ctest `starvation_watchdog_test` pins the decision: the observed false-trip pair, the 402 µs staleness, threshold boundary, genuine stalls, `timeout == 0`, `last == 0`, and the `UINT64_MAX` extremes.

## Verification

- `starvation_watchdog_test`: 11/11 pass (gcc, MinGW-w64).
- BoF3 `build-dbg` rebuilt against this branch, launched with `PSX_STARVATION_TIMEOUT_US=4000000` (the default, i.e. watchdog **enabled**) and the area poller polling at 1 s: **10 min, process alive, no `starvation_dump.jsonl` written** (249 poller connections in TIME_WAIT on the debug port at the end of the window). Before the fix the same setup tripped in ~2 min.
- Forced trip with `PSX_STARVATION_TIMEOUT_US=1000`: fires at boot (`starvation_watchdog: 1167 us without heartbeat`), dump written, and `psx_last_run_report.json` now reads `exit_origin: "starvation_watchdog"` instead of `unknown`.

Write-up with the full evidence table lives in the title repo: `BreathOfFire3Recomp/docs/starvation-watchdog-false-trip.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
