### PR TITLE
Follow the RetroPortingToolKit transfer in submodule URLs and tooling

### DIFF
--- a/.github/actions/fetch-toolchain/action.yml
+++ b/.github/actions/fetch-toolchain/action.yml
@@ -22,7 +22,7 @@ inputs:
   repo:
     description: GitHub owner/name for toolchain releases
     required: false
-    default: TechnicallyComputers/retcomm-toolchains
+    default: RetroPortingToolKit/RetroPorting-Toolchains
 
 outputs:
   toolchain-dir:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "lib/recomp-net"]
 	path = lib/recomp-net
-	url = https://github.com/TechnicallyComputers/recomp-net.git
+	url = https://github.com/RetroPortingToolKit/recomp-net.git
 	branch = main
 
 [submodule "lib/retcomm-rbengine"]
 	path = lib/retcomm-rbengine
-	url = https://github.com/TechnicallyComputers/retcomm-rbengine.git
+	url = https://github.com/RetroPortingToolKit/rbengine.git
 	branch = main

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Git for Windows also provides the `bash` the setup script uses. Then pick one
 of these for the compiler, CMake, and Ninja:
 
 - **Bundled toolchain (recommended).** Download `cmake-clang-v1-windows-x64.zip`
-  from [retcomm-toolchains](https://github.com/TechnicallyComputers/retcomm-toolchains/releases/latest),
+  from [retcomm-toolchains](https://github.com/RetroPortingToolKit/RetroPorting-Toolchains/releases/latest),
   unzip it (for example to `C:\retcomm-toolchain`), and in the PowerShell
   window you will run the setup from:
 

--- a/THIRD_PARTY_ATTRIBUTION.md
+++ b/THIRD_PARTY_ATTRIBUTION.md
@@ -86,7 +86,7 @@ All reuse keeps the original copyright and dual MIT/Apache-2.0 license.
 
 ## retcomm-studio — multi-disc project tooling
 
-[retcomm-studio](https://github.com/TechnicallyComputers/retcomm-studio) by
+[retcomm-studio](https://github.com/RetroPortingToolKit/Retro-Studio) by
 Alex Vanderveen, licensed **MIT** (notice: `LICENSE` in that repository).
 psxrecomp is PolyForm-NC, so this is permissive vendored into stricter — the
 MIT notice must ride along and is why this entry exists.

--- a/docs/GAME_PROJECT_SETUP.md
+++ b/docs/GAME_PROJECT_SETUP.md
@@ -429,10 +429,10 @@ embedded `toolchain/`. The zip includes:
 - `recomp-ui/` sources (needed to rebuild)
 - On Windows: MinGW runtime DLLs beside the host and emitters
 
-Players (or [RetComM](https://github.com/TechnicallyComputers/RetComM-Launcher))
+Players (or [RetComM](https://github.com/RetroPortingToolKit/Retro-Launcher))
 run **Generate once** (wizard or RetComM Build & Install) with a legal disc.
 RetComM / the wizard download `cmake-clang-v1` from
-[retcomm-toolchains](https://github.com/TechnicallyComputers/retcomm-toolchains)
+[retcomm-toolchains](https://github.com/RetroPortingToolKit/RetroPorting-Toolchains)
 (or accept an offline zip / `RETCOMM_TOOLCHAIN_DIR`). Pass
 `--embed-toolchain` to `package_setup_host.sh` only for special offline-first
 packs.

--- a/host/psxrecomp_codegen_host.c
+++ b/host/psxrecomp_codegen_host.c
@@ -1905,7 +1905,7 @@ static int run_cli_posix(char* const argv[],
 
 /* ---- Host-native toolchain install (no Store Python AppData redirect) ---- */
 
-static const char* k_tc_repo = "TechnicallyComputers/retcomm-toolchains";
+static const char* k_tc_repo = "RetroPortingToolKit/RetroPorting-Toolchains";
 
 static const char* toolchain_zip_asset_name(void) {
 #if defined(_WIN32)

--- a/tools/fetch_toolchain.sh
+++ b/tools/fetch_toolchain.sh
@@ -18,7 +18,7 @@ set -euo pipefail
 ARTIFACT=""
 DL_DIR=".cache/toolchain-dl"
 OUT_DIR=".cache/toolchain-pack"
-REPO="TechnicallyComputers/retcomm-toolchains"
+REPO="RetroPortingToolKit/RetroPorting-Toolchains"
 
 usage() {
   sed -n '2,16p' "$0" | sed 's/^# \{0,1\}//'

--- a/tools/new_project_layout/project_studio/gitops.py
+++ b/tools/new_project_layout/project_studio/gitops.py
@@ -17,8 +17,8 @@ from typing import Any
 
 DEFAULT_PSXRECOMP_URL = "https://github.com/mstan/psxrecomp.git"
 DEFAULT_RECOMP_UI_URL = "https://github.com/mstan/recomp-ui.git"
-DEFAULT_RECOMP_NET_URL = "https://github.com/TechnicallyComputers/recomp-net.git"
-DEFAULT_RBENGINE_URL = "https://github.com/TechnicallyComputers/retcomm-rbengine.git"
+DEFAULT_RECOMP_NET_URL = "https://github.com/RetroPortingToolKit/recomp-net.git"
+DEFAULT_RBENGINE_URL = "https://github.com/RetroPortingToolKit/rbengine.git"
 DEFAULT_BRANCH = "master"
 DEFAULT_NESTED_BRANCH = "main"
 KNOWN_SUBMODULES = ("psxrecomp", "recomp-ui")

--- a/tools/new_project_layout/project_studio/naming.py
+++ b/tools/new_project_layout/project_studio/naming.py
@@ -297,7 +297,7 @@ def build_token_map(
         "EXE_BASENAME": exe_basename(title),
         "ZIP_PREFIX": zp,
         "GITHUB_OWNER": sanitize_github_name(
-            (github_owner or "").strip() or "TechnicallyComputers"
+            (github_owner or "").strip() or "RetroPortingToolKit"
         ),
         "GITHUB_REPO": sanitize_github_name((github_repo or "").strip() or name),
         "DISC_HINT": f"your legally owned {game} disc",

--- a/tools/new_project_layout/project_studio/readme_metrics.py
+++ b/tools/new_project_layout/project_studio/readme_metrics.py
@@ -53,8 +53,8 @@ _REMOTE_RE = re.compile(
     re.I,
 )
 
-DEFAULT_GITHUB_OWNER = "TechnicallyComputers"
-LAUNCHER_REPO = "https://github.com/TechnicallyComputers/RetComM-Launcher"
+DEFAULT_GITHUB_OWNER = "RetroPortingToolKit"
+LAUNCHER_REPO = "https://github.com/RetroPortingToolKit/Retro-Launcher"
 
 
 def parse_github_remote(url: str) -> tuple[str, str] | None:
@@ -185,10 +185,12 @@ def render_boxart_block(game_name: str) -> str:
 
 
 def render_launcher_block() -> str:
-    shots = (
-        "https://raw.githubusercontent.com/TechnicallyComputers/"
-        "RetComM-Launcher/main/docs/screenshots"
-    )
+    # Derived from LAUNCHER_REPO rather than spelled out again: this was a
+    # second copy of the slug, split across two string literals, and the org
+    # rename swept past it — every regenerated README kept the dead owner.
+    shots = LAUNCHER_REPO.replace(
+        "https://github.com/", "https://raw.githubusercontent.com/"
+    ) + "/main/docs/screenshots"
     return "\n".join(
         [
             LAUNCHER_BEGIN,
@@ -250,7 +252,17 @@ def boxart_png_present(root: Path) -> bool:
 
 
 def readme_has_launcher(text: str) -> bool:
-    return "TechnicallyComputers/RetComM-Launcher" in text
+    # Both slugs: every port generated before the RetroPortingToolKit transfer
+    # carries the old one, and matching only the new one would report each of
+    # them as missing its launcher section — and append a second copy to any
+    # README that has neither the markers nor a "## RetComM Launcher" heading.
+    return any(
+        slug in text
+        for slug in (
+            "RetroPortingToolKit/Retro-Launcher",
+            "TechnicallyComputers/RetComM-Launcher",
+        )
+    )
 
 
 def readme_has_raid(text: str) -> bool:

--- a/tools/new_project_layout/setup_project.ps1
+++ b/tools/new_project_layout/setup_project.ps1
@@ -146,9 +146,9 @@ if (-not $ZipPrefix) {
 
 if (-not $GithubOwner) {
     if ($interactive) {
-        $GithubOwner = Prompt-Line "GitHub owner / org (README download badges)" "TechnicallyComputers"
+        $GithubOwner = Prompt-Line "GitHub owner / org (README download badges)" "RetroPortingToolKit"
     } else {
-        $GithubOwner = "TechnicallyComputers"
+        $GithubOwner = "RetroPortingToolKit"
     }
 }
 $derivedRepo = (python -c "from fill_tokens import sanitize_github_name; import sys; print(sanitize_github_name(sys.argv[1]))" $Name).Trim()

--- a/tools/new_project_layout/setup_project.sh
+++ b/tools/new_project_layout/setup_project.sh
@@ -9,7 +9,7 @@
 #   --stage-disc          Copy full cue+bins into repo disc/ (large; optional)
 #   --no-stage-disc       Default: probe in place, extract boot EXE only
 #   --psxrecomp-ref / --recomp-ui-ref / --recomp-net-ref / URLs
-#   --github-owner <org>  README download-badge owner (default TechnicallyComputers)
+#   --github-owner <org>  README download-badge owner (default RetroPortingToolKit)
 #   --github-repo <name>  README download-badge repo (default project name)
 #
 # Everything else is prompted on a TTY (or passed via flags / --yes defaults):
@@ -272,10 +272,10 @@ fi
 
 if [ -z "$GITHUB_OWNER" ]; then
     if [ "$YES_MODE" -eq 1 ] || ! is_tty; then
-        GITHUB_OWNER=TechnicallyComputers
+        GITHUB_OWNER=RetroPortingToolKit
     else
         prompt_line "GitHub owner / org (README download badges)" GITHUB_OWNER \
-            "TechnicallyComputers"
+            "RetroPortingToolKit"
     fi
 fi
 if [ -z "$GITHUB_REPO" ]; then

--- a/tools/new_project_layout/templates/README.md.in
+++ b/tools/new_project_layout/templates/README.md.in
@@ -28,18 +28,18 @@ Scaffolded with the New Project Layout. See
 You can run this title **standalone** (release zip + the built-in recomp-ui
 Generate & Build flow), or manage installs, updates, ROM/BIOS wiring, and queued
 builds more intuitively with
-**[RetComM Launcher](https://github.com/TechnicallyComputers/RetComM-Launcher)** —
+**[RetComM Launcher](https://github.com/RetroPortingToolKit/Retro-Launcher)** —
 the Retro Compilation Manager hub for self-compiling recomps.
 
-[Downloads](https://github.com/TechnicallyComputers/RetComM-Launcher/releases) ·
-[Full README & features](https://github.com/TechnicallyComputers/RetComM-Launcher#readme)
+[Downloads](https://github.com/RetroPortingToolKit/Retro-Launcher/releases) ·
+[Full README & features](https://github.com/RetroPortingToolKit/Retro-Launcher#readme)
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/TechnicallyComputers/RetComM-Launcher/main/docs/screenshots/hub-and-game-launcher.png" alt="RetComM hub with a background build, next to a title’s recomp-ui launcher" width="720">
+  <img src="https://raw.githubusercontent.com/RetroPortingToolKit/Retro-Launcher/main/docs/screenshots/hub-and-game-launcher.png" alt="RetComM hub with a background build, next to a title’s recomp-ui launcher" width="720">
 </p>
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/TechnicallyComputers/RetComM-Launcher/main/docs/screenshots/queue-and-background-build.png" alt="Background cmake build with titles queued" width="720">
+  <img src="https://raw.githubusercontent.com/RetroPortingToolKit/Retro-Launcher/main/docs/screenshots/queue-and-background-build.png" alt="Background cmake build with titles queued" width="720">
 </p>
 
 RetComM checks for updates, rebuilds with existing build data when possible,

--- a/tools/package_setup_host.sh
+++ b/tools/package_setup_host.sh
@@ -498,7 +498,7 @@ Standalone:
 3. Provide ${DISC_HINT} (and optional retail SCPH-1001 BIOS; otherwise
    OpenBIOS is regenerated locally).
 4. Follow the Generate & rebuild wizard. On first rebuild the host downloads
-   cmake-clang-v1 from TechnicallyComputers/retcomm-toolchains (or you can
+   cmake-clang-v1 from RetroPortingToolKit/RetroPorting-Toolchains (or you can
    pick a local cmake-clang-v1-*.zip for offline builds). System cmake/ninja
    also works if already on PATH.
 

--- a/tools/toolchain_pack.py
+++ b/tools/toolchain_pack.py
@@ -24,7 +24,7 @@ import zipfile
 from pathlib import Path
 from typing import Optional
 
-DEFAULT_REPO = "TechnicallyComputers/retcomm-toolchains"
+DEFAULT_REPO = "RetroPortingToolKit/RetroPorting-Toolchains"
 PACK_ID = "cmake-clang-v1"
 
 _ASSET = {


### PR DESCRIPTION
`recomp-net`, `retcomm-rbengine` (now **rbengine**), `retcomm-toolchains` (now **RetroPorting-Toolchains**), the catalog and the launcher moved from `TechnicallyComputers` to the `RetroPortingToolKit` org.

GitHub still redirects the old repo URLs, so **nothing is broken today**. But this repo is what every port inherits its `.gitmodules` from, so the old owner keeps propagating into each new clone until it's fixed here. Studio's *Git settings* dialog reads those URLs, which is where this surfaced:

```
$ project_studio git module-urls --root <a port>
[nested] lib/recomp-net
    .gitmodules https://github.com/TechnicallyComputers/recomp-net.git
```

## What changed

- `.gitmodules` → `RetroPortingToolKit/recomp-net.git`, `RetroPortingToolKit/rbengine.git`
- Toolchain repo in the CI action default, the codegen host, `fetch_toolchain.sh`, `toolchain_pack.py`, `package_setup_host.sh`
- Scaffolder `recomp-net` / `rbengine` defaults
- Scaffolder default GitHub owner for **new** ports → `RetroPortingToolKit` (existing ports carry their own owner in the README and remote, so they're unaffected)

## Two things a find-and-replace would have missed

**`render_launcher_block()` held a second copy of the launcher slug, split across two string literals:**

```python
shots = (
    "https://raw.githubusercontent.com/TechnicallyComputers/"
    "RetComM-Launcher/main/docs/screenshots"
)
```

Neither line contains the full slug, so a search for it doesn't match — every regenerated README kept the dead owner. It's now derived from `LAUNCHER_REPO`, so the slug lives in exactly one place.

**`readme_has_launcher()` matched one exact slug.** Pointed at the new one alone, it would report every port built before the transfer as missing its launcher section (`detect.py` feeds that into the audit's "missing" list), and append a *second* launcher block to any README carrying neither the HTML markers nor a `## RetComM Launcher` heading. It now accepts both slugs.

## Deliberately unchanged

- `psxrecomp`, `snesrecomp`, `recomp-ui` did **not** move — still `mstan`. Verified against the live repos.
- Submodule **paths** (`lib/recomp-net`, `lib/retcomm-rbengine`) are pinned by every port and are not repo slugs.

## Verification

`bash -n` clean on the scaffolders; `readme_has_launcher` checked against both old- and new-slug READMEs (both `True`, unrelated text `False`); `render_launcher_block()` emits only `RetroPortingToolKit/Retro-Launcher`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018xfKkiEkh87zL1EpE5Ty55