### PR TITLE
Check BIOS assets selected by the setup recipe

### DIFF
--- a/docs/SETUP_BIOS_ASSETS.md
+++ b/docs/SETUP_BIOS_ASSETS.md
@@ -1,0 +1,11 @@
+# Setup SDK BIOS assets
+
+The staged game.toml selects the required BIOS profile. Retail-only recipes do not require the unused OpenBIOS image and license.
+Default OpenBIOS recipes still require their profile, image and license. The selected profile must be a file inside the staged kit.
+The gate does not bundle retail BIOS dumps and does not change the CLI's BIOS selection or generated-code readiness checks.
+
+Run `python runtime/tests/test_setup_bios_assets.py` for five synthetic fixture tests.
+The existing `stage_setup_sdk.sh` gate calls the same production checker. Python 3.11 uses tomllib; older Python needs tomli, as other setup tools do.
+
+This gate is independently useful for retail SCPH1001 setup. Full selected-profile/SCPH5552 support also needs matching CLI, profile and generation support.
+The current upstream CLI still hardcodes SCPH1001 in its retail generate path. Passing this gate alone does not establish SCPH5552 setup support.

--- a/docs/SETUP_BIOS_ASSETS.md
+++ b/docs/SETUP_BIOS_ASSETS.md
@@ -4,7 +4,9 @@ The staged game.toml selects the required BIOS profile. Retail-only recipes do n
 Default OpenBIOS recipes still require their profile, image and license. The selected profile must be a file inside the staged kit.
 The gate does not bundle retail BIOS dumps and does not change the CLI's BIOS selection or generated-code readiness checks.
 
-Run `python runtime/tests/test_setup_bios_assets.py` for five synthetic fixture tests.
+Every required asset is resolved before the containment check, including default profiles and OpenBIOS assets. A file or parent-directory symlink cannot make an external asset count as part of the kit. Symlinks whose targets remain inside the kit are allowed.
+
+Run `python runtime/tests/test_setup_bios_assets.py` for ten synthetic fixture tests. Symlink controls run when the host permits symlink creation; other controls always run.
 The existing `stage_setup_sdk.sh` gate calls the same production checker. Python 3.11 uses tomllib; older Python needs tomli, as other setup tools do.
 
 This gate is independently useful for retail SCPH1001 setup. Full selected-profile/SCPH5552 support also needs matching CLI, profile and generation support.

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -562,6 +562,7 @@ if(BUILD_TESTING)
 
     find_package(Python3 COMPONENTS Interpreter)
     if(Python3_Interpreter_FOUND)
+        add_test(NAME setup_bios_assets_test COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_setup_bios_assets.py)
         add_test(NAME disc_companion_test COMMAND ${Python3_EXECUTABLE} ${PSXRECOMP_ROOT}/tools/tests/test_disc_companion.py)
         add_test(NAME sbi_registry_test COMMAND ${Python3_EXECUTABLE} ${PSXRECOMP_ROOT}/tools/tests/test_sbi_registry.py)
         add_test(NAME frame_interpolation_context_ownership_test

--- a/runtime/tests/test_setup_bios_assets.py
+++ b/runtime/tests/test_setup_bios_assets.py
@@ -50,6 +50,73 @@ class GateTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "game.toml"):
             gate.check(self.root)
 
+    def symlink(self, link, target, directory=False):
+        try:
+            link.symlink_to(target, target_is_directory=directory)
+        except (OSError, NotImplementedError) as error:
+            self.skipTest("symlink creation unavailable: " + str(error))
+
+    def outside(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        return Path(tmp.name)
+
+    def test_default_retail_rejects_external_profile_symlink(self):
+        self.recipe('[runtime]\nopenbios=false\n')
+        target = self.outside() / "SCPH1001.toml"
+        target.write_text("synthetic fixture")
+        self.symlink(self.root / "psxrecomp/bios/SCPH1001.toml", target)
+        with self.assertRaisesRegex(ValueError, "inside"):
+            gate.check(self.root)
+
+    def test_openbios_rejects_external_asset_symlinks(self):
+        self.recipe('[runtime]\n')
+        names = ("OpenBIOS.toml", "openbios.bin", "OpenBIOS.LICENSE")
+        for name in names:
+            self.asset(name)
+        target = self.outside() / "asset"
+        target.write_text("synthetic fixture")
+        for name in names:
+            with self.subTest(asset=name):
+                link = self.root / "psxrecomp/bios" / name
+                link.unlink()
+                self.symlink(link, target)
+                with self.assertRaisesRegex(ValueError, "inside"):
+                    gate.check(self.root)
+                link.unlink()
+                self.asset(name)
+
+    def test_default_retail_rejects_external_bios_directory(self):
+        self.recipe('[runtime]\nopenbios=false\n')
+        target = self.outside()
+        (target / "SCPH1001.toml").write_text("synthetic fixture")
+        link = self.root / "psxrecomp/bios"
+        link.rmdir()
+        self.symlink(link, target, directory=True)
+        with self.assertRaisesRegex(ValueError, "inside"):
+            gate.check(self.root)
+
+    def test_openbios_rejects_external_framework_directory(self):
+        self.recipe('[runtime]\n')
+        target = self.outside()
+        (target / "bios").mkdir()
+        for name in ("OpenBIOS.toml", "openbios.bin", "OpenBIOS.LICENSE"):
+            (target / "bios" / name).write_text("synthetic fixture")
+        (self.root / "psxrecomp/bios").rmdir()
+        link = self.root / "psxrecomp"
+        link.rmdir()
+        self.symlink(link, target, directory=True)
+        with self.assertRaisesRegex(ValueError, "inside"):
+            gate.check(self.root)
+
+    def test_internal_asset_symlinks_are_accepted(self):
+        self.recipe('[runtime]\n')
+        target = self.root / "shared-asset"
+        target.write_text("synthetic fixture")
+        for name in ("OpenBIOS.toml", "openbios.bin", "OpenBIOS.LICENSE"):
+            self.symlink(self.root / "psxrecomp/bios" / name, target)
+        self.assertEqual(len(gate.check(self.root)), 3)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/runtime/tests/test_setup_bios_assets.py
+++ b/runtime/tests/test_setup_bios_assets.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Exercise the production SDK BIOS gate with synthetic files only."""
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+ROOT = Path(__file__).resolve().parents[2]
+spec = importlib.util.spec_from_file_location("gate", ROOT / "tools/check_setup_bios_assets.py")
+gate = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(gate)
+
+
+class GateTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+        (self.root / "psxrecomp/bios").mkdir(parents=True)
+
+    def recipe(self, text):
+        (self.root / "game.toml").write_text(text)
+
+    def asset(self, name):
+        (self.root / "psxrecomp/bios" / name).write_text("synthetic fixture")
+
+    def test_retail_profile_without_openbios(self):
+        self.recipe('[runtime]\nopenbios=false\n[recompiler]\nbios_config="psxrecomp/bios/SCPH5552.toml"\n')
+        self.asset("SCPH5552.toml")
+        self.assertEqual(gate.check(self.root), [str(Path("psxrecomp/bios/SCPH5552.toml"))])
+
+    def test_retail_missing_profile_fails(self):
+        self.recipe('[runtime]\nopenbios=false\n[recompiler]\nbios_config="psxrecomp/bios/SCPH5552.toml"\n')
+        with self.assertRaisesRegex(ValueError, "SCPH5552"):
+            gate.check(self.root)
+
+    def test_default_openbios_requires_all_assets(self):
+        self.recipe('[runtime]\n')
+        for name in ("OpenBIOS.toml", "openbios.bin", "OpenBIOS.LICENSE"):
+            with self.assertRaises(ValueError):
+                gate.check(self.root)
+            self.asset(name)
+        self.assertEqual(len(gate.check(self.root)), 3)
+
+    def test_external_profile_fails(self):
+        self.recipe('[runtime]\nopenbios=false\n[recompiler]\nbios_config="../external.toml"\n')
+        with self.assertRaisesRegex(ValueError, "inside"):
+            gate.check(self.root)
+
+    def test_absent_recipe_fails(self):
+        with self.assertRaisesRegex(ValueError, "game.toml"):
+            gate.check(self.root)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/check_setup_bios_assets.py
+++ b/tools/check_setup_bios_assets.py
@@ -21,12 +21,7 @@ def check(stage):
     profile = config.get("recompiler", {}).get("bios_config")
     required = []
     if profile:
-        path = (stage / profile).resolve()
-        try:
-            path.relative_to(stage)
-        except ValueError:
-            raise ValueError("BIOS profile must remain inside the staged kit")
-        required.append(path)
+        required.append(stage / profile)
     elif not openbios:
         # Existing title recipes without a profile use the CLI default.
         required.append(stage / "psxrecomp/bios/SCPH1001.toml")
@@ -34,6 +29,11 @@ def check(stage):
         required.extend(stage / "psxrecomp/bios" / name for name in
                         ("OpenBIOS.toml", "openbios.bin", "OpenBIOS.LICENSE"))
     for path in required:
+        path = path.resolve()
+        try:
+            path.relative_to(stage)
+        except ValueError:
+            raise ValueError("BIOS asset must remain inside the staged kit")
         if not path.is_file():
             raise ValueError("missing staged BIOS asset: " + str(path.relative_to(stage)))
     return [str(path.relative_to(stage)) for path in required]

--- a/tools/check_setup_bios_assets.py
+++ b/tools/check_setup_bios_assets.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Require BIOS assets selected by the staged title recipe."""
+import sys
+from pathlib import Path
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib
+
+
+def check(stage):
+    stage = Path(stage).resolve()
+    recipe = stage / "game.toml"
+    if not recipe.is_file():
+        raise ValueError("missing staged game.toml for BIOS policy")
+    with recipe.open("rb") as handle:
+        config = tomllib.load(handle)
+    openbios = config.get("runtime", {}).get("openbios", True)
+    if not isinstance(openbios, bool):
+        raise ValueError("runtime.openbios must be a boolean")
+    profile = config.get("recompiler", {}).get("bios_config")
+    required = []
+    if profile:
+        path = (stage / profile).resolve()
+        try:
+            path.relative_to(stage)
+        except ValueError:
+            raise ValueError("BIOS profile must remain inside the staged kit")
+        required.append(path)
+    elif not openbios:
+        # Existing title recipes without a profile use the CLI default.
+        required.append(stage / "psxrecomp/bios/SCPH1001.toml")
+    if openbios:
+        required.extend(stage / "psxrecomp/bios" / name for name in
+                        ("OpenBIOS.toml", "openbios.bin", "OpenBIOS.LICENSE"))
+    for path in required:
+        if not path.is_file():
+            raise ValueError("missing staged BIOS asset: " + str(path.relative_to(stage)))
+    return [str(path.relative_to(stage)) for path in required]
+
+
+if __name__ == "__main__":
+    try:
+        print("staged BIOS policy: " + ", ".join(check(sys.argv[1])))
+    except (ValueError, OSError) as error:
+        sys.exit("error: " + str(error))

--- a/tools/stage_setup_sdk.sh
+++ b/tools/stage_setup_sdk.sh
@@ -201,12 +201,15 @@ cat >"${STAGE}/psxrecomp/retcomm-sdk.json" <<'EOF'
 }
 EOF
 
-for f in OpenBIOS.toml openbios.bin OpenBIOS.LICENSE SCPH1001.toml; do
-  if [[ ! -f "${STAGE}/psxrecomp/bios/${f}" ]]; then
-    echo "error: missing psxrecomp/bios/${f} in staged tree" >&2
-    exit 1
-  fi
-done
+if command -v python3 >/dev/null 2>&1; then
+  SDK_PYTHON=python3
+elif command -v python >/dev/null 2>&1; then
+  SDK_PYTHON=python
+else
+  echo "error: Python is required to check the staged BIOS policy" >&2
+  exit 1
+fi
+"${SDK_PYTHON}" "${SCRIPT_DIR}/check_setup_bios_assets.py" "${STAGE}"
 
 if [[ "${REQUIRE_CLI}" -eq 1 && ! -f "${STAGE}/psxrecomp/psxrecomp_cli.py" ]]; then
   echo "error: missing psxrecomp/psxrecomp_cli.py in staged tree" >&2


### PR DESCRIPTION
A retail-only SDK currently fails staging when unused OpenBIOS files are absent. Read the staged `game.toml` and require its selected BIOS profile. OpenBIOS-enabled recipes still require the OpenBIOS profile, image and license. Reject a missing recipe, missing selected profile or profile outside the staged kit.

Ten source-owned synthetic tests cover the policy. The unchanged shell gate rejects a retail-only fixture for missing OpenBIOS; the checker passes the corrected fixture and rejects the negative controls. Run `python runtime/tests/test_setup_bios_assets.py`.

Fork review exposed a containment gap in default/OpenBIOS paths. Resolve every required path in the common gate before checking that it stays inside the kit. Six external file/directory symlink assertions fail before this correction; all ten tests pass afterward, with no symlink skips on the native Windows test host. Internal symlinks remain supported. The complete SDK stage, owned generation and runtime suite were repeated after this correction. The runtime source and generated bytes remain identical, so the exact previously built game executable is reused for the fresh isolated startup/normal-close check.

The complete `stage_setup_sdk.sh` also passed with an actual retail-only **SCPH1001** SDK and no OpenBIOS assets. The resulting SDK verified an owned disc, generated game and BIOS code, and built the native runtime. Emitters used documented `PSXRECOMP_STATIC_CLI=ON` to avoid unrelated ambient MinGW DLL selection.

This changes asset validation only. Current upstream's retail CLI generation still selects SCPH1001. Accepting an explicit SCPH5552 profile at the asset gate does **not** establish full SCPH5552 CLI support; that integration, including existing #243, remains separate. No retail BIOS is added to source or redistributed.

## Validation and limits

- Exact base: `8d56cf659fd84367c3f778e17851674ac7896371`; review head: `406451cb92da4d9f701c81b8271e420cef8677cc`.
- Native Windows GCC 16 runtime builds and passes **69/69 enabled runtime tests**; two additional tests are disabled in the source configuration. The build has UI, setup wizard, debug tools, netplay, rewind and Vulkan disabled.
- Owned Ghost in the Shell (SCES-01050) with owned SCPH1001: verification, current-source generation, native build and an isolated 50-second startup pass; normal SDL window close at frame **2447**, process exit 0. Executable SHA-256 `474ec448d1fa040f21f121a99695ede07cfc362d893305813419269b535b70d5`. This is bounded startup and normal shutdown, not gameplay completion or listening acceptance. Audio used SDL dummy output. No native Linux/macOS game route is claimed.
- The unchanged current recompiler builds and has **58/61 enabled tests passing**, with three pre-existing baseline failures (`dirty_text_continuation_guards`, `aot_overlay_discovery`, `release_zip`) and three disabled tests. This branch does not change that recompiler source. Those baseline failures are not reported as passes.
- Diff audit: general source repair, synthetic tests and documentation only; no retail disc/BIOS, generated game code, player data or private tooling.

## Scope and fork review

[Fork review #24](https://github.com/Alexbeav/psxrecomp/pull/24) inspected this exact head against immutable `review-base/mstan-8d56cf659fd8`. Cubic found no remaining issues on the exact head (review IDs: 5133120825). The initial file/directory symlink findings were valid and fixed in the common asset check; both threads are resolved after failing-before/passing-after tests and repeated staging/runtime/owned-route validation. The public PR branch points to the same commit. Upstream master was fetched again and remains the recorded base. This contribution contains **2 commit(s) and 5 changed files**.

- `docs/SETUP_BIOS_ASSETS.md`: behavior and verification documentation.
- `runtime/CMakeLists.txt`: source-owned regression and test registration.
- `runtime/tests/test_setup_bios_assets.py`: source-owned regression and test registration.
- `tools/check_setup_bios_assets.py`: bounded correction.
- `tools/stage_setup_sdk.sh`: bounded correction.

Developed with AI assistance; validated as described (test evidence in PR body). AI writes the code and the PR, but I always test before I send something up. Happy to iterate on this process with your feedback.
