### PR TITLE
Resolve launch disc before committing mods

### DIFF
--- a/runtime/src/main.cpp
+++ b/runtime/src/main.cpp
@@ -13070,6 +13070,15 @@ int main(int argc, char** argv) {
         }
     }
 
+    if (game_config_path || disc_override_path || !resolved_disc.empty()) {
+        resolved_disc = resolve_disc_for_runtime(
+            resolved_disc, disc_override_path, game_id, argv[0]);
+        if (game_config_path && resolved_disc.empty()) {
+            std::fprintf(stderr, "psxrecomp: no disc image selected; exiting.\n");
+            return 1;
+        }
+    }
+
     {
         /* Netplay must stay vanilla: launcher commit_netplay clears the plan,
          * but a following offline-style commit would re-resolve enabled mods
@@ -13158,14 +13167,6 @@ int main(int argc, char** argv) {
         std::fprintf(stderr, "psxrecomp: no BIOS selected; exiting.\n");
         return 1;
     }
-    if (game_config_path || disc_override_path || !resolved_disc.empty()) {
-        resolved_disc = resolve_disc_for_runtime(resolved_disc, disc_override_path, game_id, argv[0]);
-        if (game_config_path && resolved_disc.empty()) {
-            std::fprintf(stderr, "psxrecomp: no disc image selected; exiting.\n");
-            return 1;
-        }
-    }
-
     /* memcard_dir was resolved to its default before the launcher (above). */
 
     std::string bios_path_str    = resolved_bios.string();


### PR DESCRIPTION
﻿Fixes a no-launcher/CLI-disc mod targeting failure seen by MegaManX6Recomp when an exact-disc mod is enabled.

The runtime was committing enabled mods before `resolve_disc_for_runtime(...)` applied the selected disc from `--disc` or cached launcher state. In that path, exact-disc package targeting could see an empty or stale disc identity and reject a valid package with `package does not target this game/image`.

This moves disc resolution ahead of the mod commit so package target checks use the same resolved disc that the runtime later mounts.

Validation:
- Reproduced against MegaManX6Recomp latest release `shared-staging-20260903` with `mmx6.tweaks.hooks` enabled and a verified stock MMX6 USA v1.1 BIN.
- Built the MMX6 runtime with this change and verified the same launch reaches BIOS/game startup without the mod target rejection.
- Ran `mmx6_preloaded_mods_test.exe <repo>\mods\preloaded`.
- Ran `mmx6_tweaks_hooks_test.exe`.
