### PR TITLE
Support scheduled overlay switches and document disc-derived AOT sharding

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,10 +85,12 @@ Three things sit on that foundation:
   works on both linked BIOS backends — the bundled OpenBIOS and a player's
   retail BIOS dump reach the game the same way — while the kernel-call half is
   enabled per image and says so at startup when it isn't.
-- **Capture-and-compile for overlays.** PS1 games stream code off the disc at
-  runtime (*overlays*) that no ahead-of-time recompiler can see. PSXRecomp
-  captures each overlay the moment it loads and recompiles it to native code,
-  cached and reused forever after (`static → gcc → tcc` backend).
+- **Ahead-of-time overlay sharding.** PS1 games stream code from disc into
+  reused RAM addresses. When the stored bytes and loader behavior are known,
+  PSXRecomp can discover and compile those overlays before gameplay, without a
+  full decompilation. The runtime selects matching native code using byte guards.
+  Capture-and-compile remains available for gaps. See the
+  [AOT sharding guide](docs/AOT_SHARDING.md) for the reusable workflow and limits.
 - **A general-purpose interpreter — as a transient safety net, not a fixture.**
   Anything not yet native (a freshly streamed overlay, RAM-installed code) runs
   in a small MIPS interpreter so the machine is always *correct*. But the
@@ -224,6 +226,7 @@ These are the 3 most important folders to be aware of:
 |------|-----|
 | How a game runs | [`docs/EXECUTION_MODEL.md`](docs/EXECUTION_MODEL.md) |
 | Architecture | [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) |
+| **AOT overlay sharding** (disc discovery, per-game recipes, validation) | [`docs/AOT_SHARDING.md`](docs/AOT_SHARDING.md) |
 | Build the framework | [`docs/BUILDING.md`](docs/BUILDING.md) |
 | **Ship a game repo** (submodules + CI + release checklist) | [`docs/GAME_PROJECT_SETUP.md`](docs/GAME_PROJECT_SETUP.md) |
 | **Netplay** (rollback, SFU/ICE, dual-raster, disc gates) | [`docs/NETPLAY.md`](docs/NETPLAY.md) |

--- a/docs/AOT_OVERLAY_PLAN.md
+++ b/docs/AOT_OVERLAY_PLAN.md
@@ -1,5 +1,9 @@
 # AOT Overlay Sharding — Spike Findings & Plan (Tomba-first)
 
+For the current workflow and reusable producer boundary, see
+[AOT sharding](AOT_SHARDING.md). This document preserves dated experiments;
+historical observed-PC coverage figures are not exhaustive correctness proofs.
+
 Status: ENHANCEMENT SPIKE (2026-07-17). Foundation executed and live-proven.
 Author: investigation via 4 parallel agents + adversarial source verification.
 Scope: can we move overlay sharding from *runtime discovery* to *build-time (AOT)*,

--- a/docs/AOT_SHARDING.md
+++ b/docs/AOT_SHARDING.md
@@ -1,0 +1,185 @@
+# Ahead-of-time overlay sharding
+
+Overlays can be recompiled before gameplay without first decompiling the game.
+The necessary knowledge is narrower: which disc bytes become executable, where
+they load, how they are transformed, and which entry points and dependencies
+can be established. Full source recovery is not a prerequisite.
+
+The goal is to prepare native coverage from original inputs so first visits do
+not depend on runtime capture and compilation. Interpreter and runtime-compiler
+fallbacks remain useful until individual titles demonstrate sufficient coverage.
+An inventory of every overlay file is not proof of every execution path.
+
+## What exists today
+
+The framework already separates discovery from compilation:
+
+| Layer | Existing implementation | Responsibility |
+| --- | --- | --- |
+| Disc/container discovery | `tools/aot_overlay_spike/extract_generic.py`, `tools/extract_overlays.py` | Read disc files and recognized archives; recover candidate load layouts and static roots. |
+| Native production | `tools/compile_overlays.py`, recompiler function analysis | Walk code, recover supported indirect dispatch, compile and audit native candidates. |
+| Cache selection | Runtime overlay loader, `.dll`/`.ranges` pairs | Match the game, build/flavor ABI and current guarded bytes before dispatch. |
+| Release staging | `tools/release_overlay_stage.ps1` and shared packaging helpers | Stage matching cache namespaces and fallback tooling. |
+
+The extractor lives under `aot_overlay_spike`: it is useful tooling with partial
+format support, not a universal overlay detector. Per-title evidence and recipes
+are still required when an input format or loader layout is ambiguous. There is
+not yet a stable, declarative plugin API covering arbitrary game loaders.
+
+The compiler's input option is named `--captures` for historical reasons. It
+also accepts records produced entirely from disc bytes. That filename/schema
+does not imply a playthrough or RAM capture is required.
+
+## The reusable boundary
+
+A title-specific producer should supply facts about memory images. The shared
+compiler should consume those facts without knowing game names or addresses.
+Keep each producer responsible for:
+
+- Source identity: disc revision, file/member offsets, sizes and hashes.
+- Transform: verbatim load, decompression or relocation, with the inputs needed
+  to reproduce its result. Record how the loader establishes these facts.
+- Destination: address of each actual file/member and the combinations that can
+  coexist. Regional editions need their own source and layout verification.
+- Known byte intervals and entry evidence: exports, loader entry tables, direct
+  calls or supported static discovery. Preserve the distinction between function
+  roots and interior dispatch targets.
+
+Common container readers, decoders, relocation handling and instruction-pattern
+recognizers belong in the framework once their contracts can be stated and
+tested independently. A game's selector table or file naming convention belongs
+in its recipe. Repeated methods can then be reused without treating a previous
+title's addresses, hashes or runtime captures as authority for a new one.
+
+Useful producer families include fixed-address raw files, self-describing PS-X
+EXEs, archive members, deterministic compressed images and relocatable images.
+The first three have existing extractor support for specific formats. The last
+two need a verified transform; arbitrary compression/relocation is not inferred
+automatically. Code that depends on runtime state may need multiple bounded
+variants or continued fallback.
+
+## A bounded discovery and build
+
+1. Identify the exact disc revision and enumerate candidate files. Hash original
+   inputs before attempting extraction. Include shared code and loader helpers,
+   not only files named like areas.
+2. Establish destinations and entry points from headers and loader behavior.
+   Treat heuristic votes as candidates. If two bases nearly tie, investigate the
+   specific loader path or skip the file; do not select the convenient answer.
+3. Emit independently reproducible memory-image recipes with known ranges.
+   Build standalone producers first, then justified shared-code combinations.
+4. Compile using the same framework headers, compiler configuration, backend,
+   architecture and flavor as the runtime being shipped.
+5. Audit published pairs and exercise transitions with runtime compilation off.
+   Retain fallback and document rejected or unresolved candidates.
+
+For formats the generic extractor recognizes, run from the framework directory:
+
+```sh
+python tools/aot_overlay_spike/extract_generic.py \
+  --game-toml /path/to/game.toml \
+  --recompiler /path/to/psxrecomp-game \
+  --out /private/aot/disc-records.json \
+  --tmp /private/aot/extraction
+
+python tools/compile_overlays.py \
+  --captures /private/aot/disc-records.json \
+  --game-toml /path/to/game.toml \
+  --recompiler /path/to/psxrecomp-game \
+  --runtime-include /path/to/psxrecomp/runtime/include \
+  --out-dir /path/to/runtime/cache \
+  --compiler gcc --gcc /path/to/gcc --flavor 0 --jobs 1
+```
+
+These are developer commands; use actual executable paths (`.exe` on Windows).
+Flavor 0 is an example matching the baseline Tomba 2 tests, not a universal
+setting. Other native flavors need matching artifacts. The full command can
+perform additional cross-variant discovery. To bound expensive investigation,
+compile one producer record per invocation into the same cache, then deliberately
+add supported combinations. That trades some discovery breadth for a predictable
+scope; it does not establish completeness.
+
+Disc recipes must explicitly declare `guard_bytes: 0` when no runtime-capture
+guard word was appended. The legacy capture heuristic can otherwise trim four
+real bytes from an image whose length is four bytes beyond a page boundary.
+The generic extractor now emits this declaration; verify it when adapting older
+output or adding a custom producer. This field concerns
+capture padding; native function guards still apply.
+
+Declare `producer_ranges` using half-open `[start, end)` intervals for bytes
+owned by each original source. A sparse image may have padding between files.
+Padding used to serialize that image is not evidence of actual RAM contents.
+Do not seed, discover or guard code across unknown intervals. If a candidate
+really depends on those bytes, establish their producer or leave it unsupported.
+
+## Validation and release gates
+
+Keep three different claims separate:
+
+| Claim | Evidence needed |
+| --- | --- |
+| The memory image was reconstructed correctly | Exact original-file/transform checks, loader destination evidence and bounded known ranges. |
+| The cache can be selected safely | Matching namespace/flavor and ABI, exports, pair identity, all declared guard and delay-slot bytes, index capacity. |
+| The translated game behavior works | Meaningful execution checks and player movement, interaction, audio, graphics and area round trips. |
+
+Audit every published pair, including supplemental fragments. A manifest row
+count is not a count of independently proven functions. Multiple recipes may
+reuse the same guarded native function when its required bytes match; a separate
+DLL per combination is unnecessary. Conversely, a successful file inventory
+cannot excuse a compile/audit rejection. Keep nonzero outcomes visible and
+review any accepted partial result explicitly.
+
+During a static-cache playtest set `PSX_OVERLAY_AUTOCOMPILE_OFF=1` and omit the
+configured runtime compilation command. Inspect `autocompile_status` to verify
+that compilation is disabled and no builds ran. Inspect `overlay_loader_status`
+for native dispatch, loaded candidates and capacity overflows. Runtime capture
+or live RAM observations may help identify an exercised area; they must not
+silently become inputs to a supposedly disc-only build.
+
+Existing captured shards are investigative references, not correctness or
+completeness oracles. Matching their entry list or containing every observed PC
+does not prove correct function boundaries, emitted semantics, or coverage of
+unvisited paths. Byte guards prevent selection of mismatching bytes; they do
+not prove that the matching translation is correct. Interpreter fallback is
+also an implementation to validate, not an unconditional correctness guarantee.
+
+For release, recompute the cache tag from the packaged configuration with the
+shared tooling; never rename a cache directory to make it look compatible.
+Validate every staged pair, report omitted candidates, keep user saves/disc
+images/capture JSON out of packages, and perform a smoke test of the packaged
+runtime. Preserve input hashes, source revision, commands and audit receipts so
+the prepared coverage can be regenerated.
+
+## Tomba 2: the same method across two regions
+
+The US and Italian discs each contain 22 area files (`A00` through `A0L`). The
+generic extraction method recovered both sets, but the bytes and addresses
+differ: US areas load at `0x80108F9C`; Italian areas load at `0x8010A444`.
+Each region therefore needs its own verified recipes and cache namespace.
+
+The Italian shared loader demonstrates why limited reverse engineering still
+matters. The generic extractor could not confidently choose GAME's base. The
+original START filename table and MAIN loader established that START, DEMO and
+GAME share destination `0x80107448`. GAME ends 372 bytes before the area starts.
+Declaring the two original-file ranges separately allowed shared/area recipes
+without inventing the contents of that gap. No full decompilation was required.
+
+The Italian test validated 77 recipes and 74 published native pairs; many GAME
+combinations reused matching functions. All 22 area files had AOT candidates.
+The owner reported great performance in water temple and Kujara Ranch with
+runtime compilation disabled. These are bounded build and gameplay results,
+not proof that every overlay path runs natively. One earlier watchdog abort
+was not reproduced in the longer repeat and was not assigned a speculative fix.
+
+The shared switch recognizer also gained support for a compiler scheduling form
+with table-address setup around the bounds branch. Register dependencies,
+producer ownership and table-target checks remain required. That improvement
+contains no Tomba-specific addresses and can benefit other matching binaries.
+
+## Related material
+
+- [Compiling and packaging overlays](COMPILING_OVERLAYS.md): cache and static-link workflows.
+- [Historical AOT investigation](AOT_OVERLAY_PLAN.md): dated experiments and observations.
+- [Extractor tooling](../tools/aot_overlay_spike/README.md): supported producers and limitations.
+- [Overlay cache format](OVERLAY_CACHE_V2.md): runtime selection and invalidation.
+- [Post-decompression data shards](DATA_SHARDS.md): a separate experiment for replaying data transforms.

--- a/docs/COMPILING_OVERLAYS.md
+++ b/docs/COMPILING_OVERLAYS.md
@@ -1,5 +1,9 @@
 # Compiling overlays from `overlay_captures.json`
 
+For ahead-of-time extraction from original disc files, start with the
+[AOT sharding guide](AOT_SHARDING.md). The compiler accepts disc-derived records
+as well as runtime captures; a playthrough is not required for supported producers.
+
 **Audience:** developers preparing a release who want to ship as much
 native-compiled overlay coverage as possible, plus modders and players who want
 to pre-build coverage for their own machine.

--- a/recompiler/include/function_analysis.h
+++ b/recompiler/include/function_analysis.h
@@ -79,7 +79,10 @@ using ExactAddressMapper = uint32_t (*)(uint32_t, const PS1Executable&);
 // Recognize only the canonical bounded-switch dependency chain:
 // sltiu/beq guard -> sll index,2 -> addu table address -> lw target -> jr.
 // The table constant may use either same-register or cross-register
-// `lui source; addiu base,source,lo`. `producer_lo/producer_hi` bound both
+// `lui source; addiu base,source,lo`, either before the guard or scheduled
+// exactly as `sltiu; beq; lui (delay slot); addiu; sll` without clobbering
+// the checked index or allowing direct edges to bypass the guard.
+// `producer_lo/producer_hi` bound both
 // table storage and case code for composite images; zero/zero means the full
 // executable. Every dependency, table word, and target must pass the hard
 // safety checks; otherwise the whole table is rejected.

--- a/recompiler/src/function_analysis.cpp
+++ b/recompiler/src/function_analysis.cpp
@@ -894,16 +894,36 @@ bool resolve_exact_bounded_jump_table(
         return false;
     }
 
-    // Exact canonical guard: sltiu; beq; nop; sll. This is the same accepted
-    // suffix as the Python capture verifier and excludes unrelated bounds.
+    // Exact guards: sltiu; beq; nop; sll, or sltiu; beq; lui; addiu; sll.
+    // The latter schedules the table's LUI in the bounds branch's delay slot.
+    // Keep both forms in parity with the Python capture verifier.
     if (sll_pc < entry + 12u) return false;
     uint32_t guard_pc = sll_pc - 8u;
     uint32_t bound_pc = sll_pc - 12u;
+    auto before_scale = read(sll_pc - 4u);
+    if (!before_scale.has_value()) return false;
+    bool scheduled_base = *before_scale != 0u;
+    if (scheduled_base) {
+        // R3000 JR would see the old target register without this load delay.
+        if (lw_pc != jr_pc - 8u) return false;
+        if (sll_pc < entry + 16u) return false;
+        guard_pc -= 4u;
+        bound_pc -= 4u;
+        auto upper_word = read(sll_pc - 8u);
+        if (!upper_word.has_value()) return false;
+        uint32_t upper_reg = (*upper_word >> 16) & 0x1Fu;
+        if ((*upper_word >> 26) != 0x0Fu ||
+            ((*upper_word >> 21) & 0x1Fu) != 0u || upper_reg == 0u ||
+            (*before_scale >> 26) != 0x09u ||
+            ((*before_scale >> 21) & 0x1Fu) != upper_reg ||
+            ((*before_scale >> 16) & 0x1Fu) != base_reg ||
+            upper_reg == index_reg || base_reg == index_reg) {
+            return false;
+        }
+    }
     auto guard_word_opt = read(guard_pc);
     auto bound_word = read(bound_pc);
-    auto guard_delay = read(sll_pc - 4u);
-    if (!guard_word_opt.has_value() || !bound_word.has_value() ||
-        !guard_delay.has_value() || *guard_delay != 0u) {
+    if (!guard_word_opt.has_value() || !bound_word.has_value()) {
         return false;
     }
     uint32_t guard_word = *guard_word_opt;
@@ -920,20 +940,23 @@ bool resolve_exact_bounded_jump_table(
     uint32_t bound_rt = (*bound_word >> 16) & 0x1Fu;
     uint32_t count = *bound_word & 0xFFFFu;
     if (bound_op != 0x0Bu || bound_rs != index_reg ||
-        bound_rt != bound_reg || count == 0u || count >= 512u ||
+        bound_rt != bound_reg || bound_reg == index_reg ||
+        count == 0u || count >= 512u ||
         in_delay_slot(bound_pc)) {
         return false;
     }
     uint32_t guard_target = exact_branch_target(guard_pc, guard_word);
     if ((guard_target & 3u) != 0u || guard_target < entry ||
         guard_target >= hard_cap ||
-        (guard_target >= sll_pc && guard_target < jr_pc + 8u)) {
+        (guard_target >= sll_pc && guard_target < jr_pc + 8u) ||
+        (scheduled_base && guard_target > bound_pc && guard_target < jr_pc + 8u)) {
         return false;
     }
 
     // Resolve the table-base reaching definition. Cross-register constants
     // (`lui rA; addiu rB,rA,lo`) are valid, but both definitions must be local,
-    // unskippable, outside delay slots, and unclobbered before use.
+    // unskippable and unclobbered before use. Only the validated scheduled
+    // form permits LUI in a delay slot, exactly that of the bounds BEQ.
     uint32_t low_pc = 0, source_reg = base_reg;
     int16_t low = 0;
     uint32_t lui_pc = 0, upper = 0;
@@ -974,7 +997,9 @@ bool resolve_exact_bounded_jump_table(
             break;
         }
     }
-    if (lui_pc == 0u || in_delay_slot(lui_pc) ||
+    if (scheduled_base && (lui_pc != guard_pc + 4u || low_pc != sll_pc - 4u))
+        return false;
+    if (lui_pc == 0u || (in_delay_slot(lui_pc) && !scheduled_base) ||
         (low_pc != 0u && in_delay_slot(low_pc)) ||
         inbound_skips(lui_pc, addu_pc) ||
         (low_pc != 0u && inbound_skips(low_pc, addu_pc)) ||
@@ -1026,6 +1051,7 @@ bool resolve_exact_bounded_jump_table(
         uint32_t runtime_target = *target_word;
         uint32_t image_target = mapped(runtime_target);
         if (image_target < entry || image_target >= hard_cap ||
+            (scheduled_base && image_target > bound_pc && image_target < jr_pc + 8u) ||
             image_target < producer_lo || image_target >= producer_hi ||
             (image_target & 3u) != 0u) {
             return false;
@@ -1089,6 +1115,7 @@ bool resolve_exact_bounded_jump_table(
             break;
         }
     }
+    uint32_t protected_pc = scheduled_base ? bound_pc : lui_pc;
     for (uint32_t source = entry; source < hard_cap; source += 4u) {
         auto word = read(source);
         if (!word.has_value()) return false;
@@ -1096,9 +1123,9 @@ bool resolve_exact_bounded_jump_table(
         bool direct = cf.kind == ExactCfKind::Branch ||
                       cf.kind == ExactCfKind::Jump ||
                       cf.kind == ExactCfKind::Jal;
-        if (direct && cf.target > lui_pc && cf.target <= jr_pc &&
-            (source < lui_pc || source > jr_pc) &&
-            !case_reachable.count(source)) {
+        if (direct && cf.target > protected_pc && cf.target <= jr_pc &&
+            (source < protected_pc || source > jr_pc) &&
+            (scheduled_base || !case_reachable.count(source))) {
             return false;
         }
     }

--- a/recompiler/tests/reachable_discovery_test.cpp
+++ b/recompiler/tests/reachable_discovery_test.cpp
@@ -102,9 +102,95 @@ bool resolves_ape_switch(const ApeSwitchFixture& f,
         nullptr, producer_lo, producer_hi);
 }
 
+ApeSwitchFixture make_scheduled_switch() {
+    auto f = make_ape_switch();
+    const size_t text = 2048;
+    put32(f.image, text + 0x500, 0);
+    put32(f.image, text + 0x504, 0);
+    put32(f.image, text + 0x508, 0x2C620003u); // sltiu v0,v1,3
+    put32(f.image, text + 0x50C, 0x1040001Cu); // beq v0,zero,+0x580
+    put32(f.image, text + 0x510, 0x3C028001u); // lui v0 (guard delay)
+    put32(f.image, text + 0x514, 0x24420A00u); // addiu v0,v0,0xa00
+    put32(f.image, text + 0x518, 0x00031880u); // sll v1,v1,2
+    put32(f.image, text + 0x51C, 0x00621821u); // addu v1,v1,v0
+    put32(f.image, text + 0x520, 0x8C620000u); // lw v0,0(v1)
+    return f;
+}
+
+void check_scheduled_switch() {
+    const size_t text = 2048;
+    auto f = make_scheduled_switch();
+    auto exe = parse(f.image);
+    PSXRecomp::ExactJumpTable table;
+    CHECK(PSXRecomp::resolve_exact_bounded_jump_table(
+              exe, f.entry, kLoad + 0x600u, f.jr_pc, 2u, table) &&
+          table.table_base == f.table && table.table_count == 3u,
+          "scheduled table constant resolves exactly");
+    std::set<uint32_t> targets;
+    for (auto target : table.targets) targets.insert(target.second);
+    CHECK(targets == std::set<uint32_t>(f.cases.begin(), f.cases.end()),
+          "scheduled table has exactly the expected case targets");
+    PSXRecomp::FunctionAnalyzer analyzer(exe);
+    auto result = analyzer.analyze_exact_entries({f.entry});
+    for (auto target : f.cases)
+        CHECK(result.exact_reachable_pcs.count(target),
+              "scheduled switch cases are reached from the function root");
+
+    auto renamed = f;
+    put32(renamed.image, text + 0x510, 0x3C088001u);
+    put32(renamed.image, text + 0x514, 0x25020A00u);
+    CHECK(resolves_ape_switch(renamed, renamed.entry),
+          "scheduled constant can rename registers");
+    auto no_load_delay = f;
+    no_load_delay.jr_pc = kLoad + 0x524u;
+    put32(no_load_delay.image, text + 0x524, 0x00400008u);
+    CHECK(!resolves_ape_switch(no_load_delay, f.entry),
+          "scheduled switch must respect the R3000 load delay");
+    auto signed_low = f;
+    signed_low.image.resize(text + 0x9000u);
+    put32(signed_low.image, 0x1C, 0x9000u);
+    put32(signed_low.image, text + 0x510, 0x3C028002u);
+    put32(signed_low.image, text + 0x514, 0x24428A00u);
+    for (size_t i = 0; i < f.cases.size(); ++i)
+        put32(signed_low.image, text + 0x8A00u + 4u * i, f.cases[i]);
+    CHECK(resolves_ape_switch(signed_low, f.entry, kLoad, kLoad + 0x9000u),
+          "scheduled constant sign-extends ADDIU low half");
+    CHECK(!resolves_ape_switch(f, f.entry, kLoad, kLoad + 0x900u),
+          "scheduled table must belong to the producer");
+
+    auto jump = [](uint32_t offset) {
+        return 0x08000000u | (((kLoad + offset) >> 2) & 0x03FFFFFFu);
+    };
+    const std::vector<std::vector<std::pair<size_t, uint32_t>>> mutations = {
+        {{0x508, 0x2C630003u}, {0x50C, 0x1060001Cu}}, // bound writes index
+        {{0x510, 0x3C038001u}, {0x514, 0x24620A00u}}, // LUI writes index
+        {{0x514, 0x24430A00u}}, // ADDIU writes index
+        {{0x514, 0x25020A00u}}, // wrong constant source
+        {{0x510, 0x3C228001u}}, // reserved LUI fields
+        {{0x50C, jump(0x580) | 0x04000000u}}, // JAL delay
+        {{0x50C, 0x5040001Cu}}, // BEQL
+        {{0x50C, 0x1040FFFFu}}, // self-loop with clobbered condition
+        {{0x50C, 0x10400000u}}, // reject into LUI
+        {{0x500, jump(0x510)}}, // earlier edge skips bound
+        {{0x590, jump(0x510)}}, // later edge skips bound
+        {{0x540, jump(0x510)}, {0x544, 0}}, // case skips bound
+        {{0x504, jump(0x580)}}, // bound in delay slot
+        {{0xA00, kLoad + 0x510u}}, // case target skips bound
+        {{0xA04, kLoad + 0x2000u}}, // out of host
+    };
+    for (const auto& changes : mutations) {
+        auto broken = f;
+        for (auto change : changes)
+            put32(broken.image, text + change.first, change.second);
+        CHECK(!resolves_ape_switch(broken, broken.entry),
+              "unsafe scheduled-switch mutation fails closed");
+    }
+}
+
 } // namespace
 
 int main() {
+    check_scheduled_switch();
     auto image = make_exe_buffer(0x2000);
     const size_t text = 2048;
 

--- a/recompiler/tests/recompiler_patch_test.cpp
+++ b/recompiler/tests/recompiler_patch_test.cpp
@@ -1068,6 +1068,29 @@ void jump_table_producer_codegen_test() {
           unbounded_alias_generated.front().full_code.find("/* jump table") !=
               std::string::npos,
           "alias regression fixture reaches the table when ownership is absent");
+
+    // The scheduled variant must feed code generation too, not merely the
+    // discovery report. Its table base overwrites the guard in the BEQ delay
+    // slot, so the existing branch emitter must preserve the tested condition.
+    write_word(exe, base + 0x500u, 0u);
+    write_word(exe, base + 0x504u, 0u);
+    write_word(exe, base + 0x508u, 0x2C620003u);
+    write_word(exe, base + 0x50Cu, 0x1040001Cu);
+    write_word(exe, base + 0x510u, 0x3C028001u);
+    write_word(exe, base + 0x514u, 0x24420A00u);
+    write_word(exe, base + 0x518u, 0x00031880u);
+    write_word(exe, base + 0x51Cu, 0x00621821u);
+    write_word(exe, base + 0x520u, 0x8C620000u);
+    PSXRecomp::ControlFlowAnalyzer scheduled_analyzer(exe);
+    const auto scheduled_cfg = scheduled_analyzer.analyze_function(function);
+    PSXRecomp::CodeGenerator scheduled_generator(exe);
+    const auto scheduled = scheduled_generator.generate_function(
+        function, scheduled_cfg).full_code;
+    check(scheduled.find("/* jump table") != std::string::npos,
+          "codegen emits a switch with its table LUI in the bounds delay slot");
+    for (uint32_t target : cases)
+        check(scheduled.find(fmt::format("goto block_{:08X}", target)) != std::string::npos,
+              "every scheduled case has an emitted native control-flow edge");
 }
 
 void cfg_codegen_load_delay_test() {

--- a/recompiler/tests/test_aot_overlay_discovery.py
+++ b/recompiler/tests/test_aot_overlay_discovery.py
@@ -1296,7 +1296,7 @@ def check_atomic_dll_publication():
             pair_id = MOD.overlay_pair_id("new source", func_ids)
             assert pair_id != MOD.overlay_pair_id("changed source", func_ids)
             bound_source = MOD.add_overlay_pair_export("new source", pair_id)
-            assert f"overlay_pair_id(void) {{ return UINT64_C(0x{pair_id:016X}); }}" in bound_source
+            assert f"overlay_pair_id(void) {{ return UINT64_C(0x{pair_id:016X}); }}" in " ".join(bound_source.split())
             assert MOD.compile_dll("ignored.c", final, [],
                                    func_ids=func_ids, pair_id=pair_id)
             with open(final, "rb") as built:
@@ -1527,6 +1527,7 @@ m.publish_shard_pair(sys.argv[2], sys.argv[3], sys.argv[4])
                 pair_dll = str(pathlib.Path(tmp) / "pair.dll")
                 pair_source.write_text(
                     '#include <stdint.h>\n' +
+                    '#define PSX_OVERLAY_EXPORT __declspec(dllexport)\n' +
                     '__declspec(dllexport) int overlay_abi(void) { return 14; }\n' +
                     '__declspec(dllexport) void overlay_init(const void *p) {(void)p;}\n' +
                     '__declspec(dllexport) void overlay_flush_cycles(void) {}\n' +
@@ -2999,7 +3000,7 @@ def check_interior_fragment_contract():
                 f"P {pair_id:016X}\nF {entry:08X} {code_crc:08X} junk\n"
                 f"R {entry:08X} 8\n")
             assert MOD.load_shard_entry_set(str(dll)) == set()
-            outside = 0x80200000
+            outside = 0x80000000 + MOD.PSX_RAM_SIZE
             ranges.write_text(
                 f"P {pair_id:016X}\nF {outside:08X} {code_crc:08X}\n"
                 f"R {outside:08X} 4\n")
@@ -3053,7 +3054,7 @@ def check_interior_fragment_contract():
             entry, data, LOAD, len(data), LOAD & 0x1FFFFFFF, "unused",
             Args(), {}, {},
             ((LOAD, LOAD + 0x40), (LOAD + 0x80, LOAD + 0x100)),
-            (LOAD + 0x200, LOAD + 0x180, LOAD + 0x200))
+            (LOAD + 0x200, LOAD + 0x180, LOAD + 0x200), guard_bytes=0)
         assert ids is None and status.startswith("recompiler-error")
     finally:
         MOD.subprocess.run = old_run
@@ -3071,7 +3072,7 @@ def check_interior_fragment_contract():
         ids, status = MOD.compile_fragment_batch(
             {entry + 0x40, entry}, data, LOAD, len(data),
             LOAD & 0x1FFFFFFF, "unused", Args(), {}, {},
-            ((LOAD, LOAD + 0x100),), ())
+            ((LOAD, LOAD + 0x100),), (), guard_bytes=0)
         assert ids is None and status.startswith("recompiler-error")
     finally:
         MOD.subprocess.run = old_run
@@ -3156,7 +3157,7 @@ def check_real_batched_fragment_publication(recompiler):
     with tempfile.TemporaryDirectory() as td:
         ids, status = MOD.compile_fragment_batch(
             {first}, bytes(data), LOAD, len(data), LOAD & 0x1FFFFFFF,
-            td, args, env, {}, initial_recipe, ())
+            td, args, env, {}, initial_recipe, (), guard_bytes=0)
         assert ids and status == 'built', (ids, status)
         initial_dlls = list(pathlib.Path(td).glob(f'*{extension}'))
         assert len(initial_dlls) == 1
@@ -3174,7 +3175,7 @@ def check_real_batched_fragment_publication(recompiler):
             requested_batches.append(tuple(roots))
             return MOD.compile_fragment_batch(
                 roots, bytes(data), LOAD, len(data), LOAD & 0x1FFFFFFF,
-                td, args, env, {}, recipe, ())
+                td, args, env, {}, recipe, (), guard_bytes=0)
 
         def warm(_roots, func_ids, _status):
             current_entries.update(
@@ -3255,7 +3256,7 @@ def check_real_hosted_fragment_publication(recompiler):
     with tempfile.TemporaryDirectory() as td:
         owner_ids, status = MOD.compile_fragment_batch(
             {host, host2}, bytes(data), LOAD, len(data), LOAD & 0x1FFFFFFF,
-            td, args, env, {}, recipe, ())
+            td, args, env, {}, recipe, (), guard_bytes=0)
         assert owner_ids and status == 'built'
         owners = {identity[0]: identity for identity in owner_ids
                   if identity[0] in (host, host2)}
@@ -3276,7 +3277,7 @@ def check_real_hosted_fragment_publication(recompiler):
         hosted_ids, status = MOD.compile_fragment_batch(
             {target, target2}, bytes(data), LOAD, len(data),
             LOAD & 0x1FFFFFFF, td, args, env, {}, recipe, (),
-            hosted_owners={target: spec, target2: spec2})
+            hosted_owners={target: spec, target2: spec2}, guard_bytes=0)
         assert hosted_ids and status == 'built', status
         by_entry = {
             entry: (crc, tuple(ranges))
@@ -3324,14 +3325,14 @@ def check_real_hosted_fragment_publication(recompiler):
         cached_ids, cached_status = MOD.compile_fragment_batch(
             {target, target2}, bytes(data), LOAD, len(data),
             LOAD & 0x1FFFFFFF, td, args, env, {}, recipe, (),
-            hosted_owners={target: spec, target2: spec2})
+            hosted_owners={target: spec, target2: spec2}, guard_bytes=0)
         assert cached_status == 'cached' and cached_ids == hosted_ids
         assert len(list(pathlib.Path(td).glob(
             f'*{MOD.overlay_ext()}'))) == dll_count
         orphan_before = set(pathlib.Path(td).glob(f'*{MOD.overlay_ext()}'))
         orphan_ids, orphan_status = MOD.compile_interior_fragment(
             target, bytes(data), LOAD, len(data), LOAD & 0x1FFFFFFF,
-            td, args, env, {}, recipe, ())
+            td, args, env, {}, recipe, (), guard_bytes=0)
         assert orphan_ids and orphan_status == 'built'
         orphan_dlls = set(pathlib.Path(td).glob(
             f'*{MOD.overlay_ext()}')) - orphan_before
@@ -3347,7 +3348,7 @@ def check_real_hosted_fragment_publication(recompiler):
             owners[host][0], owners[host][1] ^ 1, owners[host][2]))
         rejected, reason = MOD.compile_fragment_batch(
             {target}, bytes(data), LOAD, len(data), LOAD & 0x1FFFFFFF,
-            td, args, env, {}, recipe, (), hosted_owners={target: bad_spec})
+            td, args, env, {}, recipe, (), hosted_owners={target: bad_spec}, guard_bytes=0)
         assert rejected is None
         assert reason.startswith('hosted-entry-audit:'), reason
         assert len(list(pathlib.Path(td).glob(
@@ -3494,9 +3495,8 @@ def check_full_candidate_cli_fastpath(recompiler):
         # because the test could not get past the BIOS-profile probe to reach
         # the assertion (issue #72).
         leaf = (cache_root / 'CYCT-00101' / 'gcc' / MOD.cache_arch_abi() /
-                f'cg{MOD.codegen_ver(str(runtime_include))}_'
-                f'{MOD.codegen_hash(str(runtime_include)):08x}_'
-                f'gc{MOD.overlay_config_hash(recompiler, str(game_toml)):08x}')
+                MOD.cache_tag(str(runtime_include), recompiler,
+                              str(game_toml), 0))
         leaf.mkdir(parents=True)
         pair_id = 0x123456789ABCDEF0
         captured_bytes = b'\x08\x00\xE0\x03\x00\x00\x00\x00'

--- a/recompiler/tests/test_aot_overlay_discovery.py
+++ b/recompiler/tests/test_aot_overlay_discovery.py
@@ -223,6 +223,81 @@ def check_bounded_jump_table_discovery():
         LOAD + 0x60, 2, (LOAD, LOAD + 0x180)) == set()
 
 
+def check_scheduled_jump_table_discovery():
+    # Independent synthetic function: a checked input in v1, the table base
+    # in v0, and three cases returning distinct values. No captured game bytes.
+    data = bytearray(0x1000)
+    for offset, word in (
+        (0x508, 0x2C620003),  # sltiu v0,v1,3
+        (0x50C, 0x1040001C),  # beq v0,zero,+0x580
+        (0x510, 0x3C028001),  # lui v0,0x8001 (guard delay slot)
+        (0x514, 0x24420A00),  # addiu v0,v0,0xa00
+        (0x518, 0x00031880),  # sll v1,v1,2
+        (0x51C, 0x00621821),  # addu v1,v1,v0
+        (0x520, 0x8C620000),  # lw v0,0(v1)
+        (0x528, 0x00400008),  # jr v0
+        (0x580, 0x03E00008),
+    ):
+        put(data, offset, word)
+    cases = {LOAD + off for off in (0x540, 0x550, 0x560)}
+    for i, target in enumerate(sorted(cases)):
+        put(data, 0xA00 + i * 4, target)
+        put(data, target - LOAD, 0x24020001 + i)
+        put(data, target - LOAD + 4, 0x03E00008)
+
+    def resolve(image, producer=None):
+        return MOD._find_jump_table_targets(
+            image, LOAD, len(image), LOAD + 0x500, LOAD + 0x600,
+            LOAD + 0x528, 2, producer)
+
+    assert resolve(data) == cases
+    no_load_delay = bytearray(data)
+    put(no_load_delay, 0x524, 0x00400008)
+    assert MOD._find_jump_table_targets(
+        no_load_delay, LOAD, len(data), LOAD + 0x500, LOAD + 0x600,
+        LOAD + 0x524, 2) == set()
+    walk = MOD._walk_overlay_function(
+        data, LOAD, len(data), LOAD + 0x500, LOAD + 0x600)
+    assert walk['jump_table_targets'] == cases
+    assert cases <= walk['visited']
+    renamed = bytearray(data)
+    put(renamed, 0x510, 0x3C088001)  # lui t0
+    put(renamed, 0x514, 0x25020A00)  # addiu v0,t0
+    assert resolve(renamed) == cases
+    signed_low = bytearray(0x9000)
+    signed_low[:len(data)] = data
+    signed_low[0x8A00:0x8A0C] = data[0xA00:0xA0C]
+    put(signed_low, 0x510, 0x3C028002)
+    put(signed_low, 0x514, 0x24428A00)
+    assert resolve(signed_low) == cases
+    assert resolve(data, (LOAD, LOAD + 0x900)) == set()
+
+    def jump(offset):
+        return 0x08000000 | (((LOAD + offset) >> 2) & 0x03FFFFFF)
+
+    for name, mutations in (
+        ('bound overwrites index', ((0x508, 0x2C630003), (0x50C, 0x1060001C))),
+        ('LUI overwrites index', ((0x510, 0x3C038001), (0x514, 0x24620A00))),
+        ('ADDIU overwrites index', ((0x514, 0x24430A00),)),
+        ('wrong constant source', ((0x514, 0x25020A00),)),
+        ('reserved LUI fields', ((0x510, 0x3C228001),)),
+        ('call delay slot', ((0x50C, jal(LOAD + 0x580)),)),
+        ('branch likely', ((0x50C, 0x5040001C),)),
+        ('guard loop clobbers condition', ((0x50C, 0x1040FFFF),)),
+        ('reject into constant', ((0x50C, 0x10400000),)),
+        ('skip bound from before', ((0x500, jump(0x510)),)),
+        ('skip bound from after', ((0x590, jump(0x510)),)),
+        ('case skips bound', ((0x540, jump(0x510)), (0x544, 0))),
+        ('bound in delay slot', ((0x504, jump(0x580)),)),
+        ('table case skips bound', ((0xA00, LOAD + 0x510),)),
+        ('out of host target', ((0xA04, LOAD + 0x700),)),
+    ):
+        broken = bytearray(data)
+        for offset, word in mutations:
+            put(broken, offset, word)
+        assert resolve(broken) == set(), name
+
+
 def check_composite_call_boundaries():
     data = bytearray(0x100)
     cross_target = LOAD + 0x50
@@ -3649,6 +3724,7 @@ def main():
 
     check_composite_call_boundaries()
     check_bounded_jump_table_discovery()
+    check_scheduled_jump_table_discovery()
     check_static_discovery_provenance()
     check_static_dispatch_provenance()
     check_owned_direct_call_is_interior()

--- a/tools/aot_overlay_spike/README.md
+++ b/tools/aot_overlay_spike/README.md
@@ -5,7 +5,7 @@ disc image at build time, so a fresh install ships with overlay coverage instead
 of relying entirely on runtime (tcc/gcc) autocompile. See `docs/AOT_OVERLAY_PLAN.md`
 for the full design, findings, and honest coverage numbers.
 
-**Status: ENHANCEMENT SPIKE. Provably-correct for clean producers, not exhaustive.**
+**Status: ENHANCEMENT SPIKE. Partial static discovery; not a correctness proof.**
 `extract_generic.py` is path-parameterized and suitable for the current build
 pipeline. Disc-container discovery remains engine-specific; unsupported producers
 fail closed instead of being guessed as code.
@@ -41,13 +41,22 @@ the named metric.
   All 22 A*.BIN overlays converge on 0x80108F9C (region 0x80108000 +3996),
   DEMO/GAME converge on 0x80106228, and OPN resolves to 0x8018A000.
 
-## Correctness guarantee (why partial coverage is safe)
+## What byte guards establish
 
 Every shard is content-addressed by per-function `code_crc`; the runtime loader
-only executes a shard when live RAM byte-matches (`overlay_loader.c` lazy_man_matches).
-A mis-positioned / data-as-code shard either fails audit at compile time or never
-fires at runtime → coverage loss, never incorrect execution. Whatever static
-misses, production autocompile (tcc/gcc) self-heals on first visit.
+checks live RAM against its recorded byte ranges (`overlay_loader.c`
+`lazy_man_matches`). That protects against selecting a different overlay at the
+same address. It does not prove that bytes were correctly classified as code,
+that all dependencies were guarded, or that the emitted native code is correct.
+Captured shards are investigative references, not correctness or completeness
+oracles. Production fallback can cover additional executed paths; it cannot
+establish that a static extraction is complete.
+
+The shared switch recognizer accepts a bounded `sltiu; beq; lui; addiu; sll;
+addu; lw; nop; jr` pattern, including LUI in the BEQ delay slot. Register
+dependencies, producer bounds, table targets, and direct edges must pass the
+proof checks. This recovers a compiler convention across titles without game
+addresses in the recognizer. Unknown dispatch forms still require investigation.
 
 ## Durable runtime capture history
 

--- a/tools/aot_overlay_spike/extract_generic.py
+++ b/tools/aot_overlay_spike/extract_generic.py
@@ -749,6 +749,7 @@ def rec(load_addr, data, seeds, dispatch_extra=None, producer_ranges=None,
     disp = static_dispatch
     out={"schema":"psxrecomp overlay capture v2","load_addr":f"0x{load_addr:08X}",
          "size":len(data),"bytes_b64":base64.b64encode(data).decode(),
+         "guard_bytes":0,  # Original source bytes; no capture trailer appended.
          "executed_pcs":[],"dispatch_entry_pcs":[f"0x{a:08X}" for a in disp],
          "static_dispatch_entry_pcs":[
              f"0x{a:08X}" for a in static_dispatch],

--- a/tools/compile_overlays.py
+++ b/tools/compile_overlays.py
@@ -844,6 +844,11 @@ def _find_jump_table_targets(data: bytes, load_addr: int, size: int,
         sll scaled,index,2; addu address,scaled,table_base
         lw target,offset(address); [nop x 0..1]; jr target
 
+    Also accept ``sltiu; beq; lui; addiu; sll``: the LUI executes in the
+    guard's delay slot, then ADDIU completes the base on the in-range path.
+    That exact pair may not overwrite the checked index, and direct edges
+    may not bypass the bound (including edges from switch cases).
+
     ``table_base`` must be a nearest-definition LUI, optionally followed by a
     nearest-definition ADDIU.  The lower instruction may rename the
     register (``lui v0; addiu s0,v0,lo``), as used by Ape Escape.  Any other
@@ -853,7 +858,7 @@ def _find_jump_table_targets(data: bytes, load_addr: int, size: int,
     """
     lo = load_addr
     hi = load_addr + size
-    if not (entry <= jr_pc < hard_cap and 0 < jr_rs < 32):
+    if not (entry <= jr_pc < hard_cap and 0 < jr_rs < 31):
         return set()
     jr_word = _word_at(data, load_addr, jr_pc)
     if jr_word != ((jr_rs << 21) | 0x08):
@@ -904,7 +909,24 @@ def _find_jump_table_targets(data: bytes, load_addr: int, size: int,
     # The bound must guard this exact index on the sole fallthrough into SLL.
     sltiu_pc = sll_pc - 12
     branch_pc = sll_pc - 8
-    if _word_at(data, load_addr, sll_pc - 4) != 0:
+    scheduled_base = _word_at(data, load_addr, sll_pc - 4) != 0
+    if scheduled_base:
+        # R3000 load delay: JR must not consume the immediately preceding LW.
+        if lw_pc != jr_pc - 8:
+            return set()
+        sltiu_pc -= 4
+        branch_pc -= 4
+        upper = _word_at(data, load_addr, sll_pc - 8)
+        lower = _word_at(data, load_addr, sll_pc - 4)
+        if (upper is None or lower is None or
+                (upper >> 26) != 0x0F or ((upper >> 21) & 31) != 0 or
+                (lower >> 26) != 0x09 or ((lower >> 16) & 31) != table_reg or
+                ((upper >> 16) & 31) == 0 or
+                ((upper >> 16) & 31) != ((lower >> 21) & 31) or
+                index_reg in (table_reg, (upper >> 16) & 31)):
+            return set()
+    if sltiu_pc < entry or (sltiu_pc >= entry + 4 and
+            _is_control_flow(_word_at(data, load_addr, sltiu_pc - 4))):
         return set()
     sltiu_word = _word_at(data, load_addr, sltiu_pc)
     branch_word = _word_at(data, load_addr, branch_pc)
@@ -913,7 +935,7 @@ def _find_jump_table_targets(data: bytes, load_addr: int, size: int,
         return set()
     guard_reg = (sltiu_word >> 16) & 0x1F
     table_count = sltiu_word & 0xFFFF
-    if not guard_reg or not (1 <= table_count < 512):
+    if not guard_reg or guard_reg == index_reg or not (1 <= table_count < 512):
         return set()
     if branch_word is None or ((branch_word >> 26) & 0x3F) != 0x04:
         return set()
@@ -923,7 +945,8 @@ def _find_jump_table_targets(data: bytes, load_addr: int, size: int,
         return set()
     reject_target = _branch_target(branch_pc, branch_word)
     if (not (entry <= reject_target < hard_cap) or
-            sll_pc <= reject_target < jr_pc + 8):
+            sll_pc <= reject_target < jr_pc + 8 or
+            (scheduled_base and sltiu_pc < reject_target < jr_pc + 8)):
         return set()
 
     def nearest_writer(reg: int, before: int):
@@ -962,6 +985,10 @@ def _find_jump_table_targets(data: bytes, load_addr: int, size: int,
     else:
         return set()
 
+    if scheduled_base and (constant_pc != branch_pc + 4 or
+                           table_def_pc != sll_pc - 4):
+        return set()
+
     # Calls could clobber the proven constant.  Other branches could enter the
     # suffix through an unproved path.  The one exact bounds branch is allowed.
     for pc in range(constant_pc + 4, sll_pc, 4):
@@ -971,7 +998,8 @@ def _find_jump_table_targets(data: bytes, load_addr: int, size: int,
         if _is_control_flow(word) and pc != branch_pc:
             return set()
     predecessor = _word_at(data, load_addr, constant_pc - 4)
-    if constant_pc >= entry + 4 and _is_control_flow(predecessor):
+    if (constant_pc >= entry + 4 and _is_control_flow(predecessor) and
+            not scheduled_base):
         return set()
     table_base = (table_base + lw_offset) & 0xFFFFFFFF
     table_end = table_base + table_count * 4
@@ -984,6 +1012,7 @@ def _find_jump_table_targets(data: bytes, load_addr: int, size: int,
         target = _word_at(data, load_addr, table_base + index * 4)
         if (target is None or (target & 3) or
                 not (entry <= target < hard_cap) or
+                (scheduled_base and sltiu_pc < target < jr_pc + 8) or
                 not (range_lo <= target < range_hi) or
                 not _is_valid_mips_word(_word_at(data, load_addr, target))):
             return set()
@@ -1025,15 +1054,16 @@ def _find_jump_table_targets(data: bytes, load_addr: int, size: int,
         elif kind in ('jr', 'jr_ra'):
             case_reachable.add(delay)
 
+    protected_pc = sltiu_pc if scheduled_base else constant_pc
     for source in range(entry, hard_cap, 4):
         source_word = _word_at(data, load_addr, source)
         if source_word is None:
             return set()
         kind, target = _classify_cf(source, source_word)
         if (kind in ('branch', 'j', 'jal') and
-                constant_pc < target <= jr_pc and
-                not (constant_pc <= source <= jr_pc) and
-                source not in case_reachable):
+                protected_pc < target <= jr_pc and
+                not (protected_pc <= source <= jr_pc) and
+                (scheduled_base or source not in case_reachable)):
             return set()
     if proof_out is not None:
         proof_out.append({

--- a/tools/tests/test_overlay_guard_bytes_declaration.py
+++ b/tools/tests/test_overlay_guard_bytes_declaration.py
@@ -28,6 +28,8 @@ ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT / "tools"))
 
 import compile_overlays  # noqa: E402
+sys.path.insert(0, str(ROOT / "tools" / "aot_overlay_spike"))
+import extract_generic  # noqa: E402
 
 
 class GuardByteDerivationTests(unittest.TestCase):
@@ -66,6 +68,20 @@ class GuardByteDerivationTests(unittest.TestCase):
 
 class PsxExeTagTests(unittest.TestCase):
     PAYLOAD = b"\x00" * 0x2000 + struct.pack("<I", 0x1062005A)
+
+    def test_disc_record_does_not_lose_its_last_instruction(self):
+        # Real disc images can also have a page+4 length (Italian DEMO+A07).
+        # Carry the producer declaration through the normal compiler wrapper.
+        base = 0x80100000
+        record = extract_generic.rec(base, self.PAYLOAD, [base],
+                                     producer_ranges=[(base, base + len(self.PAYLOAD))])
+        guards = compile_overlays.capture_guard_bytes(record, record['size'])
+        wrapped = compile_overlays.make_psxexe(base, base, self.PAYLOAD,
+                                              guard_bytes=guards)
+        self.assertEqual(guards, 0)
+        self.assertEqual(wrapped[2048:], self.PAYLOAD)
+        off = compile_overlays.GUARD_TAG_MAGIC_OFFSET
+        self.assertNotEqual(wrapped[off:off + 8], b"PSXRGRD1")
 
     def test_tag_lands_where_the_recompiler_reads_it(self):
         wrapped = compile_overlays.make_psxexe(


### PR DESCRIPTION
Overlay switches that schedule table-address constants around their bounds branch were missed, leaving code in areas such as Tomba 2 water temple interpreted. Extend the shared recognizers with bounded register/producer checks, without title-specific addresses. Original-disc producers now explicitly declare zero capture guard bytes so page-plus-four file sizes retain their last instruction.

Add a README-linked AOT sharding guide covering the existing extraction/compiler/cache boundary, per-game loader recipes, safe sparse images, reproducible packaging, and the limits of static coverage claims. Synchronize stale test fixtures with the current export macro, guard-byte argument, RAM bound and shared cache-tag helper.

Validation: recompiler_patch_test, reachable_discovery_test, overlay_guard_bytes_declaration and the complete aot_overlay_discovery test pass. US/Italian all-22 area builds were prepared from original inputs; the owner accepted Italian water temple and Kujara Ranch performance with runtime compilation disabled. Full static coverage is unproven. One early Italian watchdog abort was not reproduced in longer retesting and is not claimed fixed.
