### PR TITLE
Bound OpenGL CPU readbacks to pending GPU writes

### DIFF
--- a/docs/GPU_GL_READBACK_REGIONS.md
+++ b/docs/GPU_GL_READBACK_REGIONS.md
@@ -1,0 +1,44 @@
+# OpenGL native readback regions
+
+OpenGL owns the rendered video memory. A CPU read must see all prior GPU writes.
+The backend now keeps a separate conservative rectangle for GPU writes that
+have not reached the CPU array. It reads that rectangle into the full-width CPU
+array with an explicit row stride. It then clears the CPU readback debt.
+
+The rectangle includes clipped primitives, fill segments and copy destinations.
+It also retains framebuffer clearing debt across depth24 transitions. GPU
+uploads and queued draws still finish before packing and reading. Texture
+sampling can consume packing debt without consuming CPU readback debt. A
+conservative union is safe for GPU-to-CPU reads because the GPU image is current;
+CPU-to-GPU uploads still use their exact rectangle list.
+
+This does not change raster rules, read values, guest clocks, draw order or
+precision. It does not switch OpenGL to software raster ownership. The original
+interlaced row clipping remains in place. State recreation clears the new debt;
+CPU-authority mode retains its existing no-readback behavior.
+
+## Verification
+
+`runtime/tests/test_gl_readback_region.c` uses an actual hidden SDL/OpenGL
+context. It checks the complete native CPU image against full hardware readback
+after ordered synthetic workloads. It covers single pixels, odd-width row
+stride, disjoint uploads, texture dependencies, wrapping fills, overlapping
+copies, masks, blending, clipping, precision margins and state restore.
+The hardware rasterizer is shared by the comparison; this proves coherence,
+not independent raster accuracy. No retail assets are required.
+
+Run `python runtime/tests/run_gl_readback_region.py --compiler-bin <mingw-bin>
+--sdl-root <deps> --output <new-directory>`. The SDL dependency root must contain
+`sdl3-src/include` and `sdl3-build/libSDL3.a`. The Windows runner uses hidden
+windows. It tests
+native and4x scales. `--gl-source <old-gpu_gl_renderer.c> --expect-unbounded`
+checks the previous implementation: pixel comparisons pass, and only the small
+transfer assertion fails. Each command/result is saved in `receipt.json` under a fresh run directory inside the output root. Configure `runtime/` with `BUILD_TESTING=ON` and `PSX_GL_READBACK_SDL_ROOT=<deps>` on MinGW to register `gl_readback_region_test`; run it with `ctest --test-dir <build> -R gl_readback_region_test --output-on-failure`. Missing dependencies print a configure-time message and do not count as a hardware pass.
+
+## Prior art and scope
+
+Existing renderer coherence code supplied the ordering and dirty-area rules.
+DuckStation's software readback path was consulted as an alternative. This correction keeps the frozen branch's GPU
+authority and needs no title hook or controller policy change. Future work can
+reduce row submissions or use a more precise dirty set if measured demand
+justifies it.

--- a/docs/GPU_GL_READBACK_REGIONS.md
+++ b/docs/GPU_GL_READBACK_REGIONS.md
@@ -23,7 +23,10 @@ CPU-authority mode retains its existing no-readback behavior.
 context. It checks the complete native CPU image against full hardware readback
 after ordered synthetic workloads. It covers single pixels, odd-width row
 stride, disjoint uploads, texture dependencies, wrapping fills, overlapping
-copies, masks, blending, clipping, precision margins and state restore.
+copies, masks, blending, clipping, precision margins and state restore. A depth24 exit followed by an immediate
+CPU read verifies that cleared movie pixels are visible and newer overlapping
+texture uploads survive. It tests this existing clear policy, not full movie
+playback or depth24 raster accuracy.
 The hardware rasterizer is shared by the comparison; this proves coherence,
 not independent raster accuracy. No retail assets are required.
 
@@ -32,8 +35,9 @@ Run `python runtime/tests/run_gl_readback_region.py --compiler-bin <mingw-bin>
 `sdl3-src/include` and `sdl3-build/libSDL3.a`. The Windows runner uses hidden
 windows. It tests
 native and4x scales. `--gl-source <old-gpu_gl_renderer.c> --expect-unbounded`
-checks the previous implementation: pixel comparisons pass, and only the small
-transfer assertion fails. Each command/result is saved in `receipt.json` under a fresh run directory inside the output root. Configure `runtime/` with `BUILD_TESTING=ON` and `PSX_GL_READBACK_SDL_ROOT=<deps>` on MinGW to register `gl_readback_region_test`; run it with `ctest --test-dir <build> -R gl_readback_region_test --output-on-failure`. Missing dependencies print a configure-time message and do not count as a hardware pass.
+accepts an unbounded implementation only when pixel comparisons pass and
+exactly the small-transfer assertion fails. An older implementation with a
+coherence defect (including the depth24 clear) is correctly rejected too. Each command/result is saved in `receipt.json` under a fresh run directory inside the output root. Configure `runtime/` with `BUILD_TESTING=ON` and `PSX_GL_READBACK_SDL_ROOT=<deps>` on MinGW to register `gl_readback_region_test`; run it with `ctest --test-dir <build> -R gl_readback_region_test --output-on-failure`. Missing dependencies print a configure-time message and do not count as a hardware pass.
 
 ## Prior art and scope
 

--- a/docs/GPU_GL_READBACK_REGIONS.md
+++ b/docs/GPU_GL_READBACK_REGIONS.md
@@ -42,3 +42,9 @@ DuckStation's software readback path was consulted as an alternative. This corre
 authority and needs no title hook or controller policy change. Future work can
 reduce row submissions or use a more precise dirty set if measured demand
 justifies it.
+
+For Clang/MinGW builds, set `PSX_GL_READBACK_COMPILER_BIN` to a GCC/MinGW
+bin directory containing both gcc.exe and g++.exe. CMake checks these files
+before registering the hardware test. `gl_readback_runner_test` separately
+checks strict result parsing without a GPU or compiler. A negative run passes
+only for exactly one failure named single-pixel bounded transfer.

--- a/docs/GPU_GL_READBACK_REGIONS.md
+++ b/docs/GPU_GL_READBACK_REGIONS.md
@@ -34,7 +34,7 @@ Run `python runtime/tests/run_gl_readback_region.py --compiler-bin <mingw-bin>
 --sdl-root <deps> --output <new-directory>`. The SDL dependency root must contain
 `sdl3-src/include` and `sdl3-build/libSDL3.a`. The Windows runner uses hidden
 windows. It tests
-native and4x scales. `--gl-source <old-gpu_gl_renderer.c> --expect-unbounded`
+native and 4x scales. `--gl-source <old-gpu_gl_renderer.c> --expect-unbounded`
 accepts an unbounded implementation only when pixel comparisons pass and
 exactly the small-transfer assertion fails. An older implementation with a
 coherence defect (including the depth24 clear) is correctly rejected too. Each command/result is saved in `receipt.json` under a fresh run directory inside the output root. Configure `runtime/` with `BUILD_TESTING=ON` and `PSX_GL_READBACK_SDL_ROOT=<deps>` on MinGW to register `gl_readback_region_test`; run it with `ctest --test-dir <build> -R gl_readback_region_test --output-on-failure`. Missing dependencies print a configure-time message and do not count as a hardware pass.
@@ -49,6 +49,7 @@ justifies it.
 
 For Clang/MinGW builds, set `PSX_GL_READBACK_COMPILER_BIN` to a GCC/MinGW
 bin directory containing both gcc.exe and g++.exe. CMake checks these files
-before registering the hardware test. `gl_readback_runner_test` separately
+before registering the hardware test. Both the configure step and the runner
+also validate the SDL3 include directory and static library. `gl_readback_runner_test` separately
 checks strict result parsing without a GPU or compiler. A negative run passes
 only for exactly one failure named single-pixel bounded transfer.

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -23,6 +23,23 @@ psxrecomp_add_runtime_target(psx-runtime
 # (docs/ENHANCEMENTS.md G1.10). Titles get their <exe>_pgxp the same way.
 
 if(BUILD_TESTING)
+    # Optional real-hardware regression. Configure its dependencies explicitly;
+    # absence must remain visible, never counted as a passing GPU test.
+    set(PSX_GL_READBACK_SDL_ROOT "" CACHE PATH "SDL3 static build root for GL readback test")
+    if(MINGW AND PSX_GL_READBACK_SDL_ROOT)
+        find_package(Python3 REQUIRED COMPONENTS Interpreter)
+        get_filename_component(_gl_test_compiler_bin "${CMAKE_C_COMPILER}" DIRECTORY)
+        add_test(NAME gl_readback_region_test
+            COMMAND "${Python3_EXECUTABLE}"
+                "${CMAKE_CURRENT_SOURCE_DIR}/tests/run_gl_readback_region.py"
+                --fixture "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_gl_readback_region.c"
+                --compiler-bin "${_gl_test_compiler_bin}"
+                --sdl-root "${PSX_GL_READBACK_SDL_ROOT}"
+                --output "${CMAKE_CURRENT_BINARY_DIR}/gl-readback-results")
+        set_tests_properties(gl_readback_region_test PROPERTIES LABELS "gpu;opengl;hardware" TIMEOUT 180)
+    else()
+        message(STATUS "gl_readback_region_test: not registered (requires MinGW and PSX_GL_READBACK_SDL_ROOT)")
+    endif()
     add_executable(launcher_device_roundtrip_test
         tests/test_launcher_device_roundtrip.cpp)
     target_include_directories(launcher_device_roundtrip_test PRIVATE include)

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -35,7 +35,9 @@ if(BUILD_TESTING)
     endif()
     if(MINGW AND PSX_GL_READBACK_SDL_ROOT
             AND EXISTS "${PSX_GL_READBACK_COMPILER_BIN}/gcc.exe"
-            AND EXISTS "${PSX_GL_READBACK_COMPILER_BIN}/g++.exe")
+            AND EXISTS "${PSX_GL_READBACK_COMPILER_BIN}/g++.exe"
+            AND IS_DIRECTORY "${PSX_GL_READBACK_SDL_ROOT}/sdl3-src/include"
+            AND EXISTS "${PSX_GL_READBACK_SDL_ROOT}/sdl3-build/libSDL3.a")
         find_package(Python3 REQUIRED COMPONENTS Interpreter)
         add_test(NAME gl_readback_region_test
             COMMAND "${Python3_EXECUTABLE}"
@@ -46,7 +48,7 @@ if(BUILD_TESTING)
                 --output "${CMAKE_CURRENT_BINARY_DIR}/gl-readback-results")
         set_tests_properties(gl_readback_region_test PROPERTIES LABELS "gpu;opengl;hardware" TIMEOUT 180)
     else()
-        message(STATUS "gl_readback_region_test: not registered (requires MinGW, PSX_GL_READBACK_SDL_ROOT and gcc.exe/g++.exe in PSX_GL_READBACK_COMPILER_BIN)")
+        message(STATUS "gl_readback_region_test: not registered (requires MinGW, SDL3 headers/static library in PSX_GL_READBACK_SDL_ROOT and gcc.exe/g++.exe in PSX_GL_READBACK_COMPILER_BIN)")
     endif()
     add_executable(launcher_device_roundtrip_test
         tests/test_launcher_device_roundtrip.cpp)

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -26,19 +26,27 @@ if(BUILD_TESTING)
     # Optional real-hardware regression. Configure its dependencies explicitly;
     # absence must remain visible, never counted as a passing GPU test.
     set(PSX_GL_READBACK_SDL_ROOT "" CACHE PATH "SDL3 static build root for GL readback test")
-    if(MINGW AND PSX_GL_READBACK_SDL_ROOT)
+    get_filename_component(_gl_test_default_bin "${CMAKE_C_COMPILER}" DIRECTORY)
+    set(PSX_GL_READBACK_COMPILER_BIN "${_gl_test_default_bin}" CACHE PATH "GCC/MinGW bin for GL fixture")
+    find_package(Python3 QUIET COMPONENTS Interpreter)
+    if(Python3_Interpreter_FOUND)
+        add_test(NAME gl_readback_runner_test COMMAND "${Python3_EXECUTABLE}"
+            "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_gl_readback_runner.py")
+    endif()
+    if(MINGW AND PSX_GL_READBACK_SDL_ROOT
+            AND EXISTS "${PSX_GL_READBACK_COMPILER_BIN}/gcc.exe"
+            AND EXISTS "${PSX_GL_READBACK_COMPILER_BIN}/g++.exe")
         find_package(Python3 REQUIRED COMPONENTS Interpreter)
-        get_filename_component(_gl_test_compiler_bin "${CMAKE_C_COMPILER}" DIRECTORY)
         add_test(NAME gl_readback_region_test
             COMMAND "${Python3_EXECUTABLE}"
                 "${CMAKE_CURRENT_SOURCE_DIR}/tests/run_gl_readback_region.py"
                 --fixture "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_gl_readback_region.c"
-                --compiler-bin "${_gl_test_compiler_bin}"
+                --compiler-bin "${PSX_GL_READBACK_COMPILER_BIN}"
                 --sdl-root "${PSX_GL_READBACK_SDL_ROOT}"
                 --output "${CMAKE_CURRENT_BINARY_DIR}/gl-readback-results")
         set_tests_properties(gl_readback_region_test PROPERTIES LABELS "gpu;opengl;hardware" TIMEOUT 180)
     else()
-        message(STATUS "gl_readback_region_test: not registered (requires MinGW and PSX_GL_READBACK_SDL_ROOT)")
+        message(STATUS "gl_readback_region_test: not registered (requires MinGW, PSX_GL_READBACK_SDL_ROOT and gcc.exe/g++.exe in PSX_GL_READBACK_COMPILER_BIN)")
     endif()
     add_executable(launcher_device_roundtrip_test
         tests/test_launcher_device_roundtrip.cpp)

--- a/runtime/src/gpu_gl_renderer.c
+++ b/runtime/src/gpu_gl_renderer.c
@@ -2544,7 +2544,10 @@ static void depth24_clear_skipped_fb(void) {
     glDisable(GL_SCISSOR_TEST);
     p_glBindFramebuffer(PSXGL_FRAMEBUFFER, 0);
     rect_add(&s_pack_dirty, x0, y0, x1, y1);
-    if (!s_cpu_auth_dual) rect_add(&s_cpu_dirty, x0, y0, x1, y1);
+    if (!s_cpu_auth_dual) {
+        rect_add(&s_cpu_dirty, x0, y0, x1, y1);
+        s_gpu_dirty = 1; /* The clear must reach an immediate CPU read too. */
+    }
     present_dirty_rect(x0, y0, x1, y1, 1);
     rect_clear(&s_d24_skip_fb);
 }

--- a/runtime/src/gpu_gl_renderer.c
+++ b/runtime/src/gpu_gl_renderer.c
@@ -119,6 +119,7 @@
 #define PSXGL_FUNC_REVERSE_SUBTRACT 0x800B
 #define PSXGL_CONSTANT_ALPHA        0x8003
 #define PSXGL_UNPACK_ROW_LENGTH     0x0CF2
+#define PSXGL_PACK_ROW_LENGTH       0x0D02
 #define PSXGL_SRC1_ALPHA            0x8589
 
 #ifndef APIENTRY
@@ -442,6 +443,7 @@ static int           s_gpu_dirty = 0;      /* CPU VRAM array may be stale    */
 
 /* Dirty-rect unions, native VRAM coords, inclusive bounds. */
 typedef struct { int x0, y0, x1, y1, set; } DirtyRect;
+static DirtyRect s_cpu_dirty; /* conservative GPU-written area not yet read into CPU VRAM */
 static DirtyRect s_pack_dirty;             /* hr FBO content not in raw mirror */
 
 /* CPU writes not yet in the FBO — an EXACT rect list, NOT a single union.
@@ -1528,6 +1530,7 @@ static void ensure_cpu(void) {
      * Never glReadPixels — that forked peer snaps/resim. */
     if (s_cpu_auth_dual || psx_netplay_active()) {
         s_gpu_dirty = 0;
+        rect_clear(&s_cpu_dirty);
         return;
     }
     flush_flat_batch();
@@ -1535,10 +1538,22 @@ static void ensure_cpu(void) {
     flush_cpu_upload();
     pack_flush();
     p_glBindFramebuffer(PSXGL_READ_FRAMEBUFFER, s_raw_fbo);
-    glReadPixels(0, 0, VRAM_W, VRAM_H, PSXGL_RED_INTEGER, GL_UNSIGNED_SHORT, s_vram);
+    /* CPU uploads have already landed; raw packing preserves command order.
+     * A union is safe for readback (GPU -> CPU), unlike CPU upload unions.
+     * Do not reuse s_pack_dirty: texture sampling can consume it before CPU reads. */
+    int rx = s_cpu_dirty.set ? s_cpu_dirty.x0 : 0;
+    int ry = s_cpu_dirty.set ? s_cpu_dirty.y0 : 0;
+    int rw = s_cpu_dirty.set ? s_cpu_dirty.x1 - rx + 1 : VRAM_W;
+    int rh = s_cpu_dirty.set ? s_cpu_dirty.y1 - ry + 1 : VRAM_H;
+    glPixelStorei(PSXGL_PACK_ROW_LENGTH, VRAM_W);
+    glReadPixels(rx, ry, rw, rh, PSXGL_RED_INTEGER, GL_UNSIGNED_SHORT,
+                 s_vram + (size_t)ry * VRAM_W + rx);
+    glPixelStorei(PSXGL_PACK_ROW_LENGTH, 0);
     p_glBindFramebuffer(PSXGL_READ_FRAMEBUFFER, 0);
     s_gpu_dirty = 0;
-    coh_record(GL_COH_ENSURE, 0, 0, VRAM_W - 1, VRAM_H - 1);
+    rect_clear(&s_cpu_dirty);
+    coh_record(GL_COH_ENSURE, rx, ry, rx + rw - 1, ry + rh - 1);
+
 }
 
 /* ---- GPU primitives ------------------------------------------------------ */
@@ -1569,6 +1584,7 @@ static void mark_prim_dirty(const int *xs, const int *ys, int n, int textured) {
     if (x1 > s_area_x2) x1 = s_area_x2;
     if (y1 > s_area_y2) y1 = s_area_y2;
     rect_add(&s_pack_dirty, x0, y0, x1, y1);
+    if (!s_cpu_auth_dual) rect_add(&s_cpu_dirty, x0, y0, x1, y1);
     /* Dual-raster keeps CPU current via SW writes — do not mark GPU-ahead. */
     if (!s_cpu_auth_dual)
         s_gpu_dirty = 1;
@@ -2205,6 +2221,7 @@ static void fill_segment(int x, int y, int w, int h, float r, float g, float b) 
     glStencilMask(0xFF);
     glClear(GL_COLOR_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
     rect_add(&s_pack_dirty, x, y, x + w - 1, y + h - 1);
+    if (!s_cpu_auth_dual) rect_add(&s_cpu_dirty, x, y, x + w - 1, y + h - 1);
 }
 
 static void gpu_fill(int x,int y,int w,int h,uint16_t c) {
@@ -2287,6 +2304,7 @@ static void gpu_copy_rect(int sx,int sy,int dx,int dy,int w,int h) {
     hr_end();
 
     rect_add(&s_pack_dirty, dx, dy, dx + w - 1, dy + h - 1);
+    if (!s_cpu_auth_dual) rect_add(&s_cpu_dirty, dx, dy, dx + w - 1, dy + h - 1);
     if (!s_cpu_auth_dual)
         s_gpu_dirty = 1;
     coh_record(GL_COH_COPY_SRC, sx, sy, sx + w - 1, sy + h - 1);
@@ -2526,6 +2544,7 @@ static void depth24_clear_skipped_fb(void) {
     glDisable(GL_SCISSOR_TEST);
     p_glBindFramebuffer(PSXGL_FRAMEBUFFER, 0);
     rect_add(&s_pack_dirty, x0, y0, x1, y1);
+    if (!s_cpu_auth_dual) rect_add(&s_cpu_dirty, x0, y0, x1, y1);
     present_dirty_rect(x0, y0, x1, y1, 1);
     rect_clear(&s_d24_skip_fb);
 }
@@ -2896,6 +2915,7 @@ static int init_gpu_raster(void) {
     s_up_nrects = 0;
     up_add(0, 0, VRAM_W - 1, VRAM_H - 1);
     s_gpu_dirty = 0;
+    rect_clear(&s_cpu_dirty);
     s_stencil_valid = 1;
     for (int i = 0; i < PRES_ROWS; i++) s_present_dirty[i] = ~0ull;
     s_last_present_path = -1;
@@ -3181,14 +3201,18 @@ void gl_renderer_restage_vram_after_savestate(void) {
         depth24_mark_scanout_band();
     }
     /* Dual-raster: CPU is authority after snap; FBO is cosmetics only. */
-    if (s_cpu_auth_dual)
+    if (s_cpu_auth_dual) {
         s_gpu_dirty = 0;
+        rect_clear(&s_cpu_dirty);
+    }
 }
 
 void gl_renderer_set_cpu_auth_dual(int on) {
     s_cpu_auth_dual = on ? 1 : 0;
-    if (s_cpu_auth_dual)
+    if (s_cpu_auth_dual) {
         s_gpu_dirty = 0;
+        rect_clear(&s_cpu_dirty);
+    }
 }
 
 int gl_renderer_cpu_auth_dual(void) {

--- a/runtime/tests/run_gl_readback_region.py
+++ b/runtime/tests/run_gl_readback_region.py
@@ -36,11 +36,15 @@ def main():
     for name in ("gcc.exe", "g++.exe"):
         if not (compiler / name).is_file():
             parser.error(f"--compiler-bin must contain {name}: {compiler}")
+    sdl = pathlib.Path(args.sdl_root).resolve()
+    if not (sdl / "sdl3-src/include").is_dir():
+        parser.error(f"--sdl-root must contain the sdl3-src/include directory: {sdl}")
+    if not (sdl / "sdl3-build/libSDL3.a").is_file():
+        parser.error(f"--sdl-root must contain sdl3-build/libSDL3.a: {sdl}")
     output = pathlib.Path(args.output).resolve()
     output.mkdir(parents=True, exist_ok=True)
     dest = pathlib.Path(tempfile.mkdtemp(prefix="readback-", dir=output))
     print("Evidence directory:", dest)
-    sdl = pathlib.Path(args.sdl_root).resolve()
     env = os.environ.copy()
     env["PATH"] = str(compiler) + os.pathsep + env.get("PATH", "")
     if args.gl_source:

--- a/runtime/tests/run_gl_readback_region.py
+++ b/runtime/tests/run_gl_readback_region.py
@@ -1,25 +1,84 @@
-import pathlib,subprocess,json,os,sys,argparse,shutil,tempfile
-parser=argparse.ArgumentParser(description="Run hidden real-GL source-owned readback tests")
-parser.add_argument('--compiler-bin',required=True);parser.add_argument('--sdl-root',required=True)
-parser.add_argument('--output',required=True);parser.add_argument('--gl-source')
-parser.add_argument('--fixture',type=pathlib.Path)
-parser.add_argument('--expect-unbounded',action='store_true');args=parser.parse_args()
-F=pathlib.Path(__file__).resolve().parents[2]
-output=pathlib.Path(args.output).resolve();output.mkdir(parents=True,exist_ok=True)
-D=pathlib.Path(tempfile.mkdtemp(prefix='readback-',dir=output))
-print('Evidence directory:',D)
-old=pathlib.Path(args.sdl_root).resolve();T=pathlib.Path(args.compiler_bin).resolve();env=os.environ.copy();env['PATH']=str(T)+os.pathsep+env['PATH']
-if args.gl_source:shutil.copyfile(args.gl_source,D/'gpu_gl_renderer.c')
-inc=['-I',str(D),'-I',str(F/'runtime/include'),'-I',str(F/'runtime/src'),'-I',str(old/'sdl3-src/include')];receipt=[]
-def run(cmd):
- p=subprocess.run([str(x) for x in cmd],cwd=D,capture_output=True,text=True,errors='replace',env=env);receipt.append({'cmd':[str(x) for x in cmd],'exit':p.returncode,'stdout':p.stdout,'stderr':p.stderr});(D/'receipt.json').write_text(json.dumps(receipt,indent=2));print(p.stdout[-600:],p.stderr[-2000:]);return p.returncode
-for name,src in [('probe',args.fixture or F/'runtime/tests/test_gl_readback_region.c'),('sw',F/'runtime/src/gpu_sw_renderer.c')]:
- if run([T/'gcc.exe','-std=c11','-O2','-flto','-DPSX_SDL3=1','-DPSX_NO_DEBUG_TOOLS=1',*inc,'-c',src,'-o',D/(name+'.o')]):sys.exit(2)
-libs=['m','kernel32','user32','gdi32','winmm','imm32','ole32','oleaut32','version','uuid','advapi32','setupapi','shell32','dinput8','opengl32']
-if run([T/'g++.exe','-O2','-flto',D/'probe.o',D/'sw.o',old/'sdl3-build/libSDL3.a',*['-l'+x for x in libs],'-o',D/'probe.exe']):sys.exit(2)
-# Test windows are hidden. No host-specific priority or affinity policy.
-for scale in [1,4]:
- code=run([D/'probe.exe',str(scale)])
- expected=1 if args.expect_unbounded else 0
- if code!=expected:sys.exit(1)
- if args.expect_unbounded and 'failures=1' not in receipt[-1]['stdout']:sys.exit(1)
+"""Run source-owned readback checks with a hidden real OpenGL context."""
+import argparse
+import json
+import os
+import pathlib
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+
+
+def probe_result_ok(code, stdout, stderr, expect_unbounded=False):
+    lines = stdout.rstrip().splitlines()
+    summary = re.fullmatch(r"checks=(\d+) failures=(\d+)", lines[-1]) if lines else None
+    if not summary or int(summary[1]) == 0:
+        return False
+    failures = [line for line in stderr.splitlines() if line.startswith("FAIL ")]
+    if expect_unbounded:
+        return (code == 1 and int(summary[2]) == 1 and
+                failures == ["FAIL single-pixel bounded transfer"])
+    return code == 0 and int(summary[2]) == 0 and not failures
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--compiler-bin", required=True)
+    parser.add_argument("--sdl-root", required=True)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--gl-source")
+    parser.add_argument("--fixture", type=pathlib.Path)
+    parser.add_argument("--expect-unbounded", action="store_true")
+    args = parser.parse_args()
+    framework = pathlib.Path(__file__).resolve().parents[2]
+    compiler = pathlib.Path(args.compiler_bin).resolve()
+    for name in ("gcc.exe", "g++.exe"):
+        if not (compiler / name).is_file():
+            parser.error(f"--compiler-bin must contain {name}: {compiler}")
+    output = pathlib.Path(args.output).resolve()
+    output.mkdir(parents=True, exist_ok=True)
+    dest = pathlib.Path(tempfile.mkdtemp(prefix="readback-", dir=output))
+    print("Evidence directory:", dest)
+    sdl = pathlib.Path(args.sdl_root).resolve()
+    env = os.environ.copy()
+    env["PATH"] = str(compiler) + os.pathsep + env.get("PATH", "")
+    if args.gl_source:
+        shutil.copyfile(args.gl_source, dest / "gpu_gl_renderer.c")
+    includes = ["-I", str(dest), "-I", str(framework / "runtime/include"),
+                "-I", str(framework / "runtime/src"), "-I", str(sdl / "sdl3-src/include")]
+    receipt = []
+
+    def run(command):
+        command = [str(value) for value in command]
+        result = subprocess.run(command, cwd=dest, capture_output=True,
+                                text=True, encoding="utf-8", errors="replace", env=env)
+        receipt.append({"cmd": command, "exit": result.returncode,
+                        "stdout": result.stdout, "stderr": result.stderr})
+        (dest / "receipt.json").write_text(json.dumps(receipt, indent=2), encoding="utf-8")
+        print(result.stdout[-600:], result.stderr[-2000:])
+        return result
+
+    fixture = args.fixture or framework / "runtime/tests/test_gl_readback_region.c"
+    for name, source in [("probe", fixture), ("sw", framework / "runtime/src/gpu_sw_renderer.c")]:
+        if run([compiler / "gcc.exe", "-std=c11", "-O2", "-flto", "-DPSX_SDL3=1",
+                "-DPSX_NO_DEBUG_TOOLS=1", *includes, "-c", source,
+                "-o", dest / (name + ".o")]).returncode:
+            return 2
+    libraries = ["m", "kernel32", "user32", "gdi32", "winmm", "imm32", "ole32",
+                 "oleaut32", "version", "uuid", "advapi32", "setupapi", "shell32",
+                 "dinput8", "opengl32"]
+    if run([compiler / "g++.exe", "-O2", "-flto", dest / "probe.o", dest / "sw.o",
+            sdl / "sdl3-build/libSDL3.a", *["-l" + name for name in libraries],
+            "-o", dest / "probe.exe"]).returncode:
+        return 2
+    for scale in (1, 4):
+        result = run([dest / "probe.exe", scale])
+        if not probe_result_ok(result.returncode, result.stdout, result.stderr,
+                               args.expect_unbounded):
+            return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/runtime/tests/run_gl_readback_region.py
+++ b/runtime/tests/run_gl_readback_region.py
@@ -1,0 +1,25 @@
+import pathlib,subprocess,json,os,sys,argparse,shutil,tempfile
+parser=argparse.ArgumentParser(description="Run hidden real-GL source-owned readback tests")
+parser.add_argument('--compiler-bin',required=True);parser.add_argument('--sdl-root',required=True)
+parser.add_argument('--output',required=True);parser.add_argument('--gl-source')
+parser.add_argument('--fixture',type=pathlib.Path)
+parser.add_argument('--expect-unbounded',action='store_true');args=parser.parse_args()
+F=pathlib.Path(__file__).resolve().parents[2]
+output=pathlib.Path(args.output).resolve();output.mkdir(parents=True,exist_ok=True)
+D=pathlib.Path(tempfile.mkdtemp(prefix='readback-',dir=output))
+print('Evidence directory:',D)
+old=pathlib.Path(args.sdl_root).resolve();T=pathlib.Path(args.compiler_bin).resolve();env=os.environ.copy();env['PATH']=str(T)+os.pathsep+env['PATH']
+if args.gl_source:shutil.copyfile(args.gl_source,D/'gpu_gl_renderer.c')
+inc=['-I',str(D),'-I',str(F/'runtime/include'),'-I',str(F/'runtime/src'),'-I',str(old/'sdl3-src/include')];receipt=[]
+def run(cmd):
+ p=subprocess.run([str(x) for x in cmd],cwd=D,capture_output=True,text=True,errors='replace',env=env);receipt.append({'cmd':[str(x) for x in cmd],'exit':p.returncode,'stdout':p.stdout,'stderr':p.stderr});(D/'receipt.json').write_text(json.dumps(receipt,indent=2));print(p.stdout[-600:],p.stderr[-2000:]);return p.returncode
+for name,src in [('probe',args.fixture or F/'runtime/tests/test_gl_readback_region.c'),('sw',F/'runtime/src/gpu_sw_renderer.c')]:
+ if run([T/'gcc.exe','-std=c11','-O2','-flto','-DPSX_SDL3=1','-DPSX_NO_DEBUG_TOOLS=1',*inc,'-c',src,'-o',D/(name+'.o')]):sys.exit(2)
+libs=['m','kernel32','user32','gdi32','winmm','imm32','ole32','oleaut32','version','uuid','advapi32','setupapi','shell32','dinput8','opengl32']
+if run([T/'g++.exe','-O2','-flto',D/'probe.o',D/'sw.o',old/'sdl3-build/libSDL3.a',*['-l'+x for x in libs],'-o',D/'probe.exe']):sys.exit(2)
+# Test windows are hidden. No host-specific priority or affinity policy.
+for scale in [1,4]:
+ code=run([D/'probe.exe',str(scale)])
+ expected=1 if args.expect_unbounded else 0
+ if code!=expected:sys.exit(1)
+ if args.expect_unbounded and 'failures=1' not in receipt[-1]['stdout']:sys.exit(1)

--- a/runtime/tests/test_gl_readback_region.c
+++ b/runtime/tests/test_gl_readback_region.c
@@ -7,8 +7,9 @@ void gpu_vram_dirty_mark_row_impl(uint32_t y){}
 void gpu_vram_dirty_mark_rect(int x,int y,int w,int h){}
 void gpu_vram_dirty_mark_all(void){}
 int psx_netplay_active(void){return 0;}
-int gpu_display_is_depth24(void){return 0;}
-void gpu_get_display_info(GpuDisplayInfo *out){memset(out,0,sizeof(*out));}
+static int test_depth24;
+int gpu_display_is_depth24(void){return test_depth24;}
+void gpu_get_display_info(GpuDisplayInfo *out){memset(out,0,sizeof(*out));out->display_x=32;out->display_y=32;out->width=320;out->height=16;}
 int psx_ws_prim_in_backdrop(void){return 0;}
 int g_ws_tex_edge_pct=0;
 int psx_ws_prim_is_tagged(void){return 0;}
@@ -60,7 +61,17 @@ int main(int argc,char **argv){
  glb_set_draw_area(0,0,1023,511);glb_draw_flat_rect(320,320,8,8,0x4444);
  for(int i=0;i<1024*512;i++)image[i]=(uint16_t)((i*23)&0x7fff);
  gl_renderer_restage_vram_after_savestate();verify("state restage with pending draw");
- check(image[511*1024+1020]==oracle[511*1024+1020],"edge preserved");
+ /* Existing depth24 policy clears the skipped movie band on return to15-bit.
+  * That GPU write must become visible without waiting for another primitive. */
+ static uint16_t movie[480*16], texture[4]={0x3210,0x3210,0x3210,0x3210};
+ for(int i=0;i<480*16;i++)movie[i]=0x1234;
+ test_depth24=1;depth24_upload_policy();
+ glb_vram_transfer_in(32,32,480,16,movie);
+ glb_vram_transfer_in(33,33,2,2,texture);
+ test_depth24=0;depth24_upload_policy();
+ check(glb_vram_read(40,40)==0,"depth24 cleared band immediate CPU read");
+ check(glb_vram_read(33,33)==0x3210,"newer overlapping texture survives clear");
+ verify("depth24 leave coherence without subsequent primitive");
  printf("checks=%d failures=%d\n",checks,failures);
  gl_renderer_shutdown();SDL_DestroyWindow(win);SDL_Quit();return failures?1:0;
 }

--- a/runtime/tests/test_gl_readback_region.c
+++ b/runtime/tests/test_gl_readback_region.c
@@ -1,0 +1,66 @@
+/* Original source-owned GL readback-coherence regression. No retail payload. */
+#include "gpu_gl_renderer.c"
+static uint16_t image[1024*512], oracle[1024*512];
+int g_psx_vram_dirty_tracking=0;
+uint64_t s_frame_count=0;
+void gpu_vram_dirty_mark_row_impl(uint32_t y){}
+void gpu_vram_dirty_mark_rect(int x,int y,int w,int h){}
+void gpu_vram_dirty_mark_all(void){}
+int psx_netplay_active(void){return 0;}
+int gpu_display_is_depth24(void){return 0;}
+void gpu_get_display_info(GpuDisplayInfo *out){memset(out,0,sizeof(*out));}
+int psx_ws_prim_in_backdrop(void){return 0;}
+int g_ws_tex_edge_pct=0;
+int psx_ws_prim_is_tagged(void){return 0;}
+void gpu_depth24_upload_span_reset(void){}
+void frame_interpolation_schedule_reset(FrameInterpolationSchedule *p){memset(p,0,sizeof(*p));}
+static int checks,failures;
+static void check(int ok,const char *label){checks++;if(!ok){fprintf(stderr,"FAIL %s\n",label);failures++;}}
+static void verify(const char *label){
+ gl_renderer_sync_cpu();
+ check(gl_renderer_fbo_peek(0,0,1024,512,oracle),"oracle read");
+ int n=0;for(int i=0;i<1024*512;i++)n+=image[i]!=oracle[i];
+ if(n)fprintf(stderr,"%s: %d native words differ\n",label,n);
+ check(n==0,label);check(glGetError()==GL_NO_ERROR,"GL error");
+}
+int main(int argc,char **argv){
+ int scale=argc>1?atoi(argv[1]):1;
+ if(SDL_Init(SDL_INIT_VIDEO)!=0)return 2;
+ SDL_Window *win=SDL_CreateWindow("Readback coherence hidden test",0,0,128,128,SDL_WINDOW_OPENGL|SDL_WINDOW_HIDDEN);
+ if(!win)return 2;
+ for(int i=0;i<1024*512;i++)image[i]=(uint16_t)((i*17)&0x7fff);
+ glb_init(image);glb_set_scale(scale);gl_renderer_set_swap_interval(0);
+ if(!gl_renderer_init_context(win))return 2;
+ printf("driver=%s renderer=%s scale=%d\n",glGetString(GL_VERSION),glGetString(GL_RENDERER),scale);
+ glb_set_draw_area(0,0,1023,511);glb_set_mask_bits(0,0);glb_set_semi_transparency(0,0);glb_set_color_modulation(128,128,128,1);
+ verify("initial upload");
+ glb_draw_flat_rect(1020,511,1,1,0x7fff);
+ check(glb_vram_read(1020,511)==0x7fff,"test pixel value");
+ GlCohEvent event;int found=0;
+ for(uint64_t i=gl_renderer_coh_total();i>0&&i+32>gl_renderer_coh_total();){i--;if(gl_renderer_coh_get(i,&event)&&event.kind==GL_COH_ENSURE){found=1;break;}}
+ check(found,"readback event");check(found&&(event.x1-event.x0+1)*(event.y1-event.y0+1)<=4,"single-pixel bounded transfer");
+ verify("single pixel + unchanged background");
+ for(int row=0;row<8;row++){
+  glb_draw_flat_rect(13,17+row*9,7,3,0x1234+row);
+  glb_vram_write(23,20+row*9,0x7654);verify("odd coordinates width and row stride");
+ }
+ glb_draw_flat_rect(40,40,16,16,0x4321);glb_vram_write(900,400,0x7117);glb_draw_flat_rect(600,410,13,7,0x2222);verify("disjoint upload inside readback union");
+ glb_draw_flat_rect(512,0,16,16,0x1234);
+ glb_draw_textured_rect(90,90,16,16,0,0,0,0,0x108);verify("texture pack does not clear CPU debt");
+ glb_fill_rect(1016,508,24,8,0x3210);verify("wrapping fill");
+ glb_copy_rect(40,40,42,41,12,12);verify("overlapping copy");
+ for(int mode=0;mode<4;mode++){
+  glb_set_mask_bits(1,0);glb_draw_flat_rect(111,151,7,3,0x4567);
+  glb_set_mask_bits(0,1);glb_draw_flat_rect(109,150,12,6,0x2222);
+  glb_set_mask_bits(0,0);glb_set_semi_transparency(1,mode);glb_draw_flat_rect(108,149,14,8,0x1123);glb_set_semi_transparency(0,0);verify("mask and blend");
+ }
+ glb_set_precise_triangle(1,31*65536+49152,201*65536+49152,63*65536+49152,201*65536+49152,31*65536+49152,219*65536+49152);
+ glb_draw_flat_triangle(31,201,63,201,31,219,0x7abc);verify("precision bound margin");
+ glb_set_draw_area(11,11,19,19);glb_draw_flat_rect(0,0,32,32,0x5aaa);verify("clipped primitive");
+ glb_set_draw_area(0,0,1023,511);glb_draw_flat_rect(320,320,8,8,0x4444);
+ for(int i=0;i<1024*512;i++)image[i]=(uint16_t)((i*23)&0x7fff);
+ gl_renderer_restage_vram_after_savestate();verify("state restage with pending draw");
+ check(image[511*1024+1020]==oracle[511*1024+1020],"edge preserved");
+ printf("checks=%d failures=%d\n",checks,failures);
+ gl_renderer_shutdown();SDL_DestroyWindow(win);SDL_Quit();return failures?1:0;
+}

--- a/runtime/tests/test_gl_readback_runner.py
+++ b/runtime/tests/test_gl_readback_runner.py
@@ -1,0 +1,36 @@
+import unittest
+from run_gl_readback_region import probe_result_ok
+
+
+class ProbeResultTest(unittest.TestCase):
+    def test_success(self):
+        self.assertTrue(probe_result_ok(0, "driver=GL\nchecks=67 failures=0\n", ""))
+
+    def test_exact_negative(self):
+        self.assertTrue(probe_result_ok(1, "checks=67 failures=1\n",
+                                       "FAIL single-pixel bounded transfer\n", True))
+
+    def test_negative_rejects_other_counts(self):
+        for count in (0, 10, 11, 100, 199):
+            with self.subTest(count=count):
+                self.assertFalse(probe_result_ok(1, f"checks=67 failures={count}\n",
+                                                "FAIL single-pixel bounded transfer\n", True))
+
+    def test_negative_requires_expected_failure(self):
+        for error in ("", "FAIL GL error\n", "FAIL single-pixel bounded transfer\nFAIL other\n"):
+            self.assertFalse(probe_result_ok(1, "checks=67 failures=1\n", error, True))
+
+    def test_rejects_missing_or_malformed_summary(self):
+        for text in ("", "checks=67 failures=1 extra", "checks=0 failures=0",
+                     "checks=67 failures=0\ntrailing text", "checks=67 failures=10"):
+            self.assertFalse(probe_result_ok(0, text, ""))
+
+    def test_rejects_exit_and_error_mismatch(self):
+        self.assertFalse(probe_result_ok(1, "checks=67 failures=0", ""))
+        self.assertFalse(probe_result_ok(0, "checks=67 failures=0", "FAIL other"))
+        self.assertFalse(probe_result_ok(0, "checks=67 failures=1",
+                                        "FAIL single-pixel bounded transfer", True))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
A tiny GPU write followed by a CPU read currently copies all 524,288 native words. Keep a separate conservative rectangle for GPU writes that have not reached the CPU array, then read that region with an explicit full-image row stride. Uploads, queued draws and packing still complete in order. Texture packing must not erase CPU readback debt. Raster values, clocks, precision and GPU ownership remain unchanged.

Fork review: https://github.com/Alexbeav/psxrecomp/pull/23. Cubic completed the exact-head check 101476046529 with zero new issues. All earlier findings are resolved in source or explicitly reconciled in the review replies; prior review jobs are terminal. The public branch is identical to this reviewed head.

Base `155e269ba5d50fe36523846f908cf124dc1561a0`; tested/reviewed head `e57d9b9f4fd220be6f65825282329215f8109a6f`; four focused commits; 6 changed files:

- `docs/GPU_GL_READBACK_REGIONS.md`
- `runtime/CMakeLists.txt`
- `runtime/src/gpu_gl_renderer.c`
- `runtime/tests/run_gl_readback_region.py`
- `runtime/tests/test_gl_readback_region.c`
- `runtime/tests/test_gl_readback_runner.py`

The renderer change owns coherence; the C fixture verifies native pixels and transfer size; the Python wrapper runs the real hidden GL context; CMake registers the optional hardware test; documentation states the invariant and limitations. No title configuration, private route tooling or retail payload is included.

Validation on this review head, Windows x64 / WinLibs GCC 16.1 / RTX 4070 Ti, NVIDIA 610.88:

- Runtime CTest: 70 enabled pass; 2 pre-existing disabled. This includes 71 real OpenGL checks at native and 4x. Every native word matches full hardware readback after each ordered synthetic workload. The earlier 67-check fixture against pristine upstream passed pixel comparisons and failed only the small-transfer assertion at both scales. The expanded fixture also detects stale CPU words after a depth24 exit: the pre-fix source failed 2 checks with 7,676 differing words. The new head passes, including an immediate read and a newer overlapping texture upload. A negative run that has this coherence error is rejected, not treated as an expected bandwidth failure. This is coherence equivalence using the same hardware rasterizer, not independent raster accuracy.
- Configure runtime with `-DBUILD_TESTING=ON -DPSX_GL_READBACK_SDL_ROOT=<SDL3-deps>` on MinGW, then `ctest --test-dir <runtime-build> -R gl_readback_region_test --output-on-failure`. Six parser unit tests reject malformed summaries, wrong exits and unexpected negative failures. The dependency root contains `sdl3-src/include` and `sdl3-build/libSDL3.a`. `PSX_GL_READBACK_COMPILER_BIN` can select GCC for a Clang/MinGW project; configure checks both compiler executables before hardware registration. Missing/restored compiler cases were verified. Both configure and runner reject missing SDL headers/static library before building; a bad dependency root is not counted as a hardware pass. The wrapper also accepts `--compiler-bin`, `--sdl-root`, `--output`; it has no fixed CPU affinity or priority and retains a fresh receipt directory on repeated runs. Other platforms are not qualified by this hardware runner.
- Recompiler sources are identical to the interlace review branch. Its broader suite passes 58/61 enabled tests, with 3 disabled. Three failures reproduce from pristine upstream source: `dirty_text_continuation_guards` stale source fragment, `release_zip` Windows LF expectation, `aot_overlay_discovery` hardcoded MSYS gcc subprocess. Python tests use PYTHONUTF8=1.
- Exact standalone head: owned Timeshock USA SLUS-00639 current-base table checkpoint loads, accepts player actions, continues ball/flipper play, then exits normally at frame 1398. This does not establish frontend startup: the title requires the separate interlace correction in https://github.com/mstan/psxrecomp/pull/327.
- Separate combined integration `96928d118bdcce574947052b4053153717eb28ac` contains the interlace correction plus this exact GL runtime change. Its fresh native OpenGL game-frontend route starts a player game, launches the ball, demonstrates flipper/ball play and closes normally at frame 6925. It is not this standalone review head. The final interlace contribution is https://github.com/mstan/psxrecomp/pull/327 at a later reviewed head; this earlier combined route is not qualification of that final union. Current runs establish route correctness only under host GPU load, not a new speed result.

The game is a private local port. Owned generated game/SCPH5552 code is reused unchanged; no emitter-regeneration claim. Current public recomp-ui/master 773155ae lacks lobby/spectator fields used by upstream runtime, so these GPU retail tests use supported `PSX_RECOMP_UI=OFF` direct launch. No launcher compatibility, broad save/load, netplay, full depth24 playback, Vulkan, full-game or audio-wide acceptance is implied. Consumer runtime pin update is required; this correction does not require code regeneration. The two corrections can merge independently. Timeshock frontend startup requires the interlace correction.

Developed with AI assistance; validated as described (test evidence in PR body). AI writes the code and the PR, but I always test before I send something up. Happy to iterate on this process with your feedback.
