### PR TITLE
Ship third-party notices with releases; name the licensing contact

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -97,4 +97,5 @@ For the avoidance of doubt, the licensor's intent is to restrict uses where
 profit is derived from this software. Non-profit personal, educational,
 or community use is welcome regardless of organizational context.
 
-For commercial licensing inquiries, contact: https://1379.tech
+For commercial licensing inquiries, contact the licensor, Matthew Stanley,
+at <https://1379.tech>.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 # PSXRecomp
 
+> ℹ️ **Note from mstan:** This repo and I are now part of [RetroPortingToolkit](https://retroportingtoolkit.com/). I remain a primary maintainer of psxrecomp alongside the team. [More info](https://1379.tech/forming-a-collective-retro-porting-toolkit/).
+
 **A general-purpose static recompiler for the PlayStation 1.** It turns a PS1
 disc into a native executable — MIPS R3000A translated to C, compiled to x64,
 linked against a hardware-accurate runtime. Not an emulator: the game becomes a
@@ -819,7 +821,14 @@ for build failures); design discussion happens in the **R.A.I.D.** Discord
 
 ## License
 
-PolyForm Noncommercial 1.0.0. See `LICENSE`.
+PolyForm Noncommercial 1.0.0. See `LICENSE`. Copyright © 2026 Matthew
+Stanley; commercial licensing inquiries go to him at <https://1379.tech>.
+
+Third-party components vendored into the runtime keep their own terms, and
+their notices ship with every release under `licenses/` in the package
+(sources in [`runtime/licenses/`](runtime/licenses)). See
+[`THIRD_PARTY_ATTRIBUTION.md`](THIRD_PARTY_ATTRIBUTION.md) for what is
+vendored and why.
 
 Retail PS1 BIOS images and game disc images remain copyrighted by their
 respective owners and are not distributed. This project does distribute the

--- a/THIRD_PARTY_ATTRIBUTION.md
+++ b/THIRD_PARTY_ATTRIBUTION.md
@@ -22,12 +22,35 @@ archive). Vendored as the pinned source archive
 recorded in `third_party/deps.manifest`, and `runtime/chd_dependency.cmake`
 verifies the archive against that digest before building it. It is compiled
 into the runtime as a static library, so the BSD notice must ship with any
-binary that links it.
+binary that links it: the notice text is `runtime/licenses/libchdr-NOTICES.txt`
+and the release packagers copy `runtime/licenses/` into the package as
+`licenses/`.
 
 The archive also carries libchdr's own bundled decompressors — Zstandard
 (BSD-3-Clause / GPL-2.0 dual), LZMA SDK (public domain), and miniz (MIT) —
 built from the same pinned tree; `WITH_SYSTEM_ZLIB`/`WITH_SYSTEM_ZSTD` are
 forced OFF so the disc decoder cannot change with the host's packages.
+
+## Vendored libraries
+
+These are checked in under `recompiler/lib/` and `runtime/third_party/` with
+their upstream license files intact. All are permissive, so nothing here
+constrains this repository's own terms; the obligation is to carry the notice.
+
+| Component | License | Linked into | Notice |
+| --- | --- | --- | --- |
+| [toml11](https://github.com/ToruNiina/toml11) by Toru Niina | MIT | recompiler **and** runtime | `recompiler/lib/toml11/LICENSE`, shipped as `runtime/licenses/toml11-NOTICES.txt` |
+| [stb_image](http://nothings.org/stb) by Sean Barrett | MIT **or** public domain (Unlicense), at your option | runtime | notice in `runtime/third_party/stb_image.h`, shipped as `runtime/licenses/stb_image-NOTICES.txt` |
+| [rabbitizer](https://github.com/Decompollaborate/rabbitizer) by Decompollaborate | MIT | recompiler only | `recompiler/lib/rabbitizer/LICENSE` |
+| [ELFIO](https://github.com/serge1/ELFIO) by Serge Lamikhov-Center | MIT | recompiler only | `recompiler/lib/ELFIO/LICENSE.txt` |
+| [{fmt}](https://github.com/fmtlib/fmt) by Victor Zverovich | MIT | recompiler only | `recompiler/lib/fmt/LICENSE.rst` |
+
+Anything that reaches a **player** binary needs its notice in
+`runtime/licenses/`, which both release packagers copy wholesale into the
+package as `licenses/` — that is the one place to add a notice when a new
+runtime dependency lands. The recompiler-only entries are developer tooling
+and are not in the shipped package; if that ever changes, their notices have
+to ship too.
 
 ## TinyCC (TCC) — toolchain-free overlay compiler shipped to players
 

--- a/runtime/licenses/stb_image-NOTICES.txt
+++ b/runtime/licenses/stb_image-NOTICES.txt
@@ -1,0 +1,44 @@
+stb_image
+=========
+
+stb_image.h v2.27 by Sean Barrett and contributors
+(http://nothings.org/stb). Dual-licensed: either the MIT license or public
+domain (Unlicense), at your option. The upstream notice follows verbatim.
+
+------------------------------------------------------------------------------
+ALTERNATIVE A - MIT License
+Copyright (c) 2017 Sean Barrett
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+------------------------------------------------------------------------------
+ALTERNATIVE B - Public Domain (www.unlicense.org)
+This is free and unencumbered software released into the public domain.
+Anyone is free to copy, modify, publish, use, compile, sell, or distribute this
+software, either in source code form or as a compiled binary, for any purpose,
+commercial or non-commercial, and by any means.
+In jurisdictions that recognize copyright laws, the author or authors of this
+software dedicate any and all copyright interest in the software to the public
+domain. We make this dedication for the benefit of the public at large and to
+the detriment of our heirs and successors. We intend this dedication to be an
+overt act of relinquishment in perpetuity of all present and future rights to
+this software under copyright law.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+------------------------------------------------------------------------------

--- a/runtime/licenses/toml11-NOTICES.txt
+++ b/runtime/licenses/toml11-NOTICES.txt
@@ -1,0 +1,24 @@
+toml11
+======
+
+The MIT License (MIT)
+
+Copyright (c) 2017 Toru Niina
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/tools/package_release.ps1
+++ b/tools/package_release.ps1
@@ -43,6 +43,16 @@ New-Item -ItemType Directory -Force $BundledBiosDst | Out-Null
 Copy-Item (Join-Path $BundledBiosSrc "openbios.bin") $BundledBiosDst
 Copy-Item (Join-Path $BundledBiosSrc "OpenBIOS.LICENSE") $BundledBiosDst
 Copy-Item (Join-Path $Root "THIRD_PARTY_ATTRIBUTION.md") $Stage
+# Third-party notices for everything statically linked into the runtime:
+# libchdr is BSD-3-Clause and toml11 is MIT, and both require the notice to
+# be reproduced in binary redistributions. Copy the whole directory so a new
+# vendored dependency ships its notice without touching this script.
+$LicensesSrc = Join-Path $Root "runtime/licenses"
+$LicensesDst = Join-Path $Stage "licenses"
+Copy-Item -LiteralPath $LicensesSrc -Destination $LicensesDst -Recurse
+if (@(Get-ChildItem -LiteralPath $LicensesDst -File).Count -eq 0) {
+    throw "Third-party notices missing from the package: $LicensesDst is empty"
+}
 if (Test-Path (Join-Path $Root "RELEASE_NOTES.md")) {
     Copy-Item (Join-Path $Root "RELEASE_NOTES.md") $Stage
 }

--- a/tools/package_release_macos.sh
+++ b/tools/package_release_macos.sh
@@ -227,6 +227,16 @@ for doc in "${DOCS[@]}"; do
         cp "$REPO/$doc" "$APPDIR/Contents/Resources/$(basename "$doc")"
     fi
 done
+# Third-party notices for everything statically linked into the runtime:
+# libchdr is BSD-3-Clause and toml11 is MIT, and both require the notice to be
+# reproduced in binary redistributions. Copy the whole directory so a new
+# vendored dependency ships its notice without touching this script.
+if [ -d "$REPO/runtime/licenses" ]; then
+    mkdir -p "$APPDIR/Contents/Resources/licenses" "$STAGE/licenses"
+    cp "$REPO"/runtime/licenses/*  "$APPDIR/Contents/Resources/licenses/"
+    cp "$REPO"/runtime/licenses/*  "$STAGE/licenses/"
+fi
+
 # Surface the player-facing docs beside the .app too, so they are readable
 # without opening the bundle. Mirrors the flat Windows package layout.
 for doc in START_HERE.txt README.md LICENSE RELEASE_NOTES.md; do
@@ -333,6 +343,11 @@ OPENBIOS="$APPDIR/Contents/Resources/bios/openbios.bin"
 [ "$(stat -f%z "$OPENBIOS")" = "524288" ] || die "OpenBIOS image is not 512 KiB"
 [ -f "$APPDIR/Contents/Resources/bios/OpenBIOS.LICENSE" ] || die "OpenBIOS MIT notice missing"
 note "bundled OpenBIOS (512 KiB) + MIT notice"
+
+# 3b. Third-party notices for the statically linked runtime dependencies.
+[ -f "$APPDIR/Contents/Resources/licenses/libchdr-NOTICES.txt" ]     || die "libchdr BSD-3-Clause notice missing"
+[ -f "$STAGE/licenses/libchdr-NOTICES.txt" ]     || die "libchdr BSD-3-Clause notice missing beside the .app"
+note "third-party notices staged in the bundle and beside it"
 
 # 4. Required mod packages. A silently mod-less launcher looks fine but has no
 #    Mods page at all, which is indistinguishable from the feature being cut.


### PR DESCRIPTION
Licensing review pass, matching the one just done on `ndsrecomp`.

**No copyleft exposure.** Every vendored component is permissive — OpenBIOS is MIT, libchdr BSD-3-Clause (its bundled Zstd is BSD/GPL-2.0 dual, so the BSD option applies), LZMA SDK public domain, miniz MIT, toml11/rabbitizer/ELFIO/fmt MIT, stb_image MIT-or-public-domain. TinyCC is LGPL-2.1 but runs as a separate subprocess, which is aggregation rather than linkage. Nothing constrains the PolyForm-NC terms.

**The real gap: release packages shipped no third-party notices.** `runtime/licenses/libchdr-NOTICES.txt` has been in the tree but is referenced by nothing, so it never reached a package. libchdr is statically linked into the runtime and BSD-3-Clause requires the notice be reproduced in binary redistributions; toml11 is MIT and linked into the runtime too, with the same requirement.

- Both packagers now copy `runtime/licenses/` into the package as `licenses/`, and fail the build if it lands empty. Copying the whole directory means a future vendored dependency ships its notice without another packaging change.
- Added `runtime/licenses/toml11-NOTICES.txt` and `runtime/licenses/stb_image-NOTICES.txt`.
- The macOS packager gained assertions beside its existing OpenBIOS one, for both the bundle and the flat stage.

**Attribution.** `THIRD_PARTY_ATTRIBUTION.md` had no entry at all for the five vendored libraries. Added a table recording each one's license, which binary it reaches, and where its notice lives, plus a note that `runtime/licenses/` is the single place to add a notice for anything reaching a player build.

**Licensing contact.** `LICENSE` named only a URL; it now names Matthew Stanley as the licensor for commercial inquiries. The README License section states the copyright holder and points at the notices.

**README.** Added the RetroPortingToolKit maintainer notice that `recomp-ui` and `ndsrecomp` carry.

Docs and packaging only — no runtime or recompiler code touched. `bash -n` passes on the macOS packager.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
