### PR TITLE
Bundle GPU regression candidates #326 #327 #328

### DIFF
--- a/docs/GPU_GL_READBACK_REGIONS.md
+++ b/docs/GPU_GL_READBACK_REGIONS.md
@@ -1,0 +1,44 @@
+# OpenGL native readback regions
+
+OpenGL owns the rendered video memory. A CPU read must see all prior GPU writes.
+The backend now keeps a separate conservative rectangle for GPU writes that
+have not reached the CPU array. It reads that rectangle into the full-width CPU
+array with an explicit row stride. It then clears the CPU readback debt.
+
+The rectangle includes clipped primitives, fill segments and copy destinations.
+It also retains framebuffer clearing debt across depth24 transitions. GPU
+uploads and queued draws still finish before packing and reading. Texture
+sampling can consume packing debt without consuming CPU readback debt. A
+conservative union is safe for GPU-to-CPU reads because the GPU image is current;
+CPU-to-GPU uploads still use their exact rectangle list.
+
+This does not change raster rules, read values, guest clocks, draw order or
+precision. It does not switch OpenGL to software raster ownership. The original
+interlaced row clipping remains in place. State recreation clears the new debt;
+CPU-authority mode retains its existing no-readback behavior.
+
+## Verification
+
+`runtime/tests/test_gl_readback_region.c` uses an actual hidden SDL/OpenGL
+context. It checks the complete native CPU image against full hardware readback
+after ordered synthetic workloads. It covers single pixels, odd-width row
+stride, disjoint uploads, texture dependencies, wrapping fills, overlapping
+copies, masks, blending, clipping, precision margins and state restore.
+The hardware rasterizer is shared by the comparison; this proves coherence,
+not independent raster accuracy. No retail assets are required.
+
+Run `python runtime/tests/run_gl_readback_region.py --compiler-bin <mingw-bin>
+--sdl-root <deps> --output <new-directory>`. The SDL dependency root must contain
+`sdl3-src/include` and `sdl3-build/libSDL3.a`. The Windows runner uses hidden
+windows. It tests
+native and4x scales. `--gl-source <old-gpu_gl_renderer.c> --expect-unbounded`
+checks the previous implementation: pixel comparisons pass, and only the small
+transfer assertion fails. Each command/result is saved in `receipt.json` under a fresh run directory inside the output root. Configure `runtime/` with `BUILD_TESTING=ON` and `PSX_GL_READBACK_SDL_ROOT=<deps>` on MinGW to register `gl_readback_region_test`; run it with `ctest --test-dir <build> -R gl_readback_region_test --output-on-failure`. Missing dependencies print a configure-time message and do not count as a hardware pass.
+
+## Prior art and scope
+
+Existing renderer coherence code supplied the ordering and dirty-area rules.
+DuckStation's software readback path was consulted as an alternative. This correction keeps the frozen branch's GPU
+authority and needs no title hook or controller policy change. Future work can
+reduce row submissions or use a more precise dirty set if measured demand
+justifies it.

--- a/docs/GPU_GL_READBACK_REGIONS.md
+++ b/docs/GPU_GL_READBACK_REGIONS.md
@@ -23,7 +23,10 @@ CPU-authority mode retains its existing no-readback behavior.
 context. It checks the complete native CPU image against full hardware readback
 after ordered synthetic workloads. It covers single pixels, odd-width row
 stride, disjoint uploads, texture dependencies, wrapping fills, overlapping
-copies, masks, blending, clipping, precision margins and state restore.
+copies, masks, blending, clipping, precision margins and state restore. A depth24 exit followed by an immediate
+CPU read verifies that cleared movie pixels are visible and newer overlapping
+texture uploads survive. It tests this existing clear policy, not full movie
+playback or depth24 raster accuracy.
 The hardware rasterizer is shared by the comparison; this proves coherence,
 not independent raster accuracy. No retail assets are required.
 
@@ -32,8 +35,9 @@ Run `python runtime/tests/run_gl_readback_region.py --compiler-bin <mingw-bin>
 `sdl3-src/include` and `sdl3-build/libSDL3.a`. The Windows runner uses hidden
 windows. It tests
 native and4x scales. `--gl-source <old-gpu_gl_renderer.c> --expect-unbounded`
-checks the previous implementation: pixel comparisons pass, and only the small
-transfer assertion fails. Each command/result is saved in `receipt.json` under a fresh run directory inside the output root. Configure `runtime/` with `BUILD_TESTING=ON` and `PSX_GL_READBACK_SDL_ROOT=<deps>` on MinGW to register `gl_readback_region_test`; run it with `ctest --test-dir <build> -R gl_readback_region_test --output-on-failure`. Missing dependencies print a configure-time message and do not count as a hardware pass.
+accepts an unbounded implementation only when pixel comparisons pass and
+exactly the small-transfer assertion fails. An older implementation with a
+coherence defect (including the depth24 clear) is correctly rejected too. Each command/result is saved in `receipt.json` under a fresh run directory inside the output root. Configure `runtime/` with `BUILD_TESTING=ON` and `PSX_GL_READBACK_SDL_ROOT=<deps>` on MinGW to register `gl_readback_region_test`; run it with `ctest --test-dir <build> -R gl_readback_region_test --output-on-failure`. Missing dependencies print a configure-time message and do not count as a hardware pass.
 
 ## Prior art and scope
 

--- a/docs/GPU_GL_READBACK_REGIONS.md
+++ b/docs/GPU_GL_READBACK_REGIONS.md
@@ -42,3 +42,9 @@ DuckStation's software readback path was consulted as an alternative. This corre
 authority and needs no title hook or controller policy change. Future work can
 reduce row submissions or use a more precise dirty set if measured demand
 justifies it.
+
+For Clang/MinGW builds, set `PSX_GL_READBACK_COMPILER_BIN` to a GCC/MinGW
+bin directory containing both gcc.exe and g++.exe. CMake checks these files
+before registering the hardware test. `gl_readback_runner_test` separately
+checks strict result parsing without a GPU or compiler. A negative run passes
+only for exactly one failure named single-pixel bounded transfer.

--- a/docs/GPU_GL_READBACK_REGIONS.md
+++ b/docs/GPU_GL_READBACK_REGIONS.md
@@ -34,7 +34,7 @@ Run `python runtime/tests/run_gl_readback_region.py --compiler-bin <mingw-bin>
 --sdl-root <deps> --output <new-directory>`. The SDL dependency root must contain
 `sdl3-src/include` and `sdl3-build/libSDL3.a`. The Windows runner uses hidden
 windows. It tests
-native and4x scales. `--gl-source <old-gpu_gl_renderer.c> --expect-unbounded`
+native and 4x scales. `--gl-source <old-gpu_gl_renderer.c> --expect-unbounded`
 accepts an unbounded implementation only when pixel comparisons pass and
 exactly the small-transfer assertion fails. An older implementation with a
 coherence defect (including the depth24 clear) is correctly rejected too. Each command/result is saved in `receipt.json` under a fresh run directory inside the output root. Configure `runtime/` with `BUILD_TESTING=ON` and `PSX_GL_READBACK_SDL_ROOT=<deps>` on MinGW to register `gl_readback_region_test`; run it with `ctest --test-dir <build> -R gl_readback_region_test --output-on-failure`. Missing dependencies print a configure-time message and do not count as a hardware pass.
@@ -49,6 +49,7 @@ justifies it.
 
 For Clang/MinGW builds, set `PSX_GL_READBACK_COMPILER_BIN` to a GCC/MinGW
 bin directory containing both gcc.exe and g++.exe. CMake checks these files
-before registering the hardware test. `gl_readback_runner_test` separately
+before registering the hardware test. Both the configure step and the runner
+also validate the SDL3 include directory and static library. `gl_readback_runner_test` separately
 checks strict result parsing without a GPU or compiler. A negative run passes
 only for exactly one failure named single-pixel bounded transfer.

--- a/docs/GPU_INTERLACED_RASTER.md
+++ b/docs/GPU_INTERLACED_RASTER.md
@@ -1,0 +1,42 @@
+# Interlaced primitive drawing
+
+The GPU preserves one row parity while drawing in 480-line interlaced mode
+when GP0(E1h) prohibits drawing to the display area. The display origin and
+current field select that parity. Progressive modes and the draw-to-display
+override draw both parities. Fills, copies and VRAM transfers keep both fields.
+
+`gpu_raster_skipped_row()` reads current GPU state for each primitive. The
+renderer facade applies the field mask with native-row clip rectangles and
+restores the original clip. This also preserves the corresponding rows in
+scaled surfaces. Each clipped triangle retains its precision and perspective
+metadata, which hardware backends otherwise consume on the first submission.
+No title address or title detection selects this behavior.
+
+Pro Pinball: Timeshock! USA SLUS-00639 repeatedly draws and reads a test pixel
+at (1020,511) during startup. Frozen source 63446a28 always returned the drawn
+pixel and stayed black. This correction lets the guest's existing field test
+finish. The same disc, BIOS and settings then reach the table.
+
+The field latch uses the runtime's existing vertical-blank model. This change
+does not claim scanline-accurate timing. Row clipping can increase submissions
+for large interlaced primitives; no general performance claim is made.
+
+## Verification
+
+Configure `runtime/` with `BUILD_TESTING=ON`, then run
+`ctest --test-dir <build> -R gpu_interlace_render_test --output-on-failure`.
+The fixture covers the mode predicate, origin/field parity, all nine primitive
+families, clip restoration, transfers, mode changes, scaled output and
+triangle metadata consumed by a backend. The original renderer fails the
+same row-preservation assertions.
+
+## Prior art
+
+- [PSX-SPX GPU specification](https://psx-spx.consoledev.net/graphicsprocessingunitgpu/)
+  describes interlace affecting draw commands.
+- [DuckStation difficult games](https://github.com/stenzek/duckstation/wiki/Difficult-to-Emulate-Games)
+  identifies required line skipping for Pro Pinball startup.
+
+These sources supplied behavioral evidence. The implementation and regression
+fixture were written independently. Exact title run receipts and route limits
+are maintained by the Timeshock correction project.

--- a/docs/GPU_INTERLACED_RASTER.md
+++ b/docs/GPU_INTERLACED_RASTER.md
@@ -48,3 +48,9 @@ integer fallback bounds and precise vertex bounds, with one row for rounding.
 Tests compare native and enhanced masked pixels with unmasked images when
 precise positions cross the integer bounds, including negative coordinates.
 A tiny precise triangle must submit three row clips rather than 256.
+
+Flat overlay rectangles also submit one-row geometry while field masking is
+active. This keeps the mask when a wide backend intentionally replaces its
+scissor. Non-interlaced overlays retain the original geometry and policy.
+A backend fixture that ignores the scissor tests both field parities, original
+progressive behavior, and clip restoration. This is not Vulkan driver testing.

--- a/docs/GPU_INTERLACED_RASTER.md
+++ b/docs/GPU_INTERLACED_RASTER.md
@@ -10,7 +10,9 @@ renderer facade applies the field mask with native-row clip rectangles and
 restores the original clip. This also preserves the corresponding rows in
 scaled surfaces. Each clipped triangle retains its precision and perspective
 metadata, which hardware backends otherwise consume on the first submission.
-No title address or title detection selects this behavior.
+The facade counts each original perspective triangle once; repeated backend
+metadata setup does not add diagnostic hits. No title address or title detection
+selects this behavior.
 
 Pro Pinball: Timeshock! USA SLUS-00639 repeatedly draws and reads a test pixel
 at (1020,511) during startup. Frozen source 63446a28 always returned the drawn

--- a/docs/GPU_INTERLACED_RASTER.md
+++ b/docs/GPU_INTERLACED_RASTER.md
@@ -42,3 +42,9 @@ same row-preservation assertions.
 These sources supplied behavioral evidence. The implementation and regression
 fixture were written independently. Exact title run receipts and route limits
 are maintained by the Timeshock correction project.
+
+Precise vertices use signed 16.16 positions. Row dispatch covers the union of
+integer fallback bounds and precise vertex bounds, with one row for rounding.
+Tests compare native and enhanced masked pixels with unmasked images when
+precise positions cross the integer bounds, including negative coordinates.
+A tiny precise triangle must submit three row clips rather than 256.

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -23,6 +23,23 @@ psxrecomp_add_runtime_target(psx-runtime
 # (docs/ENHANCEMENTS.md G1.10). Titles get their <exe>_pgxp the same way.
 
 if(BUILD_TESTING)
+    # Optional real-hardware regression. Configure its dependencies explicitly;
+    # absence must remain visible, never counted as a passing GPU test.
+    set(PSX_GL_READBACK_SDL_ROOT "" CACHE PATH "SDL3 static build root for GL readback test")
+    if(MINGW AND PSX_GL_READBACK_SDL_ROOT)
+        find_package(Python3 REQUIRED COMPONENTS Interpreter)
+        get_filename_component(_gl_test_compiler_bin "${CMAKE_C_COMPILER}" DIRECTORY)
+        add_test(NAME gl_readback_region_test
+            COMMAND "${Python3_EXECUTABLE}"
+                "${CMAKE_CURRENT_SOURCE_DIR}/tests/run_gl_readback_region.py"
+                --fixture "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_gl_readback_region.c"
+                --compiler-bin "${_gl_test_compiler_bin}"
+                --sdl-root "${PSX_GL_READBACK_SDL_ROOT}"
+                --output "${CMAKE_CURRENT_BINARY_DIR}/gl-readback-results")
+        set_tests_properties(gl_readback_region_test PROPERTIES LABELS "gpu;opengl;hardware" TIMEOUT 180)
+    else()
+        message(STATUS "gl_readback_region_test: not registered (requires MinGW and PSX_GL_READBACK_SDL_ROOT)")
+    endif()
     add_executable(launcher_device_roundtrip_test
         tests/test_launcher_device_roundtrip.cpp)
     target_include_directories(launcher_device_roundtrip_test PRIVATE include)

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -35,7 +35,9 @@ if(BUILD_TESTING)
     endif()
     if(MINGW AND PSX_GL_READBACK_SDL_ROOT
             AND EXISTS "${PSX_GL_READBACK_COMPILER_BIN}/gcc.exe"
-            AND EXISTS "${PSX_GL_READBACK_COMPILER_BIN}/g++.exe")
+            AND EXISTS "${PSX_GL_READBACK_COMPILER_BIN}/g++.exe"
+            AND IS_DIRECTORY "${PSX_GL_READBACK_SDL_ROOT}/sdl3-src/include"
+            AND EXISTS "${PSX_GL_READBACK_SDL_ROOT}/sdl3-build/libSDL3.a")
         find_package(Python3 REQUIRED COMPONENTS Interpreter)
         add_test(NAME gl_readback_region_test
             COMMAND "${Python3_EXECUTABLE}"
@@ -46,7 +48,7 @@ if(BUILD_TESTING)
                 --output "${CMAKE_CURRENT_BINARY_DIR}/gl-readback-results")
         set_tests_properties(gl_readback_region_test PROPERTIES LABELS "gpu;opengl;hardware" TIMEOUT 180)
     else()
-        message(STATUS "gl_readback_region_test: not registered (requires MinGW, PSX_GL_READBACK_SDL_ROOT and gcc.exe/g++.exe in PSX_GL_READBACK_COMPILER_BIN)")
+        message(STATUS "gl_readback_region_test: not registered (requires MinGW, SDL3 headers/static library in PSX_GL_READBACK_SDL_ROOT and gcc.exe/g++.exe in PSX_GL_READBACK_COMPILER_BIN)")
     endif()
     add_executable(launcher_device_roundtrip_test
         tests/test_launcher_device_roundtrip.cpp)

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -440,6 +440,15 @@ if(BUILD_TESTING)
     target_include_directories(gpu_sw_edges_test PRIVATE src)
     add_test(NAME gpu_sw_edges_test COMMAND gpu_sw_edges_test)
 
+    add_executable(gpu_interlace_render_test
+        tests/test_gpu_interlace_render.c src/gpu_render.c
+        src/gpu_sw_renderer.c src/gpu_vram_dirty.c)
+    target_include_directories(gpu_interlace_render_test PRIVATE include)
+    if(NOT MSVC)
+        target_link_libraries(gpu_interlace_render_test PRIVATE m)
+    endif()
+    add_test(NAME gpu_interlace_render_test COMMAND gpu_interlace_render_test)
+
     add_executable(gpu_vk_upload_alignment_test
         tests/test_gpu_vk_upload_alignment.c)
     target_include_directories(gpu_vk_upload_alignment_test PRIVATE src)

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -26,19 +26,27 @@ if(BUILD_TESTING)
     # Optional real-hardware regression. Configure its dependencies explicitly;
     # absence must remain visible, never counted as a passing GPU test.
     set(PSX_GL_READBACK_SDL_ROOT "" CACHE PATH "SDL3 static build root for GL readback test")
-    if(MINGW AND PSX_GL_READBACK_SDL_ROOT)
+    get_filename_component(_gl_test_default_bin "${CMAKE_C_COMPILER}" DIRECTORY)
+    set(PSX_GL_READBACK_COMPILER_BIN "${_gl_test_default_bin}" CACHE PATH "GCC/MinGW bin for GL fixture")
+    find_package(Python3 QUIET COMPONENTS Interpreter)
+    if(Python3_Interpreter_FOUND)
+        add_test(NAME gl_readback_runner_test COMMAND "${Python3_EXECUTABLE}"
+            "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_gl_readback_runner.py")
+    endif()
+    if(MINGW AND PSX_GL_READBACK_SDL_ROOT
+            AND EXISTS "${PSX_GL_READBACK_COMPILER_BIN}/gcc.exe"
+            AND EXISTS "${PSX_GL_READBACK_COMPILER_BIN}/g++.exe")
         find_package(Python3 REQUIRED COMPONENTS Interpreter)
-        get_filename_component(_gl_test_compiler_bin "${CMAKE_C_COMPILER}" DIRECTORY)
         add_test(NAME gl_readback_region_test
             COMMAND "${Python3_EXECUTABLE}"
                 "${CMAKE_CURRENT_SOURCE_DIR}/tests/run_gl_readback_region.py"
                 --fixture "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_gl_readback_region.c"
-                --compiler-bin "${_gl_test_compiler_bin}"
+                --compiler-bin "${PSX_GL_READBACK_COMPILER_BIN}"
                 --sdl-root "${PSX_GL_READBACK_SDL_ROOT}"
                 --output "${CMAKE_CURRENT_BINARY_DIR}/gl-readback-results")
         set_tests_properties(gl_readback_region_test PROPERTIES LABELS "gpu;opengl;hardware" TIMEOUT 180)
     else()
-        message(STATUS "gl_readback_region_test: not registered (requires MinGW and PSX_GL_READBACK_SDL_ROOT)")
+        message(STATUS "gl_readback_region_test: not registered (requires MinGW, PSX_GL_READBACK_SDL_ROOT and gcc.exe/g++.exe in PSX_GL_READBACK_COMPILER_BIN)")
     endif()
     add_executable(launcher_device_roundtrip_test
         tests/test_launcher_device_roundtrip.cpp)

--- a/runtime/include/gpu.h
+++ b/runtime/include/gpu.h
@@ -16,7 +16,8 @@ extern "C" {
 #endif
 
 void     gpu_init(void);
-uint32_t gpu_read_gpustat(void);   /* 0x1F801814 read */
+uint32_t gpu_read_gpustat(void);
+int gpu_raster_skipped_row(void);   /* 0x1F801814 read */
 uint32_t gpu_read_gpuread(void);   /* 0x1F801810 read */
 void     gpu_write_gp0(uint32_t val);  /* 0x1F801810 write */
 void     gpu_write_gp1(uint32_t val);  /* 0x1F801814 write */

--- a/runtime/include/gpu.h
+++ b/runtime/include/gpu.h
@@ -16,8 +16,8 @@ extern "C" {
 #endif
 
 void     gpu_init(void);
-uint32_t gpu_read_gpustat(void);
-int gpu_raster_skipped_row(void);   /* 0x1F801814 read */
+uint32_t gpu_read_gpustat(void);   /* 0x1F801814 read */
+int gpu_raster_skipped_row(void); /* -1: all rows; otherwise preserved field parity */
 uint32_t gpu_read_gpuread(void);   /* 0x1F801810 read */
 void     gpu_write_gp0(uint32_t val);  /* 0x1F801810 write */
 void     gpu_write_gp1(uint32_t val);  /* 0x1F801814 write */

--- a/runtime/include/gpu_interlace.h
+++ b/runtime/include/gpu_interlace.h
@@ -1,0 +1,16 @@
+#ifndef PSX_GPU_INTERLACE_H
+#define PSX_GPU_INTERLACE_H
+
+/* GP0 raster primitives skip the active field only in 480i mode with
+ * drawing-to-display prohibited. VRAM transfer commands do not use this rule.
+ * Return -1 for progressive drawing, otherwise the native VRAM row parity
+ * that must remain unchanged. The display origin participates in that parity. */
+static inline int psx_gpu_raster_skipped_row(unsigned interlace,
+        unsigned high_vertical_resolution, unsigned draw_to_display,
+        unsigned display_y, unsigned field) {
+    if (!interlace || !high_vertical_resolution || draw_to_display)
+        return -1;
+    return (int)((display_y + field) & 1u);
+}
+
+#endif

--- a/runtime/include/gpu_render.h
+++ b/runtime/include/gpu_render.h
@@ -53,9 +53,9 @@ void gr_set_precise_triangle(int enabled,
 /* Perspective-correct UV weights for the NEXT triangle ([video]
  * perspective_texturing). q[i] is the normalized 1/z homogeneous weight at
  * vertex i. enabled == 0 restores the PS1's affine UV interpolation. */
+void gr_set_perspective_triangle(int enabled, float q0, float q1, float q2);
 /* Original perspective-qualified triangles since process startup. */
 uint32_t gr_perspective_triangle_count(void);
-void gr_set_perspective_triangle(int enabled, float q0, float q1, float q2);
 
 /* Primitives */
 void gr_fill_rect(int x, int y, int w, int h, uint16_t color);

--- a/runtime/include/gpu_render.h
+++ b/runtime/include/gpu_render.h
@@ -53,6 +53,8 @@ void gr_set_precise_triangle(int enabled,
 /* Perspective-correct UV weights for the NEXT triangle ([video]
  * perspective_texturing). q[i] is the normalized 1/z homogeneous weight at
  * vertex i. enabled == 0 restores the PS1's affine UV interpolation. */
+/* Original perspective-qualified triangles since process startup. */
+uint32_t gr_perspective_triangle_count(void);
 void gr_set_perspective_triangle(int enabled, float q0, float q1, float q2);
 
 /* Primitives */

--- a/runtime/include/gpu_sw_renderer.h
+++ b/runtime/include/gpu_sw_renderer.h
@@ -34,7 +34,6 @@ void sw_set_precise_triangle(int enabled,
  * homogeneous interpolation weights associated with each screen vertex. */
 void sw_set_perspective_triangle(int enabled,
                                  float q0, float q1, float q2);
-uint32_t sw_perspective_triangle_count(void);
 
 /* Texture filtering. 0 = nearest (native PSX look, default), 1 = bilinear
  * (smooths textures/2D backgrounds; blends in RGB after the CLUT lookup,

--- a/runtime/include/gpu_vk_renderer.h
+++ b/runtime/include/gpu_vk_renderer.h
@@ -52,6 +52,7 @@ void vk_renderer_restage_vram_after_savestate(void);
  * -1=MAILBOX. Tear-free prefers MAILBOX because the frontend already paces
  * frames; unsupported modes fall back to FIFO (always available). */
 void vk_renderer_set_present_mode(int mode);
+void vk_renderer_set_display_aspect(int num, int den);
 
 #ifdef __cplusplus
 }

--- a/runtime/src/gpu.c
+++ b/runtime/src/gpu.c
@@ -3362,7 +3362,7 @@ int gpu_texture_correction_enabled(void) {
 }
 
 uint32_t gpu_texture_correction_hits(void) {
-    return sw_perspective_triangle_count();
+    return gr_perspective_triangle_count();
 }
 
 /* Per-vertex precise positions (PGXP, docs/ENHANCEMENTS.md G1). Each of the three

--- a/runtime/src/gpu.c
+++ b/runtime/src/gpu.c
@@ -11,6 +11,7 @@
  */
 
 #include "gpu.h"
+#include "gpu_interlace.h"
 #include "display_scanout.h"
 #include "pgxp.h"
 #include "mod_memory.h"
@@ -2731,6 +2732,14 @@ void gpu_init(void) {
 }
 
 /* ---- GPUSTAT read (0x1F801814) ---- */
+
+/* Primitive rasterization must leave the active display field untouched in
+ * 480-line interlaced mode unless GP0(E1h).10 permits drawing to it.
+ * Transfers, fills, and copies are not raster primitives. */
+int gpu_raster_skipped_row(void) {
+    return psx_gpu_raster_skipped_row(vertical_interlace, vres,
+                                    draw_to_display, display_area_y, lcf);
+}
 
 uint32_t gpu_read_gpustat(void) {
     /* Advance vblank when polled enough times from within a single function.

--- a/runtime/src/gpu_gl_renderer.c
+++ b/runtime/src/gpu_gl_renderer.c
@@ -2544,7 +2544,10 @@ static void depth24_clear_skipped_fb(void) {
     glDisable(GL_SCISSOR_TEST);
     p_glBindFramebuffer(PSXGL_FRAMEBUFFER, 0);
     rect_add(&s_pack_dirty, x0, y0, x1, y1);
-    if (!s_cpu_auth_dual) rect_add(&s_cpu_dirty, x0, y0, x1, y1);
+    if (!s_cpu_auth_dual) {
+        rect_add(&s_cpu_dirty, x0, y0, x1, y1);
+        s_gpu_dirty = 1; /* The clear must reach an immediate CPU read too. */
+    }
     present_dirty_rect(x0, y0, x1, y1, 1);
     rect_clear(&s_d24_skip_fb);
 }

--- a/runtime/src/gpu_gl_renderer.c
+++ b/runtime/src/gpu_gl_renderer.c
@@ -119,6 +119,7 @@
 #define PSXGL_FUNC_REVERSE_SUBTRACT 0x800B
 #define PSXGL_CONSTANT_ALPHA        0x8003
 #define PSXGL_UNPACK_ROW_LENGTH     0x0CF2
+#define PSXGL_PACK_ROW_LENGTH       0x0D02
 #define PSXGL_SRC1_ALPHA            0x8589
 
 #ifndef APIENTRY
@@ -442,6 +443,7 @@ static int           s_gpu_dirty = 0;      /* CPU VRAM array may be stale    */
 
 /* Dirty-rect unions, native VRAM coords, inclusive bounds. */
 typedef struct { int x0, y0, x1, y1, set; } DirtyRect;
+static DirtyRect s_cpu_dirty; /* conservative GPU-written area not yet read into CPU VRAM */
 static DirtyRect s_pack_dirty;             /* hr FBO content not in raw mirror */
 
 /* CPU writes not yet in the FBO — an EXACT rect list, NOT a single union.
@@ -1528,6 +1530,7 @@ static void ensure_cpu(void) {
      * Never glReadPixels — that forked peer snaps/resim. */
     if (s_cpu_auth_dual || psx_netplay_active()) {
         s_gpu_dirty = 0;
+        rect_clear(&s_cpu_dirty);
         return;
     }
     flush_flat_batch();
@@ -1535,10 +1538,22 @@ static void ensure_cpu(void) {
     flush_cpu_upload();
     pack_flush();
     p_glBindFramebuffer(PSXGL_READ_FRAMEBUFFER, s_raw_fbo);
-    glReadPixels(0, 0, VRAM_W, VRAM_H, PSXGL_RED_INTEGER, GL_UNSIGNED_SHORT, s_vram);
+    /* CPU uploads have already landed; raw packing preserves command order.
+     * A union is safe for readback (GPU -> CPU), unlike CPU upload unions.
+     * Do not reuse s_pack_dirty: texture sampling can consume it before CPU reads. */
+    int rx = s_cpu_dirty.set ? s_cpu_dirty.x0 : 0;
+    int ry = s_cpu_dirty.set ? s_cpu_dirty.y0 : 0;
+    int rw = s_cpu_dirty.set ? s_cpu_dirty.x1 - rx + 1 : VRAM_W;
+    int rh = s_cpu_dirty.set ? s_cpu_dirty.y1 - ry + 1 : VRAM_H;
+    glPixelStorei(PSXGL_PACK_ROW_LENGTH, VRAM_W);
+    glReadPixels(rx, ry, rw, rh, PSXGL_RED_INTEGER, GL_UNSIGNED_SHORT,
+                 s_vram + (size_t)ry * VRAM_W + rx);
+    glPixelStorei(PSXGL_PACK_ROW_LENGTH, 0);
     p_glBindFramebuffer(PSXGL_READ_FRAMEBUFFER, 0);
     s_gpu_dirty = 0;
-    coh_record(GL_COH_ENSURE, 0, 0, VRAM_W - 1, VRAM_H - 1);
+    rect_clear(&s_cpu_dirty);
+    coh_record(GL_COH_ENSURE, rx, ry, rx + rw - 1, ry + rh - 1);
+
 }
 
 /* ---- GPU primitives ------------------------------------------------------ */
@@ -1569,6 +1584,7 @@ static void mark_prim_dirty(const int *xs, const int *ys, int n, int textured) {
     if (x1 > s_area_x2) x1 = s_area_x2;
     if (y1 > s_area_y2) y1 = s_area_y2;
     rect_add(&s_pack_dirty, x0, y0, x1, y1);
+    if (!s_cpu_auth_dual) rect_add(&s_cpu_dirty, x0, y0, x1, y1);
     /* Dual-raster keeps CPU current via SW writes — do not mark GPU-ahead. */
     if (!s_cpu_auth_dual)
         s_gpu_dirty = 1;
@@ -2205,6 +2221,7 @@ static void fill_segment(int x, int y, int w, int h, float r, float g, float b) 
     glStencilMask(0xFF);
     glClear(GL_COLOR_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
     rect_add(&s_pack_dirty, x, y, x + w - 1, y + h - 1);
+    if (!s_cpu_auth_dual) rect_add(&s_cpu_dirty, x, y, x + w - 1, y + h - 1);
 }
 
 static void gpu_fill(int x,int y,int w,int h,uint16_t c) {
@@ -2287,6 +2304,7 @@ static void gpu_copy_rect(int sx,int sy,int dx,int dy,int w,int h) {
     hr_end();
 
     rect_add(&s_pack_dirty, dx, dy, dx + w - 1, dy + h - 1);
+    if (!s_cpu_auth_dual) rect_add(&s_cpu_dirty, dx, dy, dx + w - 1, dy + h - 1);
     if (!s_cpu_auth_dual)
         s_gpu_dirty = 1;
     coh_record(GL_COH_COPY_SRC, sx, sy, sx + w - 1, sy + h - 1);
@@ -2526,6 +2544,7 @@ static void depth24_clear_skipped_fb(void) {
     glDisable(GL_SCISSOR_TEST);
     p_glBindFramebuffer(PSXGL_FRAMEBUFFER, 0);
     rect_add(&s_pack_dirty, x0, y0, x1, y1);
+    if (!s_cpu_auth_dual) rect_add(&s_cpu_dirty, x0, y0, x1, y1);
     present_dirty_rect(x0, y0, x1, y1, 1);
     rect_clear(&s_d24_skip_fb);
 }
@@ -2896,6 +2915,7 @@ static int init_gpu_raster(void) {
     s_up_nrects = 0;
     up_add(0, 0, VRAM_W - 1, VRAM_H - 1);
     s_gpu_dirty = 0;
+    rect_clear(&s_cpu_dirty);
     s_stencil_valid = 1;
     for (int i = 0; i < PRES_ROWS; i++) s_present_dirty[i] = ~0ull;
     s_last_present_path = -1;
@@ -3181,14 +3201,18 @@ void gl_renderer_restage_vram_after_savestate(void) {
         depth24_mark_scanout_band();
     }
     /* Dual-raster: CPU is authority after snap; FBO is cosmetics only. */
-    if (s_cpu_auth_dual)
+    if (s_cpu_auth_dual) {
         s_gpu_dirty = 0;
+        rect_clear(&s_cpu_dirty);
+    }
 }
 
 void gl_renderer_set_cpu_auth_dual(int on) {
     s_cpu_auth_dual = on ? 1 : 0;
-    if (s_cpu_auth_dual)
+    if (s_cpu_auth_dual) {
         s_gpu_dirty = 0;
+        rect_clear(&s_cpu_dirty);
+    }
 }
 
 int gl_renderer_cpu_auth_dual(void) {

--- a/runtime/src/gpu_render.c
+++ b/runtime/src/gpu_render.c
@@ -116,7 +116,12 @@ void gr_set_precise_triangle(int enabled, int32_t x0, int32_t y0, int32_t x1, in
     if (g_b->set_precise_triangle)
         g_b->set_precise_triangle(enabled, x0, y0, x1, y1, x2, y2);
 }
+static uint32_t g_perspective_triangles;
+uint32_t gr_perspective_triangle_count(void) { return g_perspective_triangles; }
 void gr_set_perspective_triangle(int enabled, float q0, float q1, float q2) {
+    /* Count the original triangle, not per-row backend metadata re-arms. */
+    if (g_b->set_perspective_triangle && enabled && q0 > 0.0f && q1 > 0.0f && q2 > 0.0f)
+        ++g_perspective_triangles;
     g_pq_enabled=enabled; g_pq[0]=q0; g_pq[1]=q1; g_pq[2]=q2;
     if (g_b->set_perspective_triangle)
         g_b->set_perspective_triangle(enabled, q0, q1, q2);

--- a/runtime/src/gpu_render.c
+++ b/runtime/src/gpu_render.c
@@ -7,10 +7,11 @@
  * gl_backend_get(); if that returns NULL (GL unavailable / init failed) we
  * stay on software so a misconfigured [video] renderer never bricks boot.
  *
- * The software backend table points straight at the existing sw_* functions,
- * so the software path is byte-for-byte unchanged. */
+ * Primitive dispatch also applies the GPU's interlaced field mask through
+ * the backend clip, at native VRAM row granularity. */
 
 #include "gpu_render.h"
+#include "gpu.h"
 #include "gpu_sw_renderer.h"
 #include <stdio.h>
 
@@ -64,6 +65,11 @@ extern const GpuRenderBackend *vk_backend_get(void);
 
 static const GpuRenderBackend *g_b         = &SW_BACKEND;
 static GrBackend               g_effective = GR_BACKEND_SOFTWARE;
+/* Backends consume triangle metadata on submission. Re-arm it for each
+ * clipped row belonging to the same interlaced primitive. */
+static int g_pc_enabled, g_pq_enabled;
+static int32_t g_pc[6];
+static float g_pq[3];
 
 void gr_set_backend(GrBackend backend) {
     if (backend == GR_BACKEND_OPENGL) {
@@ -105,48 +111,92 @@ void gr_set_texture_window(uint32_t raw)             { g_b->set_texture_window(r
 void gr_set_color_modulation(int r, int g, int b, int raw) { g_b->set_color_modulation(r, g, b, raw); }
 void gr_set_precise_triangle(int enabled, int32_t x0, int32_t y0, int32_t x1, int32_t y1,
                              int32_t x2, int32_t y2) {
+    g_pc_enabled = enabled;
+    g_pc[0]=x0; g_pc[1]=y0; g_pc[2]=x1; g_pc[3]=y1; g_pc[4]=x2; g_pc[5]=y2;
     if (g_b->set_precise_triangle)
         g_b->set_precise_triangle(enabled, x0, y0, x1, y1, x2, y2);
 }
 void gr_set_perspective_triangle(int enabled, float q0, float q1, float q2) {
+    g_pq_enabled=enabled; g_pq[0]=q0; g_pq[1]=q1; g_pq[2]=q2;
     if (g_b->set_perspective_triangle)
         g_b->set_perspective_triangle(enabled, q0, q1, q2);
 }
 void gr_fill_rect(int x, int y, int w, int h, uint16_t c)  { g_b->fill_rect(x, y, w, h, c); }
 void gr_copy_rect(int sx, int sy, int dx, int dy, int w, int h) { g_b->copy_rect(sx, sy, dx, dy, w, h); }
+/* Apply field masking through each backend's native-coordinate clip. This
+ * preserves the same rows in canonical VRAM and supersampled surfaces, and
+ * leaves non-raster transfers untouched. Bounds are already offset by gpu.c.
+ * Query live GPU state per primitive so reset/restore/mode changes cannot
+ * leave a stale renderer-side field latch. */
+static int gr_min(int a, int b) { return a < b ? a : b; }
+static int gr_max(int a, int b) { return a > b ? a : b; }
+static void gr_rearm_triangle(void) {
+    if (g_b->set_precise_triangle)
+        g_b->set_precise_triangle(g_pc_enabled,g_pc[0],g_pc[1],g_pc[2],g_pc[3],g_pc[4],g_pc[5]);
+    if (g_b->set_perspective_triangle)
+        g_b->set_perspective_triangle(g_pq_enabled,g_pq[0],g_pq[1],g_pq[2]);
+}
+#define GR_TRIANGLE_ROWS(ylo, yhi, draw_call) do { \
+    /* Precise positions can cross the integer primitive bounds. */ \
+    int lo = (ylo), hi = (yhi); \
+    if (g_pc_enabled) { lo = 0; hi = 511; } \
+    GR_RASTER_ROWS(lo, hi, (gr_rearm_triangle(), draw_call)); \
+    g_pc_enabled = g_pq_enabled = 0; \
+    gr_rearm_triangle(); \
+} while (0)
+#define GR_RASTER_ROWS(ylo, yhi, draw_call) do { \
+    int skip = gpu_raster_skipped_row(); \
+    if (skip < 0) { draw_call; } else { \
+        int cx1, cy1, cx2, cy2; \
+        g_b->get_draw_area(&cx1, &cy1, &cx2, &cy2); \
+        int first = gr_max(gr_max((ylo), cy1), 0); \
+        int last = gr_min(gr_min((yhi), cy2), 511); \
+        for (int row = first; row <= last; ++row) { \
+            if ((row & 1) == skip) continue; \
+            g_b->set_draw_area(cx1, row, cx2, row); \
+            draw_call; \
+        } \
+        g_b->set_draw_area(cx1, cy1, cx2, cy2); \
+    } \
+} while (0)
+
 void gr_draw_flat_triangle(int x0, int y0, int x1, int y1, int x2, int y2, uint16_t c) {
-    g_b->draw_flat_triangle(x0, y0, x1, y1, x2, y2, c);
+    GR_TRIANGLE_ROWS(gr_min(y0, gr_min(y1, y2)), gr_max(y0, gr_max(y1, y2)), g_b->draw_flat_triangle(x0, y0, x1, y1, x2, y2, c));
 }
 void gr_draw_gouraud_triangle(int x0, int y0, uint16_t c0, int x1, int y1, uint16_t c1,
                               int x2, int y2, uint16_t c2) {
-    g_b->draw_gouraud_triangle(x0, y0, c0, x1, y1, c1, x2, y2, c2);
+    GR_TRIANGLE_ROWS(gr_min(y0, gr_min(y1, y2)), gr_max(y0, gr_max(y1, y2)), g_b->draw_gouraud_triangle(x0, y0, c0, x1, y1, c1, x2, y2, c2));
 }
 void gr_draw_textured_triangle(int x0, int y0, int u0, int v0, int x1, int y1, int u1, int v1,
                                int x2, int y2, int u2, int v2,
                                uint16_t clut_x, uint16_t clut_y, uint16_t texpage) {
-    g_b->draw_textured_triangle(x0, y0, u0, v0, x1, y1, u1, v1, x2, y2, u2, v2,
-                                clut_x, clut_y, texpage);
+    GR_TRIANGLE_ROWS(gr_min(y0, gr_min(y1, y2)), gr_max(y0, gr_max(y1, y2)), g_b->draw_textured_triangle(x0, y0, u0, v0, x1, y1, u1, v1, x2, y2, u2, v2,
+                                clut_x, clut_y, texpage));
 }
 void gr_draw_shaded_textured_triangle(int x0, int y0, int u0, int v0, uint32_t c0,
                                       int x1, int y1, int u1, int v1, uint32_t c1,
                                       int x2, int y2, int u2, int v2, uint32_t c2,
                                       uint16_t clut_x, uint16_t clut_y,
                                       uint16_t texpage, int raw) {
-    g_b->draw_shaded_textured_triangle(x0, y0, u0, v0, c0, x1, y1, u1, v1, c1,
-                                       x2, y2, u2, v2, c2, clut_x, clut_y, texpage, raw);
+    GR_TRIANGLE_ROWS(gr_min(y0, gr_min(y1, y2)), gr_max(y0, gr_max(y1, y2)), g_b->draw_shaded_textured_triangle(x0, y0, u0, v0, c0, x1, y1, u1, v1, c1,
+                                       x2, y2, u2, v2, c2, clut_x, clut_y, texpage, raw));
 }
-void gr_draw_flat_rect(int x, int y, int w, int h, uint16_t c) { g_b->draw_flat_rect(x, y, w, h, c); }
+void gr_draw_flat_rect(int x, int y, int w, int h, uint16_t c) {
+    GR_RASTER_ROWS(y, y + h - 1, g_b->draw_flat_rect(x, y, w, h, c));
+}
 void gr_draw_textured_rect(int x, int y, int w, int h, int u, int v,
                            uint16_t clut_x, uint16_t clut_y, uint16_t texpage) {
-    g_b->draw_textured_rect(x, y, w, h, u, v, clut_x, clut_y, texpage);
+    GR_RASTER_ROWS(y, y + h - 1, g_b->draw_textured_rect(x, y, w, h, u, v, clut_x, clut_y, texpage));
 }
 void gr_draw_textured_rect_scaled(int x, int y, int w, int h, int u0, int v0, int u1, int v1,
                                   uint16_t clut_x, uint16_t clut_y, uint16_t texpage) {
-    g_b->draw_textured_rect_scaled(x, y, w, h, u0, v0, u1, v1, clut_x, clut_y, texpage);
+    GR_RASTER_ROWS(y, y + h - 1, g_b->draw_textured_rect_scaled(x, y, w, h, u0, v0, u1, v1, clut_x, clut_y, texpage));
 }
-void gr_draw_line(int x0, int y0, int x1, int y1, uint16_t c) { g_b->draw_line(x0, y0, x1, y1, c); }
+void gr_draw_line(int x0, int y0, int x1, int y1, uint16_t c) {
+    GR_RASTER_ROWS(gr_min(y0, y1), gr_max(y0, y1), g_b->draw_line(x0, y0, x1, y1, c));
+}
 void gr_draw_shaded_line(int x0, int y0, uint16_t c0, int x1, int y1, uint16_t c1) {
-    g_b->draw_shaded_line(x0, y0, c0, x1, y1, c1);
+    GR_RASTER_ROWS(gr_min(y0, y1), gr_max(y0, y1), g_b->draw_shaded_line(x0, y0, c0, x1, y1, c1));
 }
 int gr_render_display(uint32_t *o, int p, int dx, int dy, int dw, int dh) {
     return g_b->render_display(o, p, dx, dy, dw, dh);

--- a/runtime/src/gpu_render.c
+++ b/runtime/src/gpu_render.c
@@ -141,10 +141,22 @@ static void gr_rearm_triangle(void) {
     if (g_b->set_perspective_triangle)
         g_b->set_perspective_triangle(g_pq_enabled,g_pq[0],g_pq[1],g_pq[2]);
 }
+/* Keep both integer fallback rows and enhanced fixed-point rows. The one-row
+ * margin covers edge rounding without submitting a full VRAM-height strip. */
+static void gr_precise_row_bounds(int *lo, int *hi) {
+    for (int i = 1; i < 6; i += 2) {
+        int y = g_pc[i] / 65536;
+        int rem = g_pc[i] % 65536;
+        int floor_y = y - (rem < 0);
+        int ceil_y = y + (rem > 0);
+        *lo = gr_min(*lo, floor_y - 1);
+        *hi = gr_max(*hi, ceil_y + 1);
+    }
+}
 #define GR_TRIANGLE_ROWS(ylo, yhi, draw_call) do { \
     /* Precise positions can cross the integer primitive bounds. */ \
     int lo = (ylo), hi = (yhi); \
-    if (g_pc_enabled) { lo = 0; hi = 511; } \
+    if (g_pc_enabled) gr_precise_row_bounds(&lo, &hi); \
     GR_RASTER_ROWS(lo, hi, (gr_rearm_triangle(), draw_call)); \
     g_pc_enabled = g_pq_enabled = 0; \
     gr_rearm_triangle(); \

--- a/runtime/src/gpu_render.c
+++ b/runtime/src/gpu_render.c
@@ -198,8 +198,20 @@ void gr_draw_shaded_textured_triangle(int x0, int y0, int u0, int v0, uint32_t c
     GR_TRIANGLE_ROWS(gr_min(y0, gr_min(y1, y2)), gr_max(y0, gr_max(y1, y2)), g_b->draw_shaded_textured_triangle(x0, y0, u0, v0, c0, x1, y1, u1, v1, c1,
                                        x2, y2, u2, v2, c2, clut_x, clut_y, texpage, raw));
 }
+/* Wide flat-overlay backends intentionally replace the clip with a full
+ * surface scissor. Submit row-height geometry too, so the field mask survives
+ * that path while ordinary full-screen overlays keep their existing policy. */
+static void gr_draw_flat_rect_row(int x, int w, uint16_t c) {
+    int x1, y1, x2, y2;
+    g_b->get_draw_area(&x1, &y1, &x2, &y2);
+    g_b->draw_flat_rect(x, y1, w, 1, c);
+}
 void gr_draw_flat_rect(int x, int y, int w, int h, uint16_t c) {
-    GR_RASTER_ROWS(y, y + h - 1, g_b->draw_flat_rect(x, y, w, h, c));
+    if (gpu_raster_skipped_row() < 0) {
+        g_b->draw_flat_rect(x, y, w, h, c);
+        return;
+    }
+    GR_RASTER_ROWS(y, y + h - 1, gr_draw_flat_rect_row(x, w, c));
 }
 void gr_draw_textured_rect(int x, int y, int w, int h, int u, int v,
                            uint16_t clut_x, uint16_t clut_y, uint16_t texpage) {

--- a/runtime/src/gpu_sw_renderer.c
+++ b/runtime/src/gpu_sw_renderer.c
@@ -56,7 +56,6 @@ static int       g_precise_valid = 0;
 static int32_t   g_precise_x16[3], g_precise_y16[3];
 static int       g_perspective_valid = 0;
 static float     g_perspective_q[3];
-static uint32_t  g_perspective_triangles = 0;
 
 /* ---- Native-wide compositor (separate present surfaces) ------------------
  * Canonical VRAM stays faithful. For an opted-in wide game we ADDITIONALLY
@@ -522,11 +521,6 @@ void sw_set_perspective_triangle(int enabled,
     g_perspective_q[0] = q0;
     g_perspective_q[1] = q1;
     g_perspective_q[2] = q2;
-    if (g_perspective_valid) g_perspective_triangles++;
-}
-
-uint32_t sw_perspective_triangle_count(void) {
-    return g_perspective_triangles;
 }
 
 static inline int precise_scaled(int axis, int vertex, int fallback, int scale) {

--- a/runtime/src/gpu_vk_renderer.c
+++ b/runtime/src/gpu_vk_renderer.c
@@ -2790,8 +2790,8 @@ static void vkb_draw_gouraud_triangle(int x0,int y0,uint16_t c0,int x1,int y1,ui
 /* Full-screen-overlay wide pass (pause gray-filter / load fade): draw a flat
  * rect covering the FULL wide width [0, wide_w) x [y, y+h) directly into the
  * active wide surface (positions already wide-space, u_xoff = 0). Mirrors GL's
- * wide_flat_rect_direct: full-surface scissor (the overlay must dim the
- * revealed margins too). The 6 verts are consumed privately (s_vbase bumped)
+ * wide_flat_rect_direct: full-width scissor (the overlay must dim the
+ * revealed margins too), while preserving the draw-area Y band. The 6 verts are consumed privately (s_vbase bumped)
  * so they never join a canonical batch. */
 static void wide_overlay_rect(int y, int h, uint16_t c, int semi) {
     if (s_wide_cur < 0 || !s_ready) return;
@@ -2803,12 +2803,9 @@ static void wide_overlay_rect(int y, int h, uint16_t c, int semi) {
     push_vert(x0, fy0, col); push_vert(x1, fy1, col); push_vert(x0, fy1, col);
     s_vbase += s_vcount; s_vcount = 0;    /* consume privately */
     int blend = (semi < 0) ? 0 : (semi + 1);
-    int S = s_scale;
     VkCommandBuffer cb = begin_oneshot();
+    /* Keep the full width and current Y clip, including interlaced row clips. */
     wide_pass_begin(cb);
-    /* Overlay covers the whole surface: override the band scissor. */
-    VkRect2D sc = { { 0, 0 }, { (uint32_t)(s_wide_w * S), (uint32_t)(VRAM_H * S) } };
-    p_vkCmdSetScissor(cb, 0, 1, &sc);
     bind_masked(cb, 0, 0, blend, s_mask_check, s_mask_set);
     GeoPush gp = { px_shift(), 0.0f, (float)s_wide_w / 2.0f };
     p_vkCmdPushConstants(cb, s_pl_geo, VK_SHADER_STAGE_VERTEX_BIT, 0, sizeof gp, &gp);

--- a/runtime/src/gpu_vk_renderer.c
+++ b/runtime/src/gpu_vk_renderer.c
@@ -2790,8 +2790,8 @@ static void vkb_draw_gouraud_triangle(int x0,int y0,uint16_t c0,int x1,int y1,ui
 /* Full-screen-overlay wide pass (pause gray-filter / load fade): draw a flat
  * rect covering the FULL wide width [0, wide_w) x [y, y+h) directly into the
  * active wide surface (positions already wide-space, u_xoff = 0). Mirrors GL's
- * wide_flat_rect_direct: full-width scissor (the overlay must dim the
- * revealed margins too), while preserving the draw-area Y band. The 6 verts are consumed privately (s_vbase bumped)
+ * wide_flat_rect_direct: full-surface scissor (the overlay must dim the
+ * revealed margins too). The 6 verts are consumed privately (s_vbase bumped)
  * so they never join a canonical batch. */
 static void wide_overlay_rect(int y, int h, uint16_t c, int semi) {
     if (s_wide_cur < 0 || !s_ready) return;
@@ -2803,9 +2803,12 @@ static void wide_overlay_rect(int y, int h, uint16_t c, int semi) {
     push_vert(x0, fy0, col); push_vert(x1, fy1, col); push_vert(x0, fy1, col);
     s_vbase += s_vcount; s_vcount = 0;    /* consume privately */
     int blend = (semi < 0) ? 0 : (semi + 1);
+    int S = s_scale;
     VkCommandBuffer cb = begin_oneshot();
-    /* Keep the full width and current Y clip, including interlaced row clips. */
     wide_pass_begin(cb);
+    /* Overlay covers the whole surface: override the band scissor. */
+    VkRect2D sc = { { 0, 0 }, { (uint32_t)(s_wide_w * S), (uint32_t)(VRAM_H * S) } };
+    p_vkCmdSetScissor(cb, 0, 1, &sc);
     bind_masked(cb, 0, 0, blend, s_mask_check, s_mask_set);
     GeoPush gp = { px_shift(), 0.0f, (float)s_wide_w / 2.0f };
     p_vkCmdPushConstants(cb, s_pl_geo, VK_SHADER_STAGE_VERTEX_BIT, 0, sizeof gp, &gp);

--- a/runtime/src/gpu_vk_renderer.c
+++ b/runtime/src/gpu_vk_renderer.c
@@ -44,6 +44,7 @@ void vk_renderer_present_blank(void){}
 void vk_renderer_sync_cpu(void){}
 void vk_renderer_restage_vram_after_savestate(void){}
 void vk_renderer_set_present_mode(int m){(void)m;}
+void vk_renderer_set_display_aspect(int n,int d){(void)n;(void)d;}
 int  vk_perf_json(char *out,int cap,int count){(void)count; return cap>2?snprintf(out,cap,"[]"):0;}
 const GpuRenderBackend *vk_backend_get(void) { return 0; }
 
@@ -62,6 +63,13 @@ const GpuRenderBackend *vk_backend_get(void) { return 0; }
 
 #define VRAM_W 1024
 #define VRAM_H 512
+
+static int s_aspect_num = 4, s_aspect_den = 3;
+
+void vk_renderer_set_display_aspect(int num, int den) {
+    if (num <= 0 || den <= 0) { num = 4; den = 3; }
+    s_aspect_num = num; s_aspect_den = den;
+}
 
 /* ---- dynamic loader ---------------------------------------------------- */
 /* vkGetInstanceProcAddr comes from SDL; everything else is loaded through it
@@ -1690,7 +1698,7 @@ int vk_renderer_present_vram(int disp_x, int disp_y, int w, int h,
 
     VkOffset3D dst[2];
     letterbox((int)s_sc_extent.width, (int)s_sc_extent.height,
-              force_4_3 ? 4 : 4, force_4_3 ? 3 : 3, dst);
+              force_4_3 ? 4 : s_aspect_num, force_4_3 ? 3 : s_aspect_den, dst);
 
     VkImageBlit blit = {0};
     blit.srcSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
@@ -1799,7 +1807,7 @@ void vk_renderer_present_cpu(const uint32_t *pixels, int src_w, int src_h,
     p_vkCmdClearColorImage(cb, sc, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, &black, 1, &rng);
 
     VkOffset3D dst[2];
-    letterbox((int)s_sc_extent.width, (int)s_sc_extent.height, 4, 3, dst);
+    letterbox((int)s_sc_extent.width, (int)s_sc_extent.height, force_4_3 ? 4 : s_aspect_num, force_4_3 ? 3 : s_aspect_den, dst);
     /* Short GP1(07h) bands: letterbox inside the 4:3 rect (see GL present). */
     if (src_h > 0 && src_h < 240) {
         int box_h = dst[1].y - dst[0].y;

--- a/runtime/src/gpu_vk_renderer.c
+++ b/runtime/src/gpu_vk_renderer.c
@@ -2763,9 +2763,7 @@ static void vkb_set_precise_triangle(int enabled,
 static void vkb_set_perspective_triangle(int enabled, float q0, float q1, float q2) {
     s_pq_valid = (enabled && q0 > 0.0f && q1 > 0.0f && q2 > 0.0f) ? 1 : 0;
     s_pq[0] = q0; s_pq[1] = q1; s_pq[2] = q2;
-    /* The corrected-triangle tally lives in the software rasterizer and backs
-     * gpu_texture_correction_hits() — the "is this doing anything on this
-     * title" counter. Forward so it reads the same on every backend. */
+    /* Keep fallback software metadata in sync; the facade counts triangles. */
     sw_set_perspective_triangle(enabled, q0, q1, q2);
 }
 /* The override describes exactly one triangle; drop it once submitted so a

--- a/runtime/src/main.cpp
+++ b/runtime/src/main.cpp
@@ -1738,6 +1738,7 @@ static void update_adaptive_widescreen() {
     g_video_aspect_num = num;
     g_video_aspect_den = den;
     gl_renderer_set_display_aspect(num, den);
+    vk_renderer_set_display_aspect(num, den);
     if (sdl_renderer) {
         g_logical_w = 480 * num * g_video_scale / den;
         SDL_RenderSetLogicalSize(sdl_renderer, g_logical_w, 480 * g_video_scale);
@@ -13384,6 +13385,7 @@ session_reboot:
      * this aspect; native-wide fills it with a genuinely wider frame (no
      * stretch), squash mode stretches the 4:3 frame into it. */
     gl_renderer_set_display_aspect(g_video_aspect_num, g_video_aspect_den);
+    vk_renderer_set_display_aspect(g_video_aspect_num, g_video_aspect_den);
     if (g_video_aspect_num * 3 != g_video_aspect_den * 4) {
         /* Hold widescreen off through the BIOS boot (authentic 4:3 logos);
          * the per-frame present path engages it at game entry. */

--- a/runtime/tests/run_gl_readback_region.py
+++ b/runtime/tests/run_gl_readback_region.py
@@ -36,11 +36,15 @@ def main():
     for name in ("gcc.exe", "g++.exe"):
         if not (compiler / name).is_file():
             parser.error(f"--compiler-bin must contain {name}: {compiler}")
+    sdl = pathlib.Path(args.sdl_root).resolve()
+    if not (sdl / "sdl3-src/include").is_dir():
+        parser.error(f"--sdl-root must contain the sdl3-src/include directory: {sdl}")
+    if not (sdl / "sdl3-build/libSDL3.a").is_file():
+        parser.error(f"--sdl-root must contain sdl3-build/libSDL3.a: {sdl}")
     output = pathlib.Path(args.output).resolve()
     output.mkdir(parents=True, exist_ok=True)
     dest = pathlib.Path(tempfile.mkdtemp(prefix="readback-", dir=output))
     print("Evidence directory:", dest)
-    sdl = pathlib.Path(args.sdl_root).resolve()
     env = os.environ.copy()
     env["PATH"] = str(compiler) + os.pathsep + env.get("PATH", "")
     if args.gl_source:

--- a/runtime/tests/run_gl_readback_region.py
+++ b/runtime/tests/run_gl_readback_region.py
@@ -1,25 +1,84 @@
-import pathlib,subprocess,json,os,sys,argparse,shutil,tempfile
-parser=argparse.ArgumentParser(description="Run hidden real-GL source-owned readback tests")
-parser.add_argument('--compiler-bin',required=True);parser.add_argument('--sdl-root',required=True)
-parser.add_argument('--output',required=True);parser.add_argument('--gl-source')
-parser.add_argument('--fixture',type=pathlib.Path)
-parser.add_argument('--expect-unbounded',action='store_true');args=parser.parse_args()
-F=pathlib.Path(__file__).resolve().parents[2]
-output=pathlib.Path(args.output).resolve();output.mkdir(parents=True,exist_ok=True)
-D=pathlib.Path(tempfile.mkdtemp(prefix='readback-',dir=output))
-print('Evidence directory:',D)
-old=pathlib.Path(args.sdl_root).resolve();T=pathlib.Path(args.compiler_bin).resolve();env=os.environ.copy();env['PATH']=str(T)+os.pathsep+env['PATH']
-if args.gl_source:shutil.copyfile(args.gl_source,D/'gpu_gl_renderer.c')
-inc=['-I',str(D),'-I',str(F/'runtime/include'),'-I',str(F/'runtime/src'),'-I',str(old/'sdl3-src/include')];receipt=[]
-def run(cmd):
- p=subprocess.run([str(x) for x in cmd],cwd=D,capture_output=True,text=True,errors='replace',env=env);receipt.append({'cmd':[str(x) for x in cmd],'exit':p.returncode,'stdout':p.stdout,'stderr':p.stderr});(D/'receipt.json').write_text(json.dumps(receipt,indent=2));print(p.stdout[-600:],p.stderr[-2000:]);return p.returncode
-for name,src in [('probe',args.fixture or F/'runtime/tests/test_gl_readback_region.c'),('sw',F/'runtime/src/gpu_sw_renderer.c')]:
- if run([T/'gcc.exe','-std=c11','-O2','-flto','-DPSX_SDL3=1','-DPSX_NO_DEBUG_TOOLS=1',*inc,'-c',src,'-o',D/(name+'.o')]):sys.exit(2)
-libs=['m','kernel32','user32','gdi32','winmm','imm32','ole32','oleaut32','version','uuid','advapi32','setupapi','shell32','dinput8','opengl32']
-if run([T/'g++.exe','-O2','-flto',D/'probe.o',D/'sw.o',old/'sdl3-build/libSDL3.a',*['-l'+x for x in libs],'-o',D/'probe.exe']):sys.exit(2)
-# Test windows are hidden. No host-specific priority or affinity policy.
-for scale in [1,4]:
- code=run([D/'probe.exe',str(scale)])
- expected=1 if args.expect_unbounded else 0
- if code!=expected:sys.exit(1)
- if args.expect_unbounded and 'failures=1' not in receipt[-1]['stdout']:sys.exit(1)
+"""Run source-owned readback checks with a hidden real OpenGL context."""
+import argparse
+import json
+import os
+import pathlib
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+
+
+def probe_result_ok(code, stdout, stderr, expect_unbounded=False):
+    lines = stdout.rstrip().splitlines()
+    summary = re.fullmatch(r"checks=(\d+) failures=(\d+)", lines[-1]) if lines else None
+    if not summary or int(summary[1]) == 0:
+        return False
+    failures = [line for line in stderr.splitlines() if line.startswith("FAIL ")]
+    if expect_unbounded:
+        return (code == 1 and int(summary[2]) == 1 and
+                failures == ["FAIL single-pixel bounded transfer"])
+    return code == 0 and int(summary[2]) == 0 and not failures
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--compiler-bin", required=True)
+    parser.add_argument("--sdl-root", required=True)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--gl-source")
+    parser.add_argument("--fixture", type=pathlib.Path)
+    parser.add_argument("--expect-unbounded", action="store_true")
+    args = parser.parse_args()
+    framework = pathlib.Path(__file__).resolve().parents[2]
+    compiler = pathlib.Path(args.compiler_bin).resolve()
+    for name in ("gcc.exe", "g++.exe"):
+        if not (compiler / name).is_file():
+            parser.error(f"--compiler-bin must contain {name}: {compiler}")
+    output = pathlib.Path(args.output).resolve()
+    output.mkdir(parents=True, exist_ok=True)
+    dest = pathlib.Path(tempfile.mkdtemp(prefix="readback-", dir=output))
+    print("Evidence directory:", dest)
+    sdl = pathlib.Path(args.sdl_root).resolve()
+    env = os.environ.copy()
+    env["PATH"] = str(compiler) + os.pathsep + env.get("PATH", "")
+    if args.gl_source:
+        shutil.copyfile(args.gl_source, dest / "gpu_gl_renderer.c")
+    includes = ["-I", str(dest), "-I", str(framework / "runtime/include"),
+                "-I", str(framework / "runtime/src"), "-I", str(sdl / "sdl3-src/include")]
+    receipt = []
+
+    def run(command):
+        command = [str(value) for value in command]
+        result = subprocess.run(command, cwd=dest, capture_output=True,
+                                text=True, encoding="utf-8", errors="replace", env=env)
+        receipt.append({"cmd": command, "exit": result.returncode,
+                        "stdout": result.stdout, "stderr": result.stderr})
+        (dest / "receipt.json").write_text(json.dumps(receipt, indent=2), encoding="utf-8")
+        print(result.stdout[-600:], result.stderr[-2000:])
+        return result
+
+    fixture = args.fixture or framework / "runtime/tests/test_gl_readback_region.c"
+    for name, source in [("probe", fixture), ("sw", framework / "runtime/src/gpu_sw_renderer.c")]:
+        if run([compiler / "gcc.exe", "-std=c11", "-O2", "-flto", "-DPSX_SDL3=1",
+                "-DPSX_NO_DEBUG_TOOLS=1", *includes, "-c", source,
+                "-o", dest / (name + ".o")]).returncode:
+            return 2
+    libraries = ["m", "kernel32", "user32", "gdi32", "winmm", "imm32", "ole32",
+                 "oleaut32", "version", "uuid", "advapi32", "setupapi", "shell32",
+                 "dinput8", "opengl32"]
+    if run([compiler / "g++.exe", "-O2", "-flto", dest / "probe.o", dest / "sw.o",
+            sdl / "sdl3-build/libSDL3.a", *["-l" + name for name in libraries],
+            "-o", dest / "probe.exe"]).returncode:
+        return 2
+    for scale in (1, 4):
+        result = run([dest / "probe.exe", scale])
+        if not probe_result_ok(result.returncode, result.stdout, result.stderr,
+                               args.expect_unbounded):
+            return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/runtime/tests/run_gl_readback_region.py
+++ b/runtime/tests/run_gl_readback_region.py
@@ -1,0 +1,25 @@
+import pathlib,subprocess,json,os,sys,argparse,shutil,tempfile
+parser=argparse.ArgumentParser(description="Run hidden real-GL source-owned readback tests")
+parser.add_argument('--compiler-bin',required=True);parser.add_argument('--sdl-root',required=True)
+parser.add_argument('--output',required=True);parser.add_argument('--gl-source')
+parser.add_argument('--fixture',type=pathlib.Path)
+parser.add_argument('--expect-unbounded',action='store_true');args=parser.parse_args()
+F=pathlib.Path(__file__).resolve().parents[2]
+output=pathlib.Path(args.output).resolve();output.mkdir(parents=True,exist_ok=True)
+D=pathlib.Path(tempfile.mkdtemp(prefix='readback-',dir=output))
+print('Evidence directory:',D)
+old=pathlib.Path(args.sdl_root).resolve();T=pathlib.Path(args.compiler_bin).resolve();env=os.environ.copy();env['PATH']=str(T)+os.pathsep+env['PATH']
+if args.gl_source:shutil.copyfile(args.gl_source,D/'gpu_gl_renderer.c')
+inc=['-I',str(D),'-I',str(F/'runtime/include'),'-I',str(F/'runtime/src'),'-I',str(old/'sdl3-src/include')];receipt=[]
+def run(cmd):
+ p=subprocess.run([str(x) for x in cmd],cwd=D,capture_output=True,text=True,errors='replace',env=env);receipt.append({'cmd':[str(x) for x in cmd],'exit':p.returncode,'stdout':p.stdout,'stderr':p.stderr});(D/'receipt.json').write_text(json.dumps(receipt,indent=2));print(p.stdout[-600:],p.stderr[-2000:]);return p.returncode
+for name,src in [('probe',args.fixture or F/'runtime/tests/test_gl_readback_region.c'),('sw',F/'runtime/src/gpu_sw_renderer.c')]:
+ if run([T/'gcc.exe','-std=c11','-O2','-flto','-DPSX_SDL3=1','-DPSX_NO_DEBUG_TOOLS=1',*inc,'-c',src,'-o',D/(name+'.o')]):sys.exit(2)
+libs=['m','kernel32','user32','gdi32','winmm','imm32','ole32','oleaut32','version','uuid','advapi32','setupapi','shell32','dinput8','opengl32']
+if run([T/'g++.exe','-O2','-flto',D/'probe.o',D/'sw.o',old/'sdl3-build/libSDL3.a',*['-l'+x for x in libs],'-o',D/'probe.exe']):sys.exit(2)
+# Test windows are hidden. No host-specific priority or affinity policy.
+for scale in [1,4]:
+ code=run([D/'probe.exe',str(scale)])
+ expected=1 if args.expect_unbounded else 0
+ if code!=expected:sys.exit(1)
+ if args.expect_unbounded and 'failures=1' not in receipt[-1]['stdout']:sys.exit(1)

--- a/runtime/tests/test_gl_readback_region.c
+++ b/runtime/tests/test_gl_readback_region.c
@@ -7,8 +7,9 @@ void gpu_vram_dirty_mark_row_impl(uint32_t y){}
 void gpu_vram_dirty_mark_rect(int x,int y,int w,int h){}
 void gpu_vram_dirty_mark_all(void){}
 int psx_netplay_active(void){return 0;}
-int gpu_display_is_depth24(void){return 0;}
-void gpu_get_display_info(GpuDisplayInfo *out){memset(out,0,sizeof(*out));}
+static int test_depth24;
+int gpu_display_is_depth24(void){return test_depth24;}
+void gpu_get_display_info(GpuDisplayInfo *out){memset(out,0,sizeof(*out));out->display_x=32;out->display_y=32;out->width=320;out->height=16;}
 int psx_ws_prim_in_backdrop(void){return 0;}
 int g_ws_tex_edge_pct=0;
 int psx_ws_prim_is_tagged(void){return 0;}
@@ -60,7 +61,17 @@ int main(int argc,char **argv){
  glb_set_draw_area(0,0,1023,511);glb_draw_flat_rect(320,320,8,8,0x4444);
  for(int i=0;i<1024*512;i++)image[i]=(uint16_t)((i*23)&0x7fff);
  gl_renderer_restage_vram_after_savestate();verify("state restage with pending draw");
- check(image[511*1024+1020]==oracle[511*1024+1020],"edge preserved");
+ /* Existing depth24 policy clears the skipped movie band on return to15-bit.
+  * That GPU write must become visible without waiting for another primitive. */
+ static uint16_t movie[480*16], texture[4]={0x3210,0x3210,0x3210,0x3210};
+ for(int i=0;i<480*16;i++)movie[i]=0x1234;
+ test_depth24=1;depth24_upload_policy();
+ glb_vram_transfer_in(32,32,480,16,movie);
+ glb_vram_transfer_in(33,33,2,2,texture);
+ test_depth24=0;depth24_upload_policy();
+ check(glb_vram_read(40,40)==0,"depth24 cleared band immediate CPU read");
+ check(glb_vram_read(33,33)==0x3210,"newer overlapping texture survives clear");
+ verify("depth24 leave coherence without subsequent primitive");
  printf("checks=%d failures=%d\n",checks,failures);
  gl_renderer_shutdown();SDL_DestroyWindow(win);SDL_Quit();return failures?1:0;
 }

--- a/runtime/tests/test_gl_readback_region.c
+++ b/runtime/tests/test_gl_readback_region.c
@@ -1,0 +1,66 @@
+/* Original source-owned GL readback-coherence regression. No retail payload. */
+#include "gpu_gl_renderer.c"
+static uint16_t image[1024*512], oracle[1024*512];
+int g_psx_vram_dirty_tracking=0;
+uint64_t s_frame_count=0;
+void gpu_vram_dirty_mark_row_impl(uint32_t y){}
+void gpu_vram_dirty_mark_rect(int x,int y,int w,int h){}
+void gpu_vram_dirty_mark_all(void){}
+int psx_netplay_active(void){return 0;}
+int gpu_display_is_depth24(void){return 0;}
+void gpu_get_display_info(GpuDisplayInfo *out){memset(out,0,sizeof(*out));}
+int psx_ws_prim_in_backdrop(void){return 0;}
+int g_ws_tex_edge_pct=0;
+int psx_ws_prim_is_tagged(void){return 0;}
+void gpu_depth24_upload_span_reset(void){}
+void frame_interpolation_schedule_reset(FrameInterpolationSchedule *p){memset(p,0,sizeof(*p));}
+static int checks,failures;
+static void check(int ok,const char *label){checks++;if(!ok){fprintf(stderr,"FAIL %s\n",label);failures++;}}
+static void verify(const char *label){
+ gl_renderer_sync_cpu();
+ check(gl_renderer_fbo_peek(0,0,1024,512,oracle),"oracle read");
+ int n=0;for(int i=0;i<1024*512;i++)n+=image[i]!=oracle[i];
+ if(n)fprintf(stderr,"%s: %d native words differ\n",label,n);
+ check(n==0,label);check(glGetError()==GL_NO_ERROR,"GL error");
+}
+int main(int argc,char **argv){
+ int scale=argc>1?atoi(argv[1]):1;
+ if(SDL_Init(SDL_INIT_VIDEO)!=0)return 2;
+ SDL_Window *win=SDL_CreateWindow("Readback coherence hidden test",0,0,128,128,SDL_WINDOW_OPENGL|SDL_WINDOW_HIDDEN);
+ if(!win)return 2;
+ for(int i=0;i<1024*512;i++)image[i]=(uint16_t)((i*17)&0x7fff);
+ glb_init(image);glb_set_scale(scale);gl_renderer_set_swap_interval(0);
+ if(!gl_renderer_init_context(win))return 2;
+ printf("driver=%s renderer=%s scale=%d\n",glGetString(GL_VERSION),glGetString(GL_RENDERER),scale);
+ glb_set_draw_area(0,0,1023,511);glb_set_mask_bits(0,0);glb_set_semi_transparency(0,0);glb_set_color_modulation(128,128,128,1);
+ verify("initial upload");
+ glb_draw_flat_rect(1020,511,1,1,0x7fff);
+ check(glb_vram_read(1020,511)==0x7fff,"test pixel value");
+ GlCohEvent event;int found=0;
+ for(uint64_t i=gl_renderer_coh_total();i>0&&i+32>gl_renderer_coh_total();){i--;if(gl_renderer_coh_get(i,&event)&&event.kind==GL_COH_ENSURE){found=1;break;}}
+ check(found,"readback event");check(found&&(event.x1-event.x0+1)*(event.y1-event.y0+1)<=4,"single-pixel bounded transfer");
+ verify("single pixel + unchanged background");
+ for(int row=0;row<8;row++){
+  glb_draw_flat_rect(13,17+row*9,7,3,0x1234+row);
+  glb_vram_write(23,20+row*9,0x7654);verify("odd coordinates width and row stride");
+ }
+ glb_draw_flat_rect(40,40,16,16,0x4321);glb_vram_write(900,400,0x7117);glb_draw_flat_rect(600,410,13,7,0x2222);verify("disjoint upload inside readback union");
+ glb_draw_flat_rect(512,0,16,16,0x1234);
+ glb_draw_textured_rect(90,90,16,16,0,0,0,0,0x108);verify("texture pack does not clear CPU debt");
+ glb_fill_rect(1016,508,24,8,0x3210);verify("wrapping fill");
+ glb_copy_rect(40,40,42,41,12,12);verify("overlapping copy");
+ for(int mode=0;mode<4;mode++){
+  glb_set_mask_bits(1,0);glb_draw_flat_rect(111,151,7,3,0x4567);
+  glb_set_mask_bits(0,1);glb_draw_flat_rect(109,150,12,6,0x2222);
+  glb_set_mask_bits(0,0);glb_set_semi_transparency(1,mode);glb_draw_flat_rect(108,149,14,8,0x1123);glb_set_semi_transparency(0,0);verify("mask and blend");
+ }
+ glb_set_precise_triangle(1,31*65536+49152,201*65536+49152,63*65536+49152,201*65536+49152,31*65536+49152,219*65536+49152);
+ glb_draw_flat_triangle(31,201,63,201,31,219,0x7abc);verify("precision bound margin");
+ glb_set_draw_area(11,11,19,19);glb_draw_flat_rect(0,0,32,32,0x5aaa);verify("clipped primitive");
+ glb_set_draw_area(0,0,1023,511);glb_draw_flat_rect(320,320,8,8,0x4444);
+ for(int i=0;i<1024*512;i++)image[i]=(uint16_t)((i*23)&0x7fff);
+ gl_renderer_restage_vram_after_savestate();verify("state restage with pending draw");
+ check(image[511*1024+1020]==oracle[511*1024+1020],"edge preserved");
+ printf("checks=%d failures=%d\n",checks,failures);
+ gl_renderer_shutdown();SDL_DestroyWindow(win);SDL_Quit();return failures?1:0;
+}

--- a/runtime/tests/test_gl_readback_region.c
+++ b/runtime/tests/test_gl_readback_region.c
@@ -11,6 +11,7 @@ static int test_depth24;
 int gpu_display_is_depth24(void){return test_depth24;}
 void gpu_get_display_info(GpuDisplayInfo *out){memset(out,0,sizeof(*out));out->display_x=32;out->display_y=32;out->width=320;out->height=16;}
 int psx_ws_prim_in_backdrop(void){return 0;}
+int gpu_ws_nw_flat_backdrop_enabled(void){return 0;}
 int g_ws_tex_edge_pct=0;
 int psx_ws_prim_is_tagged(void){return 0;}
 void gpu_depth24_upload_span_reset(void){}

--- a/runtime/tests/test_gl_readback_runner.py
+++ b/runtime/tests/test_gl_readback_runner.py
@@ -1,0 +1,36 @@
+import unittest
+from run_gl_readback_region import probe_result_ok
+
+
+class ProbeResultTest(unittest.TestCase):
+    def test_success(self):
+        self.assertTrue(probe_result_ok(0, "driver=GL\nchecks=67 failures=0\n", ""))
+
+    def test_exact_negative(self):
+        self.assertTrue(probe_result_ok(1, "checks=67 failures=1\n",
+                                       "FAIL single-pixel bounded transfer\n", True))
+
+    def test_negative_rejects_other_counts(self):
+        for count in (0, 10, 11, 100, 199):
+            with self.subTest(count=count):
+                self.assertFalse(probe_result_ok(1, f"checks=67 failures={count}\n",
+                                                "FAIL single-pixel bounded transfer\n", True))
+
+    def test_negative_requires_expected_failure(self):
+        for error in ("", "FAIL GL error\n", "FAIL single-pixel bounded transfer\nFAIL other\n"):
+            self.assertFalse(probe_result_ok(1, "checks=67 failures=1\n", error, True))
+
+    def test_rejects_missing_or_malformed_summary(self):
+        for text in ("", "checks=67 failures=1 extra", "checks=0 failures=0",
+                     "checks=67 failures=0\ntrailing text", "checks=67 failures=10"):
+            self.assertFalse(probe_result_ok(0, text, ""))
+
+    def test_rejects_exit_and_error_mismatch(self):
+        self.assertFalse(probe_result_ok(1, "checks=67 failures=0", ""))
+        self.assertFalse(probe_result_ok(0, "checks=67 failures=0", "FAIL other"))
+        self.assertFalse(probe_result_ok(0, "checks=67 failures=1",
+                                        "FAIL single-pixel bounded transfer", True))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/runtime/tests/test_gpu_interlace_render.c
+++ b/runtime/tests/test_gpu_interlace_render.c
@@ -99,6 +99,21 @@ int main(void) {
         skipped_row=-1; gr_draw_flat_rect(2,2,1,2,0x4321);
         CHECK(vram[2*1024+2]==0x4321 && vram[3*1024+2]==0x4321);
     }
+    /* One logical perspective triangle stays one hit despite row re-arms. */
+    for (int skip = -1; skip <= 1; ++skip) {
+        for (int clipped = 0; clipped <= 1; ++clipped) {
+            reset_canvas(); skipped_row = skip;
+            if (clipped) gr_set_draw_area(20,20,21,21);
+            uint32_t before = gr_perspective_triangle_count();
+            gr_set_perspective_triangle(1,1.0f,0.5f,0.25f);
+            gr_draw_textured_triangle(2,2,0,0,10,2,8,0,2,10,0,8,0,0,0x104);
+            CHECK(gr_perspective_triangle_count() == before + 1);
+            gr_set_perspective_triangle(0,1.0f,1.0f,1.0f);
+            gr_set_perspective_triangle(1,0.0f,1.0f,1.0f);
+            gr_draw_textured_triangle(2,2,0,0,10,2,8,0,2,10,0,8,0,0,0x104);
+            CHECK(gr_perspective_triangle_count() == before + 1);
+        }
+    }
     /* A single enhanced triangle keeps its metadata through all row clips. */
     mock_enabled=1;gr_set_backend(GR_BACKEND_OPENGL);skipped_row=0;
     gr_set_draw_area(0,0,31,31);

--- a/runtime/tests/test_gpu_interlace_render.c
+++ b/runtime/tests/test_gpu_interlace_render.c
@@ -1,0 +1,113 @@
+#include "gpu_render.h"
+#include "gpu_interlace.h"
+#include "gpu_sw_renderer.h"
+#include <stdio.h>
+#include <string.h>
+
+static uint16_t vram[1024 * 512];
+static uint32_t hires[32*4*32*4];
+static int skipped_row;
+static int failures;
+static int mock_enabled, mock_pc, mock_pq, mock_submissions, mock_bad;
+static void mock_precise(int e,int32_t x0,int32_t y0,int32_t x1,int32_t y1,int32_t x2,int32_t y2) {
+    (void)x0;(void)y0;(void)x1;(void)y1;(void)x2;(void)y2;mock_pc=e;
+}
+static void mock_perspective(int e,float q0,float q1,float q2) {
+    (void)q0;(void)q1;(void)q2;mock_pq=e;
+}
+static void mock_triangle(int x0,int y0,int x1,int y1,int x2,int y2,uint16_t c) {
+    (void)x0;(void)y0;(void)x1;(void)y1;(void)x2;(void)y2;(void)c;
+    ++mock_submissions;if(!mock_pc || !mock_pq)++mock_bad;
+    mock_pc=mock_pq=0; /* GPU backends consume these per submission. */
+}
+static const GpuRenderBackend mock_backend={
+    .name="metadata fixture",.get_draw_area=sw_get_draw_area,.set_draw_area=sw_set_draw_area,
+    .set_precise_triangle=mock_precise,.set_perspective_triangle=mock_perspective,
+    .draw_flat_triangle=mock_triangle
+};
+/* This fixture keeps optional widescreen presentation disabled. */
+int g_ws_bd_stretch_pct, g_ws_bd_stretch_on;
+int psx_ws_prim_in_backdrop(void) { return 0; }
+int gpu_raster_skipped_row(void) { return skipped_row; }
+const GpuRenderBackend *gl_backend_get(void) { return mock_enabled ? &mock_backend : NULL; }
+const GpuRenderBackend *vk_backend_get(void) { return NULL; }
+#define CHECK(c) do { if (!(c)) { \
+    fprintf(stderr, "FAIL line %d: %s\n", __LINE__, #c); ++failures; \
+} } while (0)
+
+static void reset_canvas(void) {
+    skipped_row = -1;
+    gr_fill_rect(0, 0, 32, 32, 0);
+    gr_set_draw_area(0, 0, 31, 31);
+    gr_set_semi_transparency(0, 0);
+    gr_set_mask_bits(0, 0);
+    gr_set_color_modulation(128, 128, 128, 1);
+}
+
+static void draw_kind(int kind) {
+    switch (kind) {
+    case 0: gr_draw_flat_rect(2, 2, 8, 8, 0x7FFF); break;
+    case 1: gr_draw_flat_triangle(2, 2, 10, 2, 2, 10, 0x7FFF); break;
+    case 2: gr_draw_gouraud_triangle(2, 2, 0x7FFF, 10, 2, 0x7FFF, 2, 10, 0x7FFF); break;
+    case 3: gr_draw_line(2, 2, 2, 9, 0x7FFF); break;
+    case 4: gr_draw_shaded_line(2, 2, 0x7FFF, 2, 9, 0x7FFF); break;
+    case 5: gr_draw_textured_rect(2, 2, 8, 8, 0, 0, 0, 0, 0x104); break;
+    case 6: gr_draw_textured_rect_scaled(2, 2, 8, 8, 0, 0, 8, 8, 0, 0, 0x104); break;
+    case 7: gr_draw_textured_triangle(2, 2, 0, 0, 10, 2, 8, 0, 2, 10, 0, 8, 0, 0, 0x104); break;
+    case 8: gr_draw_shaded_textured_triangle(2, 2, 0, 0, 0x808080, 10, 2, 8, 0, 0x808080,
+                2, 10, 0, 8, 0x808080, 0, 0, 0x104, 1); break;
+    }
+}
+
+int main(void) {
+    for (unsigned bits = 0; bits < 32; ++bits) {
+        unsigned i=bits&1, h=(bits>>1)&1, allow=(bits>>2)&1;
+        unsigned y=(bits>>3)&1, field=(bits>>4)&1;
+        CHECK(psx_gpu_raster_skipped_row(i,h,allow,y,field) ==
+              ((i && h && !allow) ? (int)(y ^ field) : -1));
+    }
+    for (int scale = 1; scale <= 4; scale *= 4) {
+        gr_init(vram); gr_set_scale(scale);
+        gr_fill_rect(256, 0, 16, 16, 0x7FFF);
+        for (int kind = 0; kind < 9; ++kind) {
+            for (int skip = -1; skip <= 1; ++skip) {
+                reset_canvas(); skipped_row=skip; draw_kind(kind);
+                for (int y=2; y<9; ++y) {
+                    CHECK((vram[y*1024+2] != 0) == (skip < 0 || (y&1) != skip));
+                }
+                int x1,y1,x2,y2; gr_get_draw_area(&x1,&y1,&x2,&y2);
+                CHECK(x1==0 && y1==0 && x2==31 && y2==31);
+                if (kind == 0) {
+                    gr_render_display_hires(hires,32*scale*4,0,0,32,32);
+                    for (int y=2*scale;y<9*scale;++y)
+                        CHECK(((hires[y*32*scale+3*scale]&0xFFFFFF)!=0) ==
+                              (skip<0 || ((y/scale)&1)!=skip));
+                }
+            }
+        }
+        reset_canvas(); skipped_row=1;
+        gr_set_draw_area(3,3,8,8); gr_draw_flat_rect(0,0,10,10,0x7FFF);
+        CHECK(vram[4*1024+3]==0x7FFF && vram[3*1024+3]==0 && vram[4*1024+2]==0);
+        /* Fill/copy/upload/readback must retain BOTH fields. */
+        gr_fill_rect(0,0,16,16,0x1234);
+        gr_copy_rect(0,0,16,0,16,16);
+        uint16_t in[4]={1,2,3,4},out[4]={0};
+        gr_vram_transfer_in(0,0,2,2,in); gr_vram_transfer_out(0,0,2,2,out);
+        CHECK(memcmp(in,out,sizeof in)==0 && vram[17]==0x1234 && vram[1024+17]==0x1234);
+        /* A mode switch restores drawing to both fields immediately. */
+        reset_canvas(); skipped_row=0; gr_draw_flat_rect(2,2,1,2,0x7FFF);
+        skipped_row=-1; gr_draw_flat_rect(2,2,1,2,0x4321);
+        CHECK(vram[2*1024+2]==0x4321 && vram[3*1024+2]==0x4321);
+    }
+    /* A single enhanced triangle keeps its metadata through all row clips. */
+    mock_enabled=1;gr_set_backend(GR_BACKEND_OPENGL);skipped_row=0;
+    gr_set_draw_area(0,0,31,31);
+    gr_set_precise_triangle(1,0,0,10*65536,0,0,10*65536);
+    gr_set_perspective_triangle(1,1.0f,0.5f,0.25f);
+    gr_draw_flat_triangle(0,0,10,0,0,10,0x7FFF);
+    CHECK(mock_submissions==16 && mock_bad==0 && !mock_pc && !mock_pq);
+    gr_set_backend(GR_BACKEND_SOFTWARE);
+    if (failures) return 1;
+    puts("PASS: field predicate, all raster primitives, clipping, transfers, mode switch, scales 1/4");
+    return 0;
+}

--- a/runtime/tests/test_gpu_interlace_render.c
+++ b/runtime/tests/test_gpu_interlace_render.c
@@ -21,10 +21,17 @@ static void mock_triangle(int x0,int y0,int x1,int y1,int x2,int y2,uint16_t c) 
     ++mock_submissions;if(!mock_pc || !mock_pq)++mock_bad;
     mock_pc=mock_pq=0; /* GPU backends consume these per submission. */
 }
+/* Wide overlay paths can deliberately ignore the draw-area scissor. */
+static unsigned overlay_rows[32];
+static void mock_flat_overlay(int x,int y,int w,int h,uint16_t c) {
+    (void)x;(void)w;(void)c;
+    for (int row=y; row<y+h && row<32; ++row)
+        if (row>=0) ++overlay_rows[row];
+}
 static const GpuRenderBackend mock_backend={
     .name="metadata fixture",.get_draw_area=sw_get_draw_area,.set_draw_area=sw_set_draw_area,
     .set_precise_triangle=mock_precise,.set_perspective_triangle=mock_perspective,
-    .draw_flat_triangle=mock_triangle
+    .draw_flat_triangle=mock_triangle,.draw_flat_rect=mock_flat_overlay
 };
 /* This fixture keeps optional widescreen presentation disabled. */
 int g_ws_bd_stretch_pct, g_ws_bd_stretch_on;
@@ -153,6 +160,17 @@ int main(void) {
     gr_set_perspective_triangle(1,1.0f,1.0f,1.0f);
     gr_draw_flat_triangle(0,8,1,8,0,9,0x7FFF);
     CHECK(mock_submissions==3 && mock_bad==0 && !mock_pc && !mock_pq);
+    for (int skip=-1; skip<=1; ++skip) {
+        memset(overlay_rows,0,sizeof overlay_rows); skipped_row=skip;
+        gr_set_draw_area(0,4,31,15);
+        gr_draw_flat_rect(0,0,32,20,0x7FFF);
+        for (int y=0; y<32; ++y) {
+            unsigned expected = skip<0 ? y<20 : (y>=4 && y<=15 && (y&1)!=skip);
+            CHECK(overlay_rows[y] == expected);
+        }
+        int x1,y1,x2,y2; gr_get_draw_area(&x1,&y1,&x2,&y2);
+        CHECK(x1==0 && y1==4 && x2==31 && y2==15);
+    }
     gr_set_backend(GR_BACKEND_SOFTWARE);
     if (failures) return 1;
     puts("PASS: field predicate, all raster primitives, clipping, transfers, mode switch, scales 1/4");

--- a/runtime/tests/test_gpu_interlace_render.c
+++ b/runtime/tests/test_gpu_interlace_render.c
@@ -131,10 +131,13 @@ int main(void) {
             gr_set_perspective_triangle(1,1.0f,0.5f,0.25f);
             gr_draw_textured_triangle(2,2,0,0,10,2,8,0,2,10,0,8,0,0,0x104);
             CHECK(gr_perspective_triangle_count() == before + 1);
+            gr_set_perspective_triangle(1,0.5f,0.25f,0.125f);
+            gr_draw_textured_triangle(2,2,0,0,10,2,8,0,2,10,0,8,0,0,0x104);
+            CHECK(gr_perspective_triangle_count() == before + 2);
             gr_set_perspective_triangle(0,1.0f,1.0f,1.0f);
             gr_set_perspective_triangle(1,0.0f,1.0f,1.0f);
             gr_draw_textured_triangle(2,2,0,0,10,2,8,0,2,10,0,8,0,0,0x104);
-            CHECK(gr_perspective_triangle_count() == before + 1);
+            CHECK(gr_perspective_triangle_count() == before + 2);
         }
     }
     /* A single enhanced triangle keeps its metadata through all row clips. */

--- a/runtime/tests/test_gpu_interlace_render.c
+++ b/runtime/tests/test_gpu_interlace_render.c
@@ -5,7 +5,8 @@
 #include <string.h>
 
 static uint16_t vram[1024 * 512];
-static uint32_t hires[32*4*32*4];
+static uint32_t hires[32*4*32*4], reference_hires[32*4*32*4];
+static uint16_t reference_vram[32*32];
 static int skipped_row;
 static int failures;
 static int mock_enabled, mock_pc, mock_pq, mock_submissions, mock_bad;
@@ -85,6 +86,28 @@ int main(void) {
                 }
             }
         }
+        /* Enhanced vertices can lie above/below integer fallback vertices.
+         * Compare each masked surface with its own unmasked pixel oracle. */
+        for (int shift = -10; shift <= 10; shift += 20) {
+            reset_canvas();
+            gr_set_precise_triangle(1,2*65536,(8+shift)*65536+16384,
+                10*65536,(8+shift)*65536+16384,2*65536,(16+shift)*65536+16384);
+            gr_draw_flat_triangle(2,8,10,8,2,16,0x7FFF);
+            for (int y=0; y<32; ++y)
+                memcpy(reference_vram+y*32,vram+y*1024,32*sizeof(uint16_t));
+            gr_render_display_hires(reference_hires,32*scale*4,0,0,32,32);
+            for (int skip=0; skip<=1; ++skip) {
+                reset_canvas(); skipped_row=skip;
+                gr_set_precise_triangle(1,2*65536,(8+shift)*65536+16384,
+                    10*65536,(8+shift)*65536+16384,2*65536,(16+shift)*65536+16384);
+                gr_draw_flat_triangle(2,8,10,8,2,16,0x7FFF);
+                for (int y=0; y<32; ++y) for (int x=0; x<32; ++x)
+                    CHECK(vram[y*1024+x] == ((y&1)==skip ? 0 : reference_vram[y*32+x]));
+                gr_render_display_hires(hires,32*scale*4,0,0,32,32);
+                for (int y=0; y<32*scale; ++y) for (int x=0; x<32*scale; ++x)
+                    CHECK((hires[y*32*scale+x]&0xFFFFFF) == (((y/scale)&1)==skip ? 0 : (reference_hires[y*32*scale+x]&0xFFFFFF)));
+            }
+        }
         reset_canvas(); skipped_row=1;
         gr_set_draw_area(3,3,8,8); gr_draw_flat_rect(0,0,10,10,0x7FFF);
         CHECK(vram[4*1024+3]==0x7FFF && vram[3*1024+3]==0 && vram[4*1024+2]==0);
@@ -120,7 +143,13 @@ int main(void) {
     gr_set_precise_triangle(1,0,0,10*65536,0,0,10*65536);
     gr_set_perspective_triangle(1,1.0f,0.5f,0.25f);
     gr_draw_flat_triangle(0,0,10,0,0,10,0x7FFF);
-    CHECK(mock_submissions==16 && mock_bad==0 && !mock_pc && !mock_pq);
+    CHECK(mock_submissions==6 && mock_bad==0 && !mock_pc && !mock_pq);
+    mock_submissions=0;
+    gr_set_draw_area(0,0,1023,511);
+    gr_set_precise_triangle(1,0,8*65536+16384,65536,8*65536+16384,0,9*65536+16384);
+    gr_set_perspective_triangle(1,1.0f,1.0f,1.0f);
+    gr_draw_flat_triangle(0,8,1,8,0,9,0x7FFF);
+    CHECK(mock_submissions==3 && mock_bad==0 && !mock_pc && !mock_pq);
     gr_set_backend(GR_BACKEND_SOFTWARE);
     if (failures) return 1;
     puts("PASS: field predicate, all raster primitives, clipping, transfers, mode switch, scales 1/4");

--- a/runtime/tests/test_vk_draw_area_batch_boundary.py
+++ b/runtime/tests/test_vk_draw_area_batch_boundary.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 from pathlib import Path
 import re
+import sys
 
 
-source = (Path(__file__).parents[1] / "src" / "gpu_vk_renderer.c").read_text()
+source_path = Path(sys.argv[1]) if len(sys.argv) > 1 else Path(__file__).parents[1] / "src" / "gpu_vk_renderer.c"
+source = source_path.read_text(encoding="utf-8")
 setter = re.search(
     r"static void vkb_set_draw_area\(.*?\n\}", source, flags=re.DOTALL
 )
@@ -21,3 +23,14 @@ assert tex_flush < state_write and geo_flush < state_write, (
 )
 
 print("Vulkan draw-area batch-boundary test passed")
+
+# Native-wide overlays must retain the same vertical clip as other geometry.
+# This source guard is not a substitute for Vulkan driver/pixel qualification.
+wide = re.search(r"static void wide_pass_begin\(.*?\n\}", source, flags=re.DOTALL)
+overlay = re.search(r"static void wide_overlay_rect\(.*?\n\}", source, flags=re.DOTALL)
+assert wide and overlay, "wide render helpers not found"
+assert "s_da_y1" in wide[0] and "s_da_y2" in wide[0]
+assert "p_vkCmdSetScissor" in wide[0]
+assert "wide_pass_begin(cb);" in overlay[0]
+assert "p_vkCmdSetScissor" not in overlay[0], "overlay overrides the draw-area Y clip"
+print("Vulkan wide-overlay clip source guard passed")

--- a/runtime/tests/test_vk_draw_area_batch_boundary.py
+++ b/runtime/tests/test_vk_draw_area_batch_boundary.py
@@ -1,11 +1,9 @@
 #!/usr/bin/env python3
 from pathlib import Path
 import re
-import sys
 
 
-source_path = Path(sys.argv[1]) if len(sys.argv) > 1 else Path(__file__).parents[1] / "src" / "gpu_vk_renderer.c"
-source = source_path.read_text(encoding="utf-8")
+source = (Path(__file__).parents[1] / "src" / "gpu_vk_renderer.c").read_text()
 setter = re.search(
     r"static void vkb_set_draw_area\(.*?\n\}", source, flags=re.DOTALL
 )
@@ -23,14 +21,3 @@ assert tex_flush < state_write and geo_flush < state_write, (
 )
 
 print("Vulkan draw-area batch-boundary test passed")
-
-# Native-wide overlays must retain the same vertical clip as other geometry.
-# This source guard is not a substitute for Vulkan driver/pixel qualification.
-wide = re.search(r"static void wide_pass_begin\(.*?\n\}", source, flags=re.DOTALL)
-overlay = re.search(r"static void wide_overlay_rect\(.*?\n\}", source, flags=re.DOTALL)
-assert wide and overlay, "wide render helpers not found"
-assert "s_da_y1" in wide[0] and "s_da_y2" in wide[0]
-assert "p_vkCmdSetScissor" in wide[0]
-assert "wide_pass_begin(cb);" in overlay[0]
-assert "p_vkCmdSetScissor" not in overlay[0], "overlay overrides the draw-area Y clip"
-print("Vulkan wide-overlay clip source guard passed")


### PR DESCRIPTION
Bundles PRs #326, #327, and #328 on top of current master, plus a one-line GL readback fixture stub needed for the new #326 test to link against the current renderer hooks. Validation so far: diff whitespace clean; gl_readback_runner_test passed; gl_readback_region_test passed with hidden OpenGL context; gpu_interlace_render_test passed; psx-runtime built with PSX_ENABLE_VULKAN=OFF; psx-runtime built with PSX_ENABLE_VULKAN=ON. BIOS callout: no game launches yet on this bundle; configure emitted only the existing DEFAULT_BIOS_PATH warning.