### PR TITLE
Restore C11 labels and C declaration ownership

### DIFF
--- a/docs/C11_SOURCE_COMPATIBILITY.md
+++ b/docs/C11_SOURCE_COMPATIBILITY.md
@@ -1,0 +1,8 @@
+# C11 source compatibility
+
+A C11 label must precede a statement. The empty statement after retry_candidates keeps the following local declaration valid without changing control flow.
+main.cpp uses fntrace.h as the single owner of fntrace_is_game_started and its C linkage. Redundant block declarations can disagree under GCC 9.
+
+Run `python runtime/tests/test_overlay_retry_c11.py --compiler gcc` and `python runtime/tests/test_fntrace_c_linkage.py`.
+The first compiles the actual label/declaration excerpt in strict C11 mode. The second checks declaration ownership.
+These focused checks do not replace a full GCC 9 compile/link of the current framework.

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -562,6 +562,10 @@ if(BUILD_TESTING)
 
     find_package(Python3 COMPONENTS Interpreter)
     if(Python3_Interpreter_FOUND)
+        add_test(NAME fntrace_c_linkage_test COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_fntrace_c_linkage.py)
+        if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
+            add_test(NAME overlay_retry_c11_test COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_overlay_retry_c11.py --compiler ${CMAKE_C_COMPILER})
+        endif()
         add_test(NAME disc_companion_test COMMAND ${Python3_EXECUTABLE} ${PSXRECOMP_ROOT}/tools/tests/test_disc_companion.py)
         add_test(NAME sbi_registry_test COMMAND ${Python3_EXECUTABLE} ${PSXRECOMP_ROOT}/tools/tests/test_sbi_registry.py)
         add_test(NAME frame_interpolation_context_ownership_test

--- a/runtime/src/main.cpp
+++ b/runtime/src/main.cpp
@@ -6740,7 +6740,6 @@ static NetplayVblankEpilogue sdl_vblank_present_body(void) {
     ep.override = override;
 
     /* Turbo-active / multitap arming share game-started detection. */
-    extern int fntrace_is_game_started(void);
 
     if (psx_netplay_active()) {
         psx_netplay_finish_frame();
@@ -7070,7 +7069,6 @@ static NetplayVblankEpilogue sdl_vblank_present_body(void) {
         return ep;
     /* Engage widescreen at game entry: BIOS boot stays authentic 4:3. */
     if (!g_ws_engaged) {
-        extern int fntrace_is_game_started(void);
         if (fntrace_is_game_started()) {
             g_ws_engaged = true;
             g_ws_projection_mode = -1;

--- a/runtime/src/overlay_loader.c
+++ b/runtime/src/overlay_loader.c
@@ -3597,6 +3597,7 @@ int overlay_loader_dispatch(CPUState *cpu, uint32_t addr) {
     }
     int lazy_loaded = 0;
 retry_candidates:
+    ; /* C11 labels must precede a statement. */
     int head = idx_head(phys);
     int loaded_range_ci = -1;
     int lazy_exact = 0;

--- a/runtime/tests/test_fntrace_c_linkage.py
+++ b/runtime/tests/test_fntrace_c_linkage.py
@@ -1,0 +1,6 @@
+from pathlib import Path
+p=Path(__file__).resolve().parents[2]/"runtime/src/main.cpp"
+s=p.read_text(encoding="utf-8")
+assert '#include "fntrace.h"' in s
+assert 'extern int fntrace_is_game_started' not in s
+print("fntrace C header ownership: PASS")

--- a/runtime/tests/test_overlay_retry_c11.py
+++ b/runtime/tests/test_overlay_retry_c11.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+"""Compile the production retry label and following declaration as strict C11."""
+import argparse
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+parser = argparse.ArgumentParser()
+parser.add_argument('--compiler', default='cc')
+args = parser.parse_args()
+root = Path(__file__).resolve().parents[1]
+text = (root/'src/overlay_loader.c').read_text(encoding='utf-8')
+start = text.index('retry_candidates:')
+end = text.index('int loaded_range_ci', start)
+fragment = text[start:end]
+with tempfile.TemporaryDirectory() as tmp:
+    source = Path(tmp)/'label.c'
+    source.write_text('static int idx_head(int p) { return p; }\nint main(void) { int phys=0; if (phys) goto retry_candidates;\n'+fragment+'return head; }\n')
+    subprocess.run([shutil.which(args.compiler) or args.compiler,'-std=c11','-pedantic-errors','-fsyntax-only',str(source)],check=True)
+print('production retry label: strict C11 passes')


### PR DESCRIPTION
GCC 9 rejects the local declaration immediately after `retry_candidates:` in `overlay_loader.c`. Add the required null statement. It then reaches linking and exposes two local C++ declarations of `fntrace_is_game_started`; remove those duplicate declarations so the existing `fntrace.h` C declaration owns the linkage.

Two source-owned checks cover the actual label/declaration excerpt under `-std=c11 -pedantic-errors` and the header-owned declaration. They fail on the unchanged source and pass on this branch. They are registered in CTest.

Native Linux GCC 9 full-runtime controls:

- [Unchanged base and corrected candidate](https://github.com/Alexbeav/psxrecomp/actions/runs/34128452801): the base fails at the C label, while this exact candidate compiles and links all 484 actions and passes both focused tests.
- [Label-only control](https://github.com/Alexbeav/psxrecomp/actions/runs/34129260371): fixing only the label reaches the final link and fails on the C++-mangled `fntrace_is_game_started()`, independently demonstrating the second correction.

The CI workflow is on a separate build-only branch and is not part of this contribution.

## Validation and limits

- Exact base: `8d56cf659fd84367c3f778e17851674ac7896371`; review head: `d8725466bcbae7b235f33a6d334bfd455e39e7f6`.
- Native Windows GCC 16 runtime builds and passes **70/70 enabled runtime tests**; two additional tests are disabled in the source configuration. The build has UI, setup wizard, debug tools, netplay, rewind and Vulkan disabled.
- Owned Ghost in the Shell (SCES-01050) with owned SCPH1001: verification, current-source generation, native build and an isolated 50-second startup pass; normal SDL window close at frame **2456**, process exit 0. Executable SHA-256 `ebf755b918c52d9625e08aedb31e3b6d4baaeebbbdfe6022d5a573257e46fe67`. This is bounded startup and normal shutdown, not gameplay completion or listening acceptance. Audio used SDL dummy output. No native Linux/macOS game route is claimed.
- The unchanged current recompiler builds and has **58/61 enabled tests passing**, with three pre-existing baseline failures (`dirty_text_continuation_guards`, `aot_overlay_discovery`, `release_zip`) and three disabled tests. This branch does not change that recompiler source. Those baseline failures are not reported as passes.
- Diff audit: general source repair, synthetic tests and documentation only; no retail disc/BIOS, generated game code, player data or private tooling.

## Scope and fork review

[Fork review #26](https://github.com/Alexbeav/psxrecomp/pull/26) inspected this exact head against immutable `review-base/mstan-8d56cf659fd8`. Cubic reported no issues on the exact head (review IDs: 5132944873); no unresolved findings remain. The public PR branch points to the same commit. Upstream master was fetched again and remains the recorded base. This contribution contains **1 commit and 6 changed files**.

- `docs/C11_SOURCE_COMPATIBILITY.md`: behavior and verification documentation.
- `runtime/CMakeLists.txt`: source-owned regression and test registration.
- `runtime/src/main.cpp`: bounded correction.
- `runtime/src/overlay_loader.c`: bounded correction.
- `runtime/tests/test_fntrace_c_linkage.py`: source-owned regression and test registration.
- `runtime/tests/test_overlay_retry_c11.py`: source-owned regression and test registration.

Developed with AI assistance; validated as described (test evidence in PR body). AI writes the code and the PR, but I always test before I send something up. Happy to iterate on this process with your feedback.
