### PR TITLE
Preserve CUE track metadata at launch

### DIFF
--- a/docs/LAUNCH_DISC_PATH.md
+++ b/docs/LAUNCH_DISC_PATH.md
@@ -1,0 +1,14 @@
+# Launch disc selection
+
+The launch adapter uses the existing disc-path resolver before mounting player media.
+A usable CUE remains selected and retains its track metadata; a raw image can resolve to its owning CUE.
+Unaccompanied raw images, CHD, and the existing unusable-CUE fallback retain their resolver behavior.
+
+The source-owned `runtime/tests/test_launch_disc_path.py` extracts the exact production adapter and compiles it with the production resolver and CUE parser.
+Eight synthetic cases cover 12-track mixed media, eight-track audio-only media, CUE and BIN entry points, raw-only, CHD passthrough, broken CUE fallback, and missing files.
+The original adapter loses the track map in four cases; the correction passes all eight and checks each track number, audio/data type, and start position.
+This is an adapter/parser regression; it does not establish full controller behavior or game playback.
+
+Local corpus: PSX-CD-012, with Vib-Ribbon and Wipeout XL as two consumers.
+Exact-title web searches found audio conversion tools and emulator issues but no applicable earlier PSXRecomp launch-adapter repair.
+Use the existing resolver rather than introducing another CUE parser.

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -562,6 +562,9 @@ if(BUILD_TESTING)
 
     find_package(Python3 COMPONENTS Interpreter)
     if(Python3_Interpreter_FOUND)
+        if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+            add_test(NAME launch_disc_path_test COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_launch_disc_path.py --compiler ${CMAKE_CXX_COMPILER})
+        endif()
         add_test(NAME disc_companion_test COMMAND ${Python3_EXECUTABLE} ${PSXRECOMP_ROOT}/tools/tests/test_disc_companion.py)
         add_test(NAME sbi_registry_test COMMAND ${Python3_EXECUTABLE} ${PSXRECOMP_ROOT}/tools/tests/test_sbi_registry.py)
         add_test(NAME frame_interpolation_context_ownership_test

--- a/runtime/src/main.cpp
+++ b/runtime/src/main.cpp
@@ -2383,27 +2383,8 @@ static bool validate_disc_for_launch(const std::filesystem::path& path,
 }
 
 static std::filesystem::path normalize_disc_path_for_launch(const std::filesystem::path& path) {
-    namespace fs = std::filesystem;
-    std::error_code ec;
-    fs::path p = fs::absolute(path, ec);
-    if (ec) p = path;
-
-    if (uppercase_ascii(p.extension().string()) == ".CUE") {
-        fs::path bin = p;
-        bin.replace_extension(".bin");
-        if (fs::exists(bin, ec)) {
-            fs::path abs = fs::absolute(bin, ec);
-            return ec ? bin : abs;
-        }
-        ec.clear();
-        bin.replace_extension(".BIN");
-        if (fs::exists(bin, ec)) {
-            fs::path abs = fs::absolute(bin, ec);
-            return ec ? bin : abs;
-        }
-    }
-
-    return p;
+    // Keep the resolver's mount path so a usable CUE retains its track map.
+    return PSXRecompV4::resolve_disc_path(path).mount;
 }
 
 /* Which image of a MULTI-DISC set to mount, given the roster this build was
@@ -2417,15 +2398,13 @@ static std::filesystem::path normalize_disc_path_for_launch(const std::filesyste
  * who browsed for their own copy of the selected disc is still honoured,
  * because a relocated or container-swapped image keeps its stem -- a Redump
  * dump names the disc in the file name and only the extension moves
- * (".. (Disc 2).cue" -> ".. (Disc 2).bin", which is exactly the substitution
- * normalize_disc_path_for_launch performs).
+ * (".. (Disc 2).cue" and ".. (Disc 2).bin" identify the same disc).
+ * normalize_disc_path_for_launch preserves the resolver's mount path.
  *
  * Single-disc titles (roster of 0 or 1) are returned unchanged: the persisted
  * path wins, exactly as it did before any of this existed. */
-/* Roster position of `disc`, or -1. Stem-compared for the same reason
- * resolve_selected_disc() is: the roster holds .cue entries while everything
- * downstream has already been through normalize_disc_path_for_launch(), which
- * swaps a .cue for its .bin. */
+/* Roster position of `disc`, or -1. Compare stems so the roster can identify
+ * equivalent CUE and raw-image selections after disc-path resolution. */
 static int roster_index_for_disc(
     const std::vector<std::filesystem::path>& roster,
     const std::filesystem::path& disc) {

--- a/runtime/tests/test_launch_disc_path.py
+++ b/runtime/tests/test_launch_disc_path.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Compile the actual launcher adapter and check its mounted CUE track map."""
+import argparse
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--compiler', default=os.environ.get('CXX', 'c++'))
+    args = parser.parse_args()
+    root = Path(__file__).resolve().parents[1]
+    text = (root / 'src/main.cpp').read_text(encoding='utf-8')
+    start = text.index('static std::filesystem::path normalize_disc_path_for_launch(')
+    end = text.index('\n}\n', start) + 2
+    adapter = text[start:end]
+    with tempfile.TemporaryDirectory(prefix='launch disc path ') as tmp:
+        work = Path(tmp)
+        source = work / 'probe.cpp'
+        source.write_text('''#include <filesystem>
+#include <string>
+#include <cctype>
+#include <iostream>
+#include "disc_path.h"
+#include "cue_sheet.h"
+static std::string uppercase_ascii(std::string s) {
+    for (char& c : s) c = (char)std::toupper((unsigned char)c);
+    return s;
+}
+''' + adapter + '''
+int main(int argc, char** argv) {
+    for (int i = 1; i < argc; ++i) {
+        const auto mount = normalize_disc_path_for_launch(argv[i]);
+        const auto cue = PSXRecompV4::parse_cue_sheet(mount);
+        std::cout << mount.filename().generic_string() << "|" << cue.tracks.size();
+        for (const auto& track : cue.tracks)
+            std::cout << ":" << track.number << "," << track.is_audio << "," << track.index01;
+        std::cout << "\\n";
+    }
+}
+''', encoding='utf-8')
+        program = work / ('probe.exe' if os.name == 'nt' else 'probe')
+        env = os.environ.copy()
+        compiler = shutil.which(args.compiler) or args.compiler
+        env['PATH'] = str(Path(compiler).parent) + os.pathsep + env.get('PATH', '')
+        subprocess.run([compiler, '-std=c++17', '-O2', '-I' + str(root/'include'), str(source),
+                        str(root/'src/disc_path.cpp'), str(root/'src/cue_sheet.cpp'), '-o', str(program)],
+                       check=True, env=env)
+        for stem, tracks in [('disc', 12), ('album', 8)]:
+            (work/(stem+'.bin')).write_bytes(bytes(2352*40))
+            cue = 'FILE "'+stem+'.bin" BINARY\n'
+            for n in range(1, tracks+1):
+                kind = 'MODE2/2352' if stem == 'disc' and n == 1 else 'AUDIO'
+                cue += f' TRACK {n:02d} {kind}\n INDEX 01 00:00:{n*2:02d}\n'
+            (work/(stem+'.cue')).write_text(cue)
+        (work/'plain.bin').write_bytes(bytes(2352*4))
+        (work/'portable.chd').write_bytes(b'synthetic placeholder; parser must not read CHD')
+        (work/'broken.cue').write_text('FILE "missing.bin" BINARY\n TRACK 01 MODE2/2352\n INDEX 01 00:00:00\n')
+        (work/'broken.bin').write_bytes(bytes(2352*4))
+        cases = [('disc.cue','disc.cue|12'), ('disc.bin','disc.cue|12'),
+                 ('album.cue','album.cue|8'), ('album.bin','album.cue|8'),
+                 ('plain.bin','plain.bin|0'), ('portable.chd','portable.chd|0'),
+                 ('broken.cue','broken.bin|0'), ('missing.cue','missing.cue|0')]
+        result = subprocess.run([str(program)] + [str(work/name) for name,_ in cases],
+                                check=True, env=env, text=True, capture_output=True)
+        got = result.stdout.splitlines()
+        wanted = []
+        for name, value in cases:
+            if name.startswith(('disc.', 'album.')):
+                count = 12 if name.startswith('disc.') else 8
+                value += ''.join(f':{n},{int(name.startswith("album.") or n != 1)},{n*2}'
+                                 for n in range(1, count+1))
+            wanted.append(value)
+        assert got == wanted, (got, wanted)
+        print('launch adapter: 8 cases passed; mixed and audio-only CUE track maps retained')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Selecting a same-stem CUE currently replaces it with the BIN before mounting, so the runtime loses the CUE track layout. Use the existing `resolve_disc_path(path).mount` result at the launch adapter. Raw-only images, CHD and the resolver's unusable-CUE fallback retain their existing behavior.

The source-owned regression extracts the actual adapter and compiles it with the production resolver and parser. The unchanged adapter loses track metadata in four of eight synthetic cases; the corrected adapter passes all eight, including 12-track mixed media and eight-track audio-only media through both CUE and BIN entry points. It checks track numbers, types and starts.

Run `python runtime/tests/test_launch_disc_path.py --help` for the configured-compiler entry point. CTest registers the regression for GNU/Clang C++ builds.

## Validation and limits

- Exact base: `8d56cf659fd84367c3f778e17851674ac7896371`; review head: `7c11d57ea12812aa01587dcb5c313093ed1123d5`.
- Native Windows GCC 16 runtime builds and passes **69/69 enabled runtime tests**; two additional tests are disabled in the source configuration. The build has UI, setup wizard, debug tools, netplay, rewind and Vulkan disabled.
- Owned Wipeout XL (USA), canonical 12-track CUE with owned SCPH1001: verification, current-source generation, native build and an isolated 50-second startup pass; normal SDL window close at frame **3092**, process exit 0. Executable SHA-256 `49f53d0ef9bbf63a3a03f064534901434bf93bf601d8b4de811768ea84eac630`. This is bounded startup and normal shutdown, not gameplay completion or listening acceptance. Audio used SDL dummy output. No native Linux/macOS game route is claimed.
- The unchanged current recompiler builds and has **58/61 enabled tests passing**, with three pre-existing baseline failures (`dirty_text_continuation_guards`, `aot_overlay_discovery`, `release_zip`) and three disabled tests. This branch does not change that recompiler source. Those baseline failures are not reported as passes.
- Diff audit: general source repair, synthetic tests and documentation only; no retail disc/BIOS, generated game code, player data or private tooling.

## Scope and fork review

[Fork review #25](https://github.com/Alexbeav/psxrecomp/pull/25) inspected this exact head against immutable `review-base/mstan-8d56cf659fd8`. Cubic reported no issues on the exact head (review IDs: 5132910678, 5132913804); no unresolved findings remain. The public PR branch points to the same commit. Upstream master was fetched again and remains the recorded base. This contribution contains **1 commit and 4 changed files**.

- `docs/LAUNCH_DISC_PATH.md`: behavior and verification documentation.
- `runtime/CMakeLists.txt`: source-owned regression and test registration.
- `runtime/src/main.cpp`: bounded correction.
- `runtime/tests/test_launch_disc_path.py`: source-owned regression and test registration.

Developed with AI assistance; validated as described (test evidence in PR body). AI writes the code and the PR, but I always test before I send something up. Happy to iterate on this process with your feedback.
