### PR TITLE
Rename the product to Retro, and follow recomp-ui to the org

### DIFF
--- a/THIRD_PARTY_ATTRIBUTION.md
+++ b/THIRD_PARTY_ATTRIBUTION.md
@@ -107,5 +107,5 @@ written here because neither repository had it: `probe_disc.py
 scaffolding a project and destructive on a live one.
 
 Keep the pin above accurate when re-syncing. These files are the reason a
-standalone setup-wizard install and a RetComM build produce the same
+standalone setup-wizard install and a Retro build produce the same
 multi-disc `game.toml`; if the two drift, so do those two paths.

--- a/docs/GAME_PROJECT_SETUP.md
+++ b/docs/GAME_PROJECT_SETUP.md
@@ -298,7 +298,7 @@ multi-track `.cue`/`.bin` requirements.
 Everything game-specific lives at the **root** of *your* title repo. Framework
 and UI are submodules next to that code — not nested under each other.
 
-The RetComM / Generate & rebuild CLI (`psxrecomp_cli.py`, `tools/prepare_disc.py`,
+The Retro / Generate & rebuild CLI (`psxrecomp_cli.py`, `tools/prepare_disc.py`,
 pack helpers) ships **inside** the `psxrecomp` submodule. There is no separate
 `psxrecomp-sdk/` tree.
 
@@ -307,12 +307,12 @@ YourGameRecomp/                 # your git repo
 ├── .gitmodules
 ├── CMakeLists.txt              # thin: psxrecomp_add_game_runtime(...)
 ├── game.toml                   # probe autofills identity / netplay gates
-├── catalog_identity.json       # RetComM / catalog digests + track_counts + disc_fp
+├── catalog_identity.json       # Retro / catalog digests + track_counts + disc_fp
 ├── framework_pins.txt          # optional scaffold snapshot (gitlinks are authoritative)
 ├── README.md                   # scaffold stub (legal + quick start)
 ├── VERSION                     # release pin (e.g. 0.1.0)
 ├── assets/
-│   ├── psxrecomp.ico           # default Windows app icon (RetComM-themed pad)
+│   ├── psxrecomp.ico           # default Windows app icon (Retro-themed pad)
 │   ├── psxrecomp.png           # staged beside exe / packaging
 │   └── psxrecomp.svg           # source mark (see psxrecomp/assets/)
 ├── seeds/ghidra_funcs.txt      # probe: boot-EXE JAL seeds (grow over time)
@@ -371,7 +371,7 @@ Or use the scaffolding scripts under **New Project Layout (preview)** above.
 ```bash
 cd YourGameRecomp
 git submodule add -b master https://github.com/mstan/psxrecomp.git psxrecomp
-git submodule add -b master https://github.com/mstan/recomp-ui.git recomp-ui
+git submodule add -b master https://github.com/RetroPortingToolKit/recomp-ui.git recomp-ui
 git submodule update --init --recursive
 ```
 
@@ -429,9 +429,9 @@ embedded `toolchain/`. The zip includes:
 - `recomp-ui/` sources (needed to rebuild)
 - On Windows: MinGW runtime DLLs beside the host and emitters
 
-Players (or [RetComM](https://github.com/RetroPortingToolKit/Retro-Launcher))
-run **Generate once** (wizard or RetComM Build & Install) with a legal disc.
-RetComM / the wizard download `cmake-clang-v1` from
+Players (or [Retro](https://github.com/RetroPortingToolKit/Retro-Launcher))
+run **Generate once** (wizard or Retro Build & Install) with a legal disc.
+Retro / the wizard download `cmake-clang-v1` from
 [retcomm-toolchains](https://github.com/RetroPortingToolKit/RetroPorting-Toolchains)
 (or accept an offline zip / `RETCOMM_TOOLCHAIN_DIR`). Pass
 `--embed-toolchain` to `package_setup_host.sh` only for special offline-first
@@ -441,7 +441,7 @@ packs.
 
 | Action | Meaning |
 |--------|---------|
-| **Update** (RetComM) | New setup-host zip → refresh source → cmake rebuild. Skips disc→C when `codegen-cache` fingerprints (ROM/BIOS/emitters) still match. |
+| **Update** (Retro) | New setup-host zip → refresh source → cmake rebuild. Skips disc→C when `codegen-cache` fingerprints (ROM/BIOS/emitters) still match. |
 | **Generate & Rebuild** | Force regenerate game C from the disc, then rebuild. Use when emit inputs change or cache is wrong. |
 
 Ordinary host/UI releases do **not** require Generate & Rebuild. Details:
@@ -559,7 +559,7 @@ Full action reference: `[ci/README.md](ci/README.md)`.
 ## Bundled release checklist
 
 Use this before tagging a setup-host release that matches other titles
-(BPE / MotK / RetComM).
+(BPE / MotK / Retro).
 
 ### Repository
 
@@ -631,7 +631,7 @@ Use this before tagging a setup-host release that matches other titles
   ```
 - [ ] Extract → run host → Generate with a legal disc succeeds end-to-end
 - [ ] After rebuild, game launches; saves/settings land beside the exe
-- [ ] RetComM install/update (if you publish a catalog entry) uses this **same**
+- [ ] Retro install/update (if you publish a catalog entry) uses this **same**
   ```
   zip — no separate tools pack required; Update rebuilds via codegen-cache
   (not raw zip extract over a Play binary)
@@ -648,4 +648,4 @@ Use this before tagging a setup-host release that matches other titles
   ```
   no pre-generated game C)
   ```
-- [ ] Catalog / RetComM entry points at the release assets when ready
+- [ ] Catalog / Retro entry points at the release assets when ready

--- a/docs/GPU_FRAME_TOOLS.md
+++ b/docs/GPU_FRAME_TOOLS.md
@@ -12,7 +12,7 @@ tools/gpu_parity.py          frame-locked image parity vs DuckStation
 tools/tests/test_gpu_frame.py
 ```
 
-RetComM Studio's **Frames** tab is a viewer and launcher over exactly these
+Retro Studio's **Frames** tab is a viewer and launcher over exactly these
 artifacts. It never decodes a GP0 packet itself, so a headless capture and the
 GUI can never disagree about what a frame contained.
 
@@ -96,7 +96,7 @@ grep -E '^(PSX_DEBUG_TOOLS|CMAKE_BUILD_TYPE):' build-release/CMakeCache.txt
 `CMAKE_BUILD_TYPE` on an **existing** build dir does *not* flip it. Pass the
 `-D` explicitly, or start a fresh build dir.
 
-In RetComM Studio this is the **Build tab → Debug tools** row: a selector that
+In Retro Studio this is the **Build tab → Debug tools** row: a selector that
 injects the flag, a **Configure for debugging** button that sets Release + ON in
 one click, and a status line that reads the configured build dir and says
 whether the server will be there. The Frames tab shows the same line when it

--- a/docs/LOCAL_CODEGEN_SDK.md
+++ b/docs/LOCAL_CODEGEN_SDK.md
@@ -1,7 +1,7 @@
 # Local codegen SDK
 
 Headless contract for regenerating an existing psxrecomp game project from a
-user-supplied disc. Intended for `recomp-ui` setup flows and RetComM launcher
+user-supplied disc. Intended for `recomp-ui` setup flows and Retro launcher
 automation. This does **not** redistribute disc images.
 
 PGO (optional) runs **only on the user’s machine** during local rebuild when
@@ -38,14 +38,14 @@ product binary (`psxrecomp_codegen_host_forward_if_built`). Opt out with
 | `tools/stage_setup_sdk.sh` | Pack: emitters, OpenBIOS checks, optional `toolchain/`, MinGW DLLs |
 | `tools/bundle_mingw_dlls.sh` | Windows: copy MinGW runtime DLLs next to host + emitters |
 | Project `toolchain/` | Stamp file `.psxrecomp-bin` pointing at the shared pack `bin/` |
-| Shared toolchain cache | `%LOCALAPPDATA%/retcomm/toolchains/cmake-clang-v1/` (Windows) or `~/.local/share/retcomm/toolchains/cmake-clang-v1/` — same tree RetComM uses |
+| Shared toolchain cache | `%LOCALAPPDATA%/retcomm/toolchains/cmake-clang-v1/` (Windows) or `~/.local/share/retcomm/toolchains/cmake-clang-v1/` — same tree Retro uses |
 | `docs/ci/` | Composite actions + [`templates/setup-release.yml`](ci/templates/setup-release.yml) |
 | `docs/GAME_PROJECT_SETUP.md` | Submodules, CI template usage, bundled-release checklist |
 | Game sources | `game.toml`, seeds, `CMakeLists.txt` at repo root; `psxrecomp/`, `recomp-ui/` submodules |
 
-RetComM harvests emitters into the SDK cache and **downloads** `cmake-clang-v1`
+Retro harvests emitters into the SDK cache and **downloads** `cmake-clang-v1`
 (no separate tools zip; game zips stay lean). The setup host and CLI install the
-portable pack into the **shared RetComM cache**
+portable pack into the **shared Retro cache**
 (`%LOCALAPPDATA%/retcomm/toolchains/cmake-clang-v1/<tag>/`, or XDG equivalent)
 with host-native `curl` + `tar`/`unzip` when possible — so Microsoft Store
 Python AppData redirection cannot hide cmake. Offline zips unpack to the same

--- a/docs/NETPLAY.md
+++ b/docs/NETPLAY.md
@@ -156,7 +156,7 @@ asymmetric NAT does not strand players on failed ICE attempts.
 signaling, and fallbacks. With `PSX_NETPLAY=ON`, `runtime.cmake` defaults
 `RNET_ENABLE_ICE=ON` (libjuice) before adding `recomp-net`. Pass
 `-DRNET_ENABLE_ICE=OFF` only for LAN-only / no-FetchContent builds.
-libjuice is pulled as a **pinned URL tarball** (not `git clone`) so RetComM
+libjuice is pulled as a **pinned URL tarball** (not `git clone`) so Retro
 AppImage / mismatched-libcurl hosts can still configure; offline builds can
 vendor `lib/recomp-net/third_party/libjuice` or set `-DRNET_LIBJUICE_ROOT`.
 “Force TURN” in the UI can raise delay floors for relay-heavy paths; it

--- a/docs/ci/HOST_ONLY_RELEASES.md
+++ b/docs/ci/HOST_ONLY_RELEASES.md
@@ -33,17 +33,17 @@ the portable llvm-mingw fetch; host compile stays on MSYS2 g++.
 Bump the `psxrecomp` gitlink when emitter/CLI behavior must change; leave it
 pinned for pure host/UI/`recomp-ui` releases so CI stays cmake-time.
 
-## What players / RetComM do
+## What players / Retro do
 
 | Step | When |
 |------|------|
-| **Generate** (wizard or RetComM Build & Install) | First install, or after ROM/BIOS/emitter fingerprint changes |
-| **Update** (RetComM) | New setup-host zip → refresh source → cmake rebuild; **codegen-cache** skips regenerate when fingerprints match |
+| **Generate** (wizard or Retro Build & Install) | First install, or after ROM/BIOS/emitter fingerprint changes |
+| **Update** (Retro) | New setup-host zip → refresh source → cmake rebuild; **codegen-cache** skips regenerate when fingerprints match |
 | **Generate & Rebuild** | Force disc→C again (`force_generate`) |
 
 Players do **not** need Generate & Rebuild for ordinary host/UI updates after the
-first successful generate. RetComM keeps `apps/<title>/codegen-cache/` keyed by
-ROM/BIOS + emitter fingerprints (see RetComM `docs/BUILD_PACKS.md`).
+first successful generate. Retro keeps `apps/<title>/codegen-cache/` keyed by
+ROM/BIOS + emitter fingerprints (see Retro `docs/BUILD_PACKS.md`).
 
 Raw zip extract is for true prebuilt Play binaries only. Setup-host catalog
 entries use local generate+cmake (`install_title_auto` / `update_title_auto`).

--- a/docs/ci/README.md
+++ b/docs/ci/README.md
@@ -37,7 +37,7 @@ patch). Pass an explicit version to override. Shared helper:
 
 
 **Host-only model / player updates:** [`HOST_ONLY_RELEASES.md`](HOST_ONLY_RELEASES.md)
-(CI never ships game C; RetComM Update reuses codegen-cache for host/UI bumps;
+(CI never ships game C; Retro Update reuses codegen-cache for host/UI bumps;
 `reuse_cached_emitters` + ccache speed up release jobs when the `psxrecomp` pin
 is unchanged).
 

--- a/docs/ci/templates/setup-release.yml
+++ b/docs/ci/templates/setup-release.yml
@@ -21,7 +21,7 @@
 # still loads the ICD dynamically via SDL.
 #
 # workflow_dispatch: leave version empty to auto-bump patch (or choose bump).
-# Host-focused releases: CI never ships game C. Players Generate once; RetComM
+# Host-focused releases: CI never ships game C. Players Generate once; Retro
 # Update reuses codegen-cache when ROM/BIOS/emitters match (cmake-only).
 # See docs/ci/HOST_ONLY_RELEASES.md. reuse_cached_emitters skips rebuilding
 # psxrecomp-game/bios when the psxrecomp SHA cache hits (host/UI bumps).
@@ -554,7 +554,7 @@ jobs:
             export BPE_RUNTIME_BIN_DIR=/mingw64/bin
           fi
           export RELEASE_VERSION
-          # Lean zip (no embedded toolchain/). RetComM / wizard download
+          # Lean zip (no embedded toolchain/). Retro / wizard download
           # cmake-clang-v1; pass --embed-toolchain only for offline-first packs.
           scripts/package_setup_release.sh build-ci "${{ matrix.artifact }}" build-recompiler
           ls -la dist/

--- a/docs/config_schema.md
+++ b/docs/config_schema.md
@@ -90,9 +90,9 @@ that is where the others go when a title needs them.
 
 Offline Play may still launch with a TOC warning; first-run setup Finish and
 online Create/Join require `netplay_ok` (and online also a clean verify +
-non-empty `disc_fp`). Mirror `required_tracks` in the RetComM catalog as
+non-empty `disc_fp`). Mirror `required_tracks` in the Retro catalog as
 `rom_identity.track_counts` so the hub library scan rejects Track-01-only dumps.
-Wizard / RetComM / catalog submission accept Redump `.cue` + sibling `.bin`
+Wizard / Retro / catalog submission accept Redump `.cue` + sibling `.bin`
 tracks only — not `.iso`/`.chd` (cannot reliably expand to multi-track).
 
 ## Program / game block

--- a/host/psxrecomp_codegen_host.c
+++ b/host/psxrecomp_codegen_host.c
@@ -475,7 +475,7 @@ static int python_env_usable(const char* env) {
     return 1;
 }
 
-/* Prefer portable pack CPython (RetComM / cmake-clang-v1), then system. */
+/* Prefer portable pack CPython (Retro / cmake-clang-v1), then system. */
 static int find_python(char* out, size_t cap) {
     const char* env = getenv("RETCOMM_PYTHON");
     if (python_env_usable(env)) {
@@ -998,7 +998,7 @@ static int name_is_releases(const char* name) {
 #endif
 }
 
-/* RetComM stages Play under apps/<title>/releases/<tag>/ while the generate
+/* Retro stages Play under apps/<title>/releases/<tag>/ while the generate
  * tree lives at apps/<title>/src/current/. Walking parents of the release dir
  * never visits that sibling — probe it explicitly. */
 static int try_retcomm_src_current(const char* start, char* out, size_t cap) {
@@ -3412,7 +3412,7 @@ static int host_toolchain_update_available(char* local_ver, size_t local_cap,
 
 /* Download or offline-install cmake-clang-v1 (wizard page 0 / rebuild fallback).
  * Prefer host-native curl/tar so Microsoft Store Python cannot redirect the
- * unpack into Packages\\...\\LocalCache. Installs into the shared RetComM
+ * unpack into Packages\\...\\LocalCache. Installs into the shared Retro
  * cache: %LOCALAPPDATA%/retcomm/toolchains/cmake-clang-v1/…
  * Broken latest/ stamps are healed, then GitHub /releases/latest is fetched.
  *
@@ -3520,7 +3520,7 @@ static int host_ensure_toolchain(RecompLauncherCPrepareProgressFn on_progress,
  * disc.cfg is the mounted-image cache and the runtime takes only its first
  * line; the hot-swap roster is built from game.toml [game] discs. So the
  * wizard's picks reach the roster only by being written there -- which is
- * exactly what the RetComM path does by running probe_disc.py per image and
+ * exactly what the Retro path does by running probe_disc.py per image and
  * verify_disc_set.py over the results.
  *
  * update_disc_set.py performs the same probe/verify and then edits ONLY the

--- a/psxrecomp_cli.py
+++ b/psxrecomp_cli.py
@@ -593,7 +593,7 @@ def _build_recompiler_targets(
             )
 
     src = recompiler_source_dir(project_root)
-    # Prefer recompiler/build (packaging / RetComM harvest layout); also keep
+    # Prefer recompiler/build (packaging / Retro harvest layout); also keep
     # project-root build-recompiler if that is where prior binaries lived.
     build_dir = src / "build"
     try:
@@ -755,7 +755,7 @@ def ensure_framework(
 ) -> Path:
     """Ensure project_root/psxrecomp has BIOS profiles + seeds for local generate.
 
-    GitHub zipballs omit git submodules, so RetComM source trees often lack
+    GitHub zipballs omit git submodules, so Retro source trees often lack
     psxrecomp/bios. Seed from the SDK pack that ships this CLI (ROOT).
     """
     fw = project_root / "psxrecomp"
@@ -780,7 +780,7 @@ def ensure_framework(
         marker = fw / ".gitignore"
         if not marker.is_file():
             marker.write_text(
-                "# RetComM SDK seed marker (project-root for psxrecomp-bios)\n",
+                "# Retro SDK seed marker (project-root for psxrecomp-bios)\n",
                 encoding="utf-8",
             )
     return framework_root(project_root)
@@ -1765,7 +1765,7 @@ def cmd_pgo_train(args: argparse.Namespace, progress: ProgressReporter) -> int:
 
 
 def cmd_ensure_toolchain(args: argparse.Namespace, progress: ProgressReporter) -> int:
-    """Resolve / download / unpack cmake-clang-v1 into the shared RetComM cache."""
+    """Resolve / download / unpack cmake-clang-v1 into the shared Retro cache."""
     project_root = (
         Path(args.project_root).expanduser().resolve()
         if args.project_root

--- a/recompiler/src/analysis_export.h
+++ b/recompiler/src/analysis_export.h
@@ -1,7 +1,7 @@
 #pragma once
 // analysis_export.h — writers that turn an AnalysisDb into artifacts.
 //
-// The JSON files are the stable public interface: RetComM Studio and any other
+// The JSON files are the stable public interface: Retro Studio and any other
 // front end consume those, never the analyzer's in-process types. Everything
 // else here exists to hand the data to tools people already use rather than to
 // make them adopt a new one.

--- a/recompiler/src/full_function_emitter.cpp
+++ b/recompiler/src/full_function_emitter.cpp
@@ -2309,7 +2309,7 @@ EmitStats FullFunctionEmitter::emit(
 {
     EmitStats stats;
 
-    // Setup / RetComM zips omit generated/; create it before ofstream.
+    // Setup / Retro zips omit generated/; create it before ofstream.
     if (!out_dir.empty()) {
         std::error_code ec;
         std::filesystem::create_directories(out_dir, ec);

--- a/runtime/runtime.cmake
+++ b/runtime/runtime.cmake
@@ -31,7 +31,7 @@ endif()
 # SOURCE + compiler + flags (content, not mtime), so those recompiles collapse to
 # near-instant cache hits after any branch op. Completely no-op when ccache is not
 # on PATH, so builds still work without it. Set once, before any target is added.
-# RetComM cmake-clang-v1 packs ship bin/ccache and prepend that dir to PATH;
+# Retro cmake-clang-v1 packs ship bin/ccache and prepend that dir to PATH;
 # also HINT RETCOMM_TOOLCHAIN_DIR for wizards that only set the env override.
 if(NOT DEFINED CMAKE_C_COMPILER_LAUNCHER)
     set(_psx_ccache_hints "")
@@ -103,7 +103,7 @@ set(PSX_SDL_LIBRARIES "")
 set(PSX_SDL_STATIC_LDFLAGS "")
 set(PSX_SDL3 OFF)
 
-# Portable cmake-clang-v1 pack roots (wizard / RetComM / CI emitter fetch).
+# Portable cmake-clang-v1 pack roots (wizard / Retro / CI emitter fetch).
 # Collect as HINTS only — never list(PREPEND CMAKE_PREFIX_PATH …): on Windows CI
 # the pack is llvm-mingw while the setup host links with MSYS2 g++, and a
 # global prefix puts pack lib/ on the -L path so -static-libstdc++ can pick up
@@ -1447,7 +1447,7 @@ function(psxrecomp_add_runtime_target target)
 
     # ---- Windows / desktop app icon ---------------------------------------
     # Prefer an explicit APP_ICON, then the game-repo copy under assets/, then
-    # the framework default shipped in psxrecomp/assets (RetComM-themed pad).
+    # the framework default shipped in psxrecomp/assets (Retro-themed pad).
     if(NOT PSXRT_APP_ICON)
         if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/assets/psxrecomp.ico")
             set(PSXRT_APP_ICON "${CMAKE_CURRENT_SOURCE_DIR}/assets/psxrecomp.ico")
@@ -1862,7 +1862,7 @@ function(psxrecomp_add_runtime_target target)
                 "PSX_RECOMP_UI=ON but recomp-ui is missing.\n"
                 "Add at the game repo root:\n"
                 "  git submodule add -b master "
-                "https://github.com/mstan/recomp-ui.git recomp-ui\n"
+                "https://github.com/RetroPortingToolKit/recomp-ui.git recomp-ui\n"
                 "Or set -DRECOMP_UI_ROOT=/path/to/recomp-ui")
         endif()
         # recomp-ui gates its Mods view behind RECOMP_UI_ENABLE_MODS, which

--- a/tools/duckstation/README.md
+++ b/tools/duckstation/README.md
@@ -13,7 +13,7 @@ PSXRecomp v4 uses a patched build of [stenzek/duckstation](https://github.com/st
 ## First-time setup -- Linux / macOS
 
 Use `tools/duckstation_oracle.py`. It installs outside any game repo, into the
-shared RetComM data root, so one build serves every title:
+shared Retro data root, so one build serves every title:
 
 ```text
 ~/.local/share/retcomm/oracle/duckstation/     ($RETCOMM_DATA_DIR, or $RETCOMM_ORACLE_DIR)

--- a/tools/duckstation_oracle.py
+++ b/tools/duckstation_oracle.py
@@ -18,7 +18,7 @@ bracket where.
 Where it lives
 --------------
 NOT in the game repo. The oracle is a developer tool shared by every recomp
-title, so it installs into the RetComM data root alongside the toolchains and
+title, so it installs into the Retro data root alongside the toolchains and
 catalog:
 
     ~/.local/share/retcomm/oracle/duckstation/       (Linux / macOS)
@@ -26,7 +26,7 @@ catalog:
     %LOCALAPPDATA%\\retcomm\\oracle\\duckstation\\      (Windows fallback)
 
 Override with RETCOMM_ORACLE_DIR, or move the whole root with RETCOMM_DATA_DIR
-(the same variables RetComM Launcher and Studio already honour).
+(the same variables Retro Launcher and Studio already honour).
 
     <root>/src/          pinned upstream checkout with the oracle patch applied
     <root>/build/        cmake/ninja tree
@@ -160,7 +160,7 @@ def log(msg: str) -> None:
 # ---------------------------------------------------------------------------
 
 def data_root() -> Path:
-    """The RetComM shared data root — same one the launcher and Studio use.
+    """The Retro shared data root — same one the launcher and Studio use.
 
     The precedence must match studio_runner.cpp's retcomm_data_dir() exactly,
     XDG_DATA_HOME included. If the two disagree, the GUI reports an oracle
@@ -656,7 +656,7 @@ def cmd_build(args: argparse.Namespace) -> int:
 def find_bios(explicit: Optional[str]) -> Optional[Path]:
     """Locate a retail BIOS image for the oracle.
 
-    Order: what the caller passed, then the RetComM BIOS root, then the engine
+    Order: what the caller passed, then the Retro BIOS root, then the engine
     checkout this script lives in. Never downloads one — a BIOS dump is the
     user's own property and is not redistributable.
     """
@@ -1209,7 +1209,7 @@ def main(argv=None) -> int:
 
     p = sub.add_parser("status", help="where it is and what state it is in")
     p.add_argument("--json", action="store_true",
-                   help="machine-readable, for RetComM Studio")
+                   help="machine-readable, for Retro Studio")
     p.set_defaults(func=cmd_status)
 
     p = sub.add_parser("path", help="print the install root")

--- a/tools/gpu_frame_capture.py
+++ b/tools/gpu_frame_capture.py
@@ -21,7 +21,7 @@ freezing forwards, and it is the only thing that works for a glitch you cannot
 stop on.
 
 Writes <out>/<tag>.json (a psx-gpu-frame dump), <out>/<tag>.summary.json (the
-compact attribution RetComM Studio reads), <out>/<tag>.png (the presented
+compact attribution Retro Studio reads), <out>/<tag>.png (the presented
 frame), and <out>/<tag>.opcodes.json, so a later diff or layer render needs
 nothing still running.
 """

--- a/tools/gpu_parity.py
+++ b/tools/gpu_parity.py
@@ -27,7 +27,7 @@ there is nothing to do but restart the DuckStation side; that is reported rather
 than papered over.
 
 Getting the oracle: `python3 duckstation_oracle.py all` builds and installs a
-patched DuckStation into the RetComM data root (once, ~10 minutes), and
+patched DuckStation into the Retro data root (once, ~10 minutes), and
 `duckstation_oracle.py start --disc <cue>` runs it headless on 4371. Pass
 --start-oracle here to have this tool do that for you when nothing is listening.
 

--- a/tools/new_project_layout/fill_tokens.py
+++ b/tools/new_project_layout/fill_tokens.py
@@ -42,7 +42,7 @@ def install_dir_name(name: str) -> str:
     """Local checkout / launcher ``apps/`` folder — same slug as the GitHub repo name.
 
     New-project wizard must create this folder (not the display name with spaces)
-    so Studio catalog matching and RetComM ``install_dir_name`` stay consistent.
+    so Studio catalog matching and Retro ``install_dir_name`` stay consistent.
     """
     return sanitize_github_name(name)
 

--- a/tools/new_project_layout/probe_disc.py
+++ b/tools/new_project_layout/probe_disc.py
@@ -651,7 +651,7 @@ def main() -> int:
     ap.add_argument(
         "--write-catalog",
         default="",
-        help="write catalog_identity.json for RetComM / submission autofill",
+        help="write catalog_identity.json for Retro / submission autofill",
     )
     ap.add_argument(
         "--write-seeds",

--- a/tools/new_project_layout/project_studio/cli.py
+++ b/tools/new_project_layout/project_studio/cli.py
@@ -168,13 +168,13 @@ def cmd_gui(args: argparse.Namespace) -> int:
     # tools/new_project_layout/project_studio/cli.py → repo root
     repo = here.parents[3] if len(here.parents) > 3 else here.parents[2]
     for rel in (
-        Path("build") / "RetComM-Studio",
+        Path("build") / "Retro-Studio",
         Path("build") / "retcomm-studio",
-        Path("build-release") / "RetComM-Studio",
-        Path("out") / "bin" / "RetComM-Studio",
+        Path("build-release") / "Retro-Studio",
+        Path("out") / "bin" / "Retro-Studio",
     ):
         candidates.append(repo / rel)
-    which = shutil.which("RetComM-Studio") or shutil.which("retcomm-studio")
+    which = shutil.which("Retro-Studio") or shutil.which("retcomm-studio")
     if which:
         candidates.append(Path(which))
 
@@ -186,10 +186,10 @@ def cmd_gui(args: argparse.Namespace) -> int:
             return int(subprocess.call(cmd))
 
     print(
-        "RetComM Studio GUI is Dear ImGui (native).\n"
+        "Retro Studio GUI is Dear ImGui (native).\n"
         "Build it first:\n"
         "  cmake -S . -B build && cmake --build build\n"
-        "  ./build/RetComM-Studio\n"
+        "  ./build/Retro-Studio\n"
         "Or set RETCOMM_STUDIO_BIN to the executable path.",
         file=sys.stderr,
     )

--- a/tools/new_project_layout/project_studio/detect.py
+++ b/tools/new_project_layout/project_studio/detect.py
@@ -740,7 +740,7 @@ def audit_project(root: Path) -> AuditReport:
                 title="Disc / catalog identity",
                 status=CheckStatus.WARN,
                 severity=Severity.RECOMMENDED,
-                detail="No catalog_identity.json / [prepare_disc] — needed for RetComM gates.",
+                detail="No catalog_identity.json / [prepare_disc] — needed for Retro gates.",
                 fix_op="probe_disc_refresh",
             )
         )
@@ -785,7 +785,7 @@ def audit_project(root: Path) -> AuditReport:
             )
         )
 
-    # Default RetComM-themed app icon (Windows .ico + PNG)
+    # Default Retro-themed app icon (Windows .ico + PNG)
     app_ico = root / "assets" / "psxrecomp.ico"
     if app_ico.is_file():
         checks.append(
@@ -804,7 +804,7 @@ def audit_project(root: Path) -> AuditReport:
                 title="assets/psxrecomp app icon",
                 status=CheckStatus.WARN,
                 severity=Severity.RECOMMENDED,
-                detail="Missing assets/psxrecomp.ico (RetComM-themed default pad icon).",
+                detail="Missing assets/psxrecomp.ico (Retro-themed default pad icon).",
                 fix_op="ensure_app_icon",
             )
         )
@@ -895,7 +895,7 @@ def audit_project(root: Path) -> AuditReport:
             )
         )
 
-    # README download badges + boxart + RetComM Launcher (idempotent migrate op)
+    # README download badges + boxart + Retro Launcher (idempotent migrate op)
     readme_path = root / "README.md"
     readme_text = _read(readme_path) if readme_path.is_file() else ""
     missing_readme: list[str] = []
@@ -907,7 +907,7 @@ def audit_project(root: Path) -> AuditReport:
         if not readme_has_boxart(readme_text):
             missing_readme.append("libretro boxart")
         if not readme_has_launcher(readme_text):
-            missing_readme.append("RetComM Launcher section")
+            missing_readme.append("Retro Launcher section")
         if not readme_has_raid(readme_text):
             missing_readme.append("R.A.I.D. Discord footer")
     if not (root / ".github" / "raid-discord.png").is_file():
@@ -932,7 +932,7 @@ def audit_project(root: Path) -> AuditReport:
                 title="README download metrics / launcher / RAID / boxart",
                 status=CheckStatus.PASS,
                 severity=Severity.RECOMMENDED,
-                detail="Download badges, boxart, RetComM Launcher, and R.A.I.D. footer present.",
+                detail="Download badges, boxart, Retro Launcher, and R.A.I.D. footer present.",
             )
         )
 

--- a/tools/new_project_layout/project_studio/gitops.py
+++ b/tools/new_project_layout/project_studio/gitops.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from typing import Any
 
 DEFAULT_PSXRECOMP_URL = "https://github.com/mstan/psxrecomp.git"
-DEFAULT_RECOMP_UI_URL = "https://github.com/mstan/recomp-ui.git"
+DEFAULT_RECOMP_UI_URL = "https://github.com/RetroPortingToolKit/recomp-ui.git"
 DEFAULT_RECOMP_NET_URL = "https://github.com/RetroPortingToolKit/recomp-net.git"
 DEFAULT_RBENGINE_URL = "https://github.com/RetroPortingToolKit/rbengine.git"
 DEFAULT_BRANCH = "master"

--- a/tools/new_project_layout/project_studio/gui.py
+++ b/tools/new_project_layout/project_studio/gui.py
@@ -294,7 +294,7 @@ def _ensure_gui_deps() -> str | None:
         if _ctk_importable():
             return None
         return (
-            "Frozen RetComM Studio build is missing customtkinter.\n"
+            "Frozen Retro Studio build is missing customtkinter.\n"
             "Reinstall from a release package, or run from source."
         )
 
@@ -376,7 +376,7 @@ class ProjectStudioApp:
     def __init__(self, ctk, *, initial_root: Path | None = None) -> None:
         self.ctk = ctk
         self.root = ctk.CTk()
-        self.root.title("RetComM Studio")
+        self.root.title("Retro Studio")
         self.root.geometry("1100x820")
         self.root.minsize(900, 640)
         # Maximize after the first map so WMs honor zoomed/fullscreen hints.
@@ -518,7 +518,7 @@ class ProjectStudioApp:
         header.pack(fill="x", padx=16, pady=(16, 8))
         ctk.CTkLabel(
             header,
-            text="RetComM Studio",
+            text="Retro Studio",
             font=ctk.CTkFont(size=22, weight="bold"),
         ).pack(side="left")
         ctk.CTkLabel(
@@ -1123,7 +1123,7 @@ class ProjectStudioApp:
                     self._prompt_apply_updates(result)
                 elif not silent_if_current:
                     messagebox.showinfo(
-                        "RetComM Studio",
+                        "Retro Studio",
                         result.message or "Everything is up to date.",
                         parent=self.root,
                     )
@@ -1146,10 +1146,10 @@ class ProjectStudioApp:
             "Updates are available:\n\n"
             + "\n".join(lines)
             + "\n\nApply now?\n"
-            "(Toolchain installs into the shared RetComM cache used by the "
+            "(Toolchain installs into the shared Retro cache used by the "
             "launcher and game apps.)"
         )
-        if not messagebox.askyesno("RetComM Studio", body, parent=self.root):
+        if not messagebox.askyesno("Retro Studio", body, parent=self.root):
             return
 
         update_studio = bool(result.studio.available)
@@ -1177,14 +1177,14 @@ class ProjectStudioApp:
                 self._update_status_var.set("Update done" if not should_exit else "Restarting…")
                 if should_exit:
                     messagebox.showinfo(
-                        "RetComM Studio",
+                        "Retro Studio",
                         summary + "\n\nStudio will exit to finish the update.",
                         parent=self.root,
                     )
                     self.root.after(300, self.root.destroy)
                 else:
                     messagebox.showinfo(
-                        "RetComM Studio", summary, parent=self.root
+                        "Retro Studio", summary, parent=self.root
                     )
 
             self.root.after(0, done)

--- a/tools/new_project_layout/project_studio/ops.py
+++ b/tools/new_project_layout/project_studio/ops.py
@@ -568,7 +568,7 @@ def op_ensure_recomp_ui_submodule(root: Path, options: MigrateOptions) -> ApplyR
         or (root / "recomp-ui" / ".git").exists()
     ):
         return ApplyResult("ensure_recomp_ui_submodule", True, "Already present", [])
-    url = "https://github.com/mstan/recomp-ui.git"
+    url = "https://github.com/RetroPortingToolKit/recomp-ui.git"
     ok, out = _run(
         ["git", "submodule", "add", "-b", "master", url, "recomp-ui"],
         root,
@@ -1259,7 +1259,7 @@ def _ensure_boxart_png(root: Path, options: MigrateOptions) -> list[str]:
 
 
 def op_patch_readme_metrics(root: Path, options: MigrateOptions) -> ApplyResult:
-    """Upsert download badges, libretro boxart, RetComM Launcher, and R.A.I.D. footer."""
+    """Upsert download badges, libretro boxart, Retro Launcher, and R.A.I.D. footer."""
     from .readme_metrics import (
         apply_github_about,
         boxart_png_present,
@@ -1313,7 +1313,7 @@ def op_patch_readme_metrics(root: Path, options: MigrateOptions) -> ApplyResult:
     parts: list[str] = []
     if changed:
         parts.append(
-            f"Patched README badges, boxart, RetComM Launcher, and R.A.I.D. footer ({owner}/{repo})"
+            f"Patched README badges, boxart, Retro Launcher, and R.A.I.D. footer ({owner}/{repo})"
         )
     if fetched:
         parts.append("fetched libretro boxart")

--- a/tools/new_project_layout/project_studio/plan.py
+++ b/tools/new_project_layout/project_studio/plan.py
@@ -54,7 +54,7 @@ _OP_TITLES = {
     "annotate_legacy_packaging": "Annotate legacy prebuilt packaging",
     "probe_disc_refresh": "Refresh disc identity via probe_disc.py",
     "record_framework_pins": "Write framework_pins.txt",
-    "patch_readme_metrics": "Patch README badges, RetComM Launcher, and R.A.I.D. footer",
+    "patch_readme_metrics": "Patch README badges, Retro Launcher, and R.A.I.D. footer",
 }
 
 

--- a/tools/new_project_layout/project_studio/readme_metrics.py
+++ b/tools/new_project_layout/project_studio/readme_metrics.py
@@ -1,4 +1,4 @@
-"""README download-badge + RetComM Launcher blocks for scaffold and migrate."""
+"""README download-badge + Retro Launcher blocks for scaffold and migrate."""
 
 from __future__ import annotations
 
@@ -41,7 +41,10 @@ _RAID_RE = re.compile(
     re.S,
 )
 _LEGACY_LAUNCHER_RE = re.compile(
-    r"^## RetComM Launcher\n.*?(?=^## |\Z)",
+    # Both headings: this section was "## RetComM Launcher" until the
+    # rename, and every README generated before it still says so. Matching
+    # only the new one leaves the old block in place and appends a second.
+    r"^## (?:Retro|RetComM) Launcher\n.*?(?=^## |\Z)",
     re.M | re.S,
 )
 _LEGACY_RAID_RE = re.compile(
@@ -194,26 +197,26 @@ def render_launcher_block() -> str:
     return "\n".join(
         [
             LAUNCHER_BEGIN,
-            "## RetComM Launcher",
+            "## Retro Launcher",
             "",
             "You can run this title **standalone** (release zip + the built-in recomp-ui",
             "Generate & Build flow), or manage installs, updates, ROM/BIOS wiring, and queued",
             "builds more intuitively with",
-            f"**[RetComM Launcher]({LAUNCHER_REPO})** —",
+            f"**[Retro Launcher]({LAUNCHER_REPO})** —",
             "the Retro Compilation Manager hub for self-compiling recomps.",
             "",
             f"[Downloads]({LAUNCHER_REPO}/releases) ·",
             f"[Full README & features]({LAUNCHER_REPO}#readme)",
             "",
             "<p align=\"center\">",
-            f'  <img src="{shots}/hub-and-game-launcher.png" alt="RetComM hub with a background build, next to a title’s recomp-ui launcher" width="720">',
+            f'  <img src="{shots}/hub-and-game-launcher.png" alt="Retro hub with a background build, next to a title’s recomp-ui launcher" width="720">',
             "</p>",
             "",
             "<p align=\"center\">",
             f'  <img src="{shots}/queue-and-background-build.png" alt="Background cmake build with titles queued" width="720">',
             "</p>",
             "",
-            "RetComM checks for updates, rebuilds with existing build data when possible,",
+            "Retro checks for updates, rebuilds with existing build data when possible,",
             "shares the portable toolchain used by per-title launchers, and automates",
             "BIOS/ROM/save plumbing so you are not stuck repeating each game’s wizard by hand.",
             LAUNCHER_END,
@@ -255,7 +258,7 @@ def readme_has_launcher(text: str) -> bool:
     # Both slugs: every port generated before the RetroPortingToolKit transfer
     # carries the old one, and matching only the new one would report each of
     # them as missing its launcher section — and append a second copy to any
-    # README that has neither the markers nor a "## RetComM Launcher" heading.
+    # README that has neither the markers nor a "## Retro Launcher" heading.
     return any(
         slug in text
         for slug in (

--- a/tools/new_project_layout/setup_project.ps1
+++ b/tools/new_project_layout/setup_project.ps1
@@ -53,7 +53,7 @@ param(
     [string]$PsxrecompRef = "master",
     [string]$RecompUiRef = "master",
     [string]$PsxrecompUrl = "https://github.com/mstan/psxrecomp.git",
-    [string]$RecompUiUrl = "https://github.com/mstan/recomp-ui.git"
+    [string]$RecompUiUrl = "https://github.com/RetroPortingToolKit/recomp-ui.git"
 )
 
 $ErrorActionPreference = "Stop"
@@ -293,7 +293,7 @@ set(PSX_RECOMP_UI OFF CACHE BOOL
 
 if ($useNetplay) {
     # PSX_NETPLAY defaults RNET_ENABLE_ICE=ON; recomp-net FetchContents
-    # libjuice via pinned URL (not git) so RetComM AppImage builds configure.
+    # libjuice via pinned URL (not git) so Retro AppImage builds configure.
     Set-Content -Encoding UTF8 -Path $NetplayBlockFile -Value @"
 if(EXISTS "`${PSXRECOMP_ROOT}/lib/recomp-net/CMakeLists.txt")
     set(PSX_NETPLAY ON CACHE BOOL
@@ -430,7 +430,7 @@ if ($useRecompUi) {
 }
 git submodule update --init --recursive
 
-# RetComM-themed default app icon (Windows .ico + PNG for packaging).
+# Retro-themed default app icon (Windows .ico + PNG for packaging).
 $iconSrc = Join-Path $Root "psxrecomp\assets"
 $iconDst = Join-Path $Root "assets"
 if (Test-Path $iconSrc) {

--- a/tools/new_project_layout/setup_project.sh
+++ b/tools/new_project_layout/setup_project.sh
@@ -75,7 +75,7 @@ PSXRECOMP_REF="master"
 RECOMP_UI_REF="master"
 RECOMP_NET_REF="${RECOMP_NET_REF:-}"
 PSXRECOMP_URL="${PSXRECOMP_URL:-https://github.com/mstan/psxrecomp.git}"
-RECOMP_UI_URL="${RECOMP_UI_URL:-https://github.com/mstan/recomp-ui.git}"
+RECOMP_UI_URL="${RECOMP_UI_URL:-https://github.com/RetroPortingToolKit/recomp-ui.git}"
 
 # Track whether bools were set on the CLI (so prompts can skip).
 SET_RECOMP_UI=0
@@ -512,7 +512,7 @@ fi
 
 if [ "$ENABLE_NETPLAY" -eq 1 ]; then
     # PSX_NETPLAY defaults RNET_ENABLE_ICE=ON; recomp-net FetchContents
-    # libjuice via pinned URL (not git) so RetComM AppImage builds configure.
+    # libjuice via pinned URL (not git) so Retro AppImage builds configure.
     printf '%s\n' \
 'if(EXISTS "${PSXRECOMP_ROOT}/lib/recomp-net/CMakeLists.txt")
     set(PSX_NETPLAY ON CACHE BOOL
@@ -651,7 +651,7 @@ if [ "$ENABLE_RECOMP_UI" -eq 1 ]; then
 fi
 git submodule update --init --recursive
 
-# RetComM-themed default app icon (Windows .ico + PNG for packaging).
+# Retro-themed default app icon (Windows .ico + PNG for packaging).
 if [ -d psxrecomp/assets ]; then
     mkdir -p "$ROOT/assets"
     for _icon in psxrecomp.svg psxrecomp.png psxrecomp.ico; do

--- a/tools/new_project_layout/templates/README.md.in
+++ b/tools/new_project_layout/templates/README.md.in
@@ -8,7 +8,7 @@
 
 Static recompilation of **@GAME_NAME@** built on
 [psxrecomp](https://github.com/mstan/psxrecomp) and
-[recomp-ui](https://github.com/mstan/recomp-ui).
+[recomp-ui](https://github.com/RetroPortingToolKit/recomp-ui).
 
 @DESCRIPTION@
 
@@ -23,26 +23,26 @@ Scaffolded with the New Project Layout. See
 `psxrecomp/docs/GAME_PROJECT_SETUP.md` for the full flow.
 
 <!-- retcomm-readme-launcher -->
-## RetComM Launcher
+## Retro Launcher
 
 You can run this title **standalone** (release zip + the built-in recomp-ui
 Generate & Build flow), or manage installs, updates, ROM/BIOS wiring, and queued
 builds more intuitively with
-**[RetComM Launcher](https://github.com/RetroPortingToolKit/Retro-Launcher)** —
+**[Retro Launcher](https://github.com/RetroPortingToolKit/Retro-Launcher)** —
 the Retro Compilation Manager hub for self-compiling recomps.
 
 [Downloads](https://github.com/RetroPortingToolKit/Retro-Launcher/releases) ·
 [Full README & features](https://github.com/RetroPortingToolKit/Retro-Launcher#readme)
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/RetroPortingToolKit/Retro-Launcher/main/docs/screenshots/hub-and-game-launcher.png" alt="RetComM hub with a background build, next to a title’s recomp-ui launcher" width="720">
+  <img src="https://raw.githubusercontent.com/RetroPortingToolKit/Retro-Launcher/main/docs/screenshots/hub-and-game-launcher.png" alt="Retro hub with a background build, next to a title’s recomp-ui launcher" width="720">
 </p>
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/RetroPortingToolKit/Retro-Launcher/main/docs/screenshots/queue-and-background-build.png" alt="Background cmake build with titles queued" width="720">
 </p>
 
-RetComM checks for updates, rebuilds with existing build data when possible,
+Retro checks for updates, rebuilds with existing build data when possible,
 shares the portable toolchain used by per-title launchers, and automates
 BIOS/ROM/save plumbing so you are not stuck repeating each game’s wizard by hand.
 <!-- /retcomm-readme-launcher -->
@@ -53,7 +53,7 @@ You must own the original game. Disc images under `disc/` are gitignored and
 must never be committed. Retail BIOS dumps are not redistributed; OpenBIOS is
 used for Generate unless you supply your own SCPH locally.
 
-Default app icon: `assets/psxrecomp.ico` (and `.png` / `.svg`) — RetComM-themed controller mark from `psxrecomp/assets/`. Windows builds embed it via `APP_ICON`.
+Default app icon: `assets/psxrecomp.ico` (and `.png` / `.svg`) — Retro-themed controller mark from `psxrecomp/assets/`. Windows builds embed it via `APP_ICON`.
 
 Optional box art under `launcher_assets/img/` may come from
 [libretro-thumbnails](https://github.com/libretro-thumbnails/libretro-thumbnails)

--- a/tools/new_project_layout/update_disc_set.py
+++ b/tools/new_project_layout/update_disc_set.py
@@ -17,7 +17,7 @@ player located and update only the keys that describe the set:
 Everything else in the file is preserved byte-for-byte, comments included.
 
 This is the step that makes the standalone wizard reach the same end state as
-the RetComM path, which runs probe_disc.py per disc and verify_disc_set.py over
+the Retro path, which runs probe_disc.py per disc and verify_disc_set.py over
 the results. The runtime's hot-swap roster is built from [game] discs -- not
 from disc.cfg, which is only the mounted-image cache -- so without this the
 wizard can record every disc a player owns and none of them reach the roster.
@@ -212,7 +212,7 @@ def main() -> int:
             print(f"error: missing disc image {c}", file=sys.stderr)
             return 1
 
-    # Probe each disc, writing the same per-disc artifacts the RetComM path
+    # Probe each disc, writing the same per-disc artifacts the Retro path
     # leaves behind (disc_probe.json, disc_probe.2.json, ...).
     probes, probe_jsons = [], []
     for i, cue in enumerate(cues, start=1):

--- a/tools/package_setup_host.sh
+++ b/tools/package_setup_host.sh
@@ -3,7 +3,7 @@
 #
 # Stages the host exe, title sources, filtered psxrecomp/ + recomp-ui/, then
 # finishes with stage_setup_sdk.sh (emitters, OpenBIOS, MinGW DLLs).
-# Portable cmake/clang is NOT embedded by default — RetComM / the setup wizard
+# Portable cmake/clang is NOT embedded by default — Retro / the setup wizard
 # download cmake-clang-v1 from retcomm-toolchains (or accept an offline zip).
 #
 # Usage (from game repo root):
@@ -262,7 +262,7 @@ ZIP_NAME="${ZIP_PREFIX}-${VERSION}-${ARTIFACT}.zip"
 rm -f "${DIST}/${ZIP_NAME}"
 
 cp -a "${EXE}" "${STAGE}/"
-# Ship the stamp beside the exe so installers / RetComM can prefer it over VERSION.
+# Ship the stamp beside the exe so installers / Retro can prefer it over VERSION.
 if [[ -f "$(dirname "${EXE}")/psx_game_version.txt" ]]; then
   cp -a "$(dirname "${EXE}")/psx_game_version.txt" "${STAGE}/psx_game_version.txt"
 else
@@ -502,7 +502,7 @@ Standalone:
    pick a local cmake-clang-v1-*.zip for offline builds). System cmake/ninja
    also works if already on PATH.
 
-RetComM uses this same zip: it harvests emitters into a shared SDK cache,
+Retro uses this same zip: it harvests emitters into a shared SDK cache,
 downloads the toolchain pack (or uses RETCOMM_TOOLCHAIN_DIR), and preserves
 saves/user config across updates.
 EOF

--- a/tools/prepare_disc.py
+++ b/tools/prepare_disc.py
@@ -13,7 +13,7 @@ Accepted inputs:
 
 Writes working ``.bin`` + ``.cue`` (or copies a multi-track Redump set),
 extracts ``SYSTEM.CNF`` + boot EXE, and prints ``RESULT_CUE=<abs path>``
-for the first-run wizard / RetComM.
+for the first-run wizard / Retro.
 
 ISO→2352 sets Mode2 Form1 sync/header/subheader/EDC (ECC zeroed — fine for
 software readers). Rebuilt images are not bit-identical to Redump.

--- a/tools/psx_gpu_frame.py
+++ b/tools/psx_gpu_frame.py
@@ -674,7 +674,7 @@ def summarise_dump(dump: Dict[str, Any], dump_name: str = "") -> Dict[str, Any]:
 
     A busy frame's full dump runs to tens of megabytes. Nothing that only wants
     to know *who drew what* should have to parse that, so the summary is a
-    separate artifact and RetComM Studio reads this rather than the dump.
+    separate artifact and Retro Studio reads this rather than the dump.
     """
     ops: Dict[str, int] = {}
     modes: Dict[str, int] = {}

--- a/tools/stage_setup_sdk.sh
+++ b/tools/stage_setup_sdk.sh
@@ -3,7 +3,7 @@
 # into an existing setup-host release stage directory.
 #
 # Title packagers copy the host exe, game sources, and framework tree first,
-# then call this to finish the RetComM/wizard-complete zip layout.
+# then call this to finish the Retro/wizard-complete zip layout.
 #
 # Usage:
 #   stage_setup_sdk.sh --stage <stage-dir> [options]
@@ -235,7 +235,7 @@ if [[ -n "${TOOLCHAIN_DIR}" && -d "${TOOLCHAIN_DIR}" ]]; then
   fi
   echo "bundled toolchain from ${TOOLCHAIN_DIR}"
 elif [[ "${ALLOW_NO_TOOLCHAIN}" -eq 1 ]]; then
-  echo "note: no embedded toolchain/ — RetComM/wizard will download cmake-clang-v1" \
+  echo "note: no embedded toolchain/ — Retro/wizard will download cmake-clang-v1" \
        "(or accept an offline zip / system cmake)" >&2
 else
   echo "error: toolchain dir required (pass --toolchain-dir or set PSXRECOMP_TOOLCHAIN_DIR)" >&2

--- a/tools/tests/test_duckstation_oracle.py
+++ b/tools/tests/test_duckstation_oracle.py
@@ -193,7 +193,7 @@ class TestSettingsMerge(unittest.TestCase):
 
 
 class TestStatusDoc(EnvGuard):
-    """The status document is the whole contract with RetComM Studio."""
+    """The status document is the whole contract with Retro Studio."""
 
     def test_absent_install_reports_absent(self):
         os.environ["RETCOMM_ORACLE_DIR"] = tempfile.mkdtemp()

--- a/tools/toolchain_pack.py
+++ b/tools/toolchain_pack.py
@@ -1,6 +1,6 @@
 """Resolve / download / unpack portable cmake-clang-v1 toolchain packs.
 
-Shared cache matches RetComM / retcomm-toolchains install.sh:
+Shared cache matches Retro / retcomm-toolchains install.sh:
 
   Windows: %LOCALAPPDATA%/retcomm/toolchains/cmake-clang-v1/<tag>/
   Linux/macOS: $XDG_DATA_HOME/retcomm/… and ~/.local/share/retcomm/…
@@ -260,7 +260,7 @@ def shared_cache_roots() -> list[Path]:
     Layout matches retcomm-toolchains install.sh:
       …/retcomm/toolchains/cmake-clang-v1/<tag>/   plus latest → current
 
-    RetComM (`retcomm`) is preferred; legacy `psxrecomp` remains a read/migrate
+    Retro (`retcomm`) is preferred; legacy `psxrecomp` remains a read/migrate
     fallback. Honors RETCOMM_TOOLCHAIN_CACHE / RETCOMM_DATA_HOME.
     """
     roots: list[Path] = []
@@ -281,7 +281,7 @@ def shared_cache_roots() -> list[Path]:
 
 
 def preferred_install_root() -> Path:
-    """Where newly downloaded / offline-unpacked packs land (RetComM shared)."""
+    """Where newly downloaded / offline-unpacked packs land (Retro shared)."""
     cache = (os.environ.get("RETCOMM_TOOLCHAIN_CACHE") or "").strip()
     if cache:
         r = Path(cache).expanduser()
@@ -747,7 +747,7 @@ def _register_user_path_unix(cache_root: Path, latest: Path, log=None) -> None:
     )
     block = (
         f"{_MARKER_BEGIN}\n"
-        f"# Managed by psxrecomp / RetComM — remove via uninstall.sh\n"
+        f"# Managed by psxrecomp / Retro — remove via uninstall.sh\n"
         f'if [ -f "{hook}" ]; then\n'
         f"  # shellcheck disable=SC1091\n"
         f'  . "{hook}"\n'
@@ -775,7 +775,7 @@ def _register_user_path_unix(cache_root: Path, latest: Path, log=None) -> None:
 def register_toolchain_user_env(pack_root: Path, log=None) -> Path:
     """Refresh ``latest`` + idempotently add ``latest/bin`` to the user login PATH.
 
-    Mirrors retcomm-toolchains zip ``install.sh`` / ``install.ps1`` so RetComM
+    Mirrors retcomm-toolchains zip ``install.sh`` / ``install.ps1`` so Retro
     setup hosts and the standalone wizard leave cmake/clang on PATH for shell
     development after placing the pack in the shared cache.
     """
@@ -953,7 +953,7 @@ def ensure_toolchain(
     Resolution order: env override → project stamp/toolchain/ → shared
     retcomm cache (legacy psxrecomp migrated) → optional --from-zip → download.
 
-    Installs always land under the shared RetComM cache; the project only gets
+    Installs always land under the shared Retro cache; the project only gets
     a stamp file pointing at that pack.
     """
     need = min_version or default_min_version()


### PR DESCRIPTION
Follow-on to #340, which moved the submodule URLs. Two things have changed since it merged.

**The product is Retro now.** The launcher and studio ship as *Retro Launcher* and *Retro Studio*, so the old name is gone from display text, docs and generated READMEs.

**recomp-ui moved to the org.** `mstan/recomp-ui` → `RetroPortingToolKit/recomp-ui`, so the scaffolder defaults and docs follow it. `psxrecomp` itself has not moved and is untouched.

## The split is by case, and it is not cosmetic

CamelCase `RetComM` was always the product. Lowercase `retcomm` and `RETCOMM_` are identifiers — the namespace, binaries, data directories, CMake and environment variables, readme markers. Renaming those orphans existing installs for no benefit, so they are untouched.

## Three things are deliberately still spelled RetComM

- `RetComM-Data` is CamelCase but it is a directory on disk (`<exe_dir>\RetComM-Data\{runtime,config,data}` for a portable install). Renaming it strands every portable user's config, toolchains and catalog cache.
- `TechnicallyComputers/RetComM-Launcher` in `readme_has_launcher()` is the historical half of a both-slugs test. Renaming it duplicates the line above and reports every pre-transfer port as missing its launcher section.
- `_LEGACY_LAUNCHER_RE` matched `^## RetComM Launcher`. The sweep renamed it, which would have silently stopped it matching every README already out there — it now accepts both headings.

## Verification

`bash -n` on the scaffolders; every touched `.py` compiles; and the README machinery checked directly:

```
old heading: True    new heading: True
old slug   : True    new slug   : True
generated block heading: ## Retro Launcher
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013DpaQqVguHFpBuCmdoFYWY