### PR TITLE
WIP: guarded native-wide backgrounds and persistent composite lifetime

### DIFF
--- a/docs/WIDESCREEN.md
+++ b/docs/WIDESCREEN.md
@@ -1,5 +1,32 @@
 # Widescreen support (`feat/widescreen`)
 
+## Explicit native-wide background polygons (September 2026)
+
+A title plugin can call `gpu_ws_tag_background_prim(prim)` for each opaque
+background polygon in a verified composite, before submitting its ordering
+table. The command starts at `prim + 4`; an embedded command can therefore use
+`command_address - 4` even when that preceding word is not a DMA header.
+The framework validates command type, RAM bounds, complete packet contents,
+address and freshness. The title owns the proof that these are backgrounds
+and that their union covers the authored viewport. No fixed game addresses or
+background guesses belong in the shared API.
+
+OpenGL and software rendering stretch only those polygons about the display
+center in the native-wide surface, preserving canonical VRAM and the default
+4:3 path. Tag every part, including flat fills behind textured sky quads, so
+the composite remains continuous. Tags expire after two frames and reject
+reused packets whose words changed. This method performs no guest writes or
+extra guest allocations.
+
+OpenGL preserves the tag across flat and textured batching. While an explicitly
+tagged background is active, it renders the full wide composite instead of
+copying the canonical center over it, which would create a scale seam. Other
+scenes retain the center-copy optimization. Measure performance in the title
+and validate the visible sky at the requested aspect before release. Vulkan's
+native-wide compositor is not implemented; this API does not add one.
+
+## Earlier projection-and-stretch implementation
+
 Status as of 2026-06-13. Branch `feat/widescreen` in **both** `psxrecomp`
 (framework) and `TombaRecomp` (game opt-in + config), pushed to remote.
 Experimental. Latest: the far-backdrop edge void is largely fixed (2D backdrop

--- a/docs/WIDESCREEN.md
+++ b/docs/WIDESCREEN.md
@@ -18,12 +18,27 @@ the composite remains continuous. Tags expire after two frames and reject
 reused packets whose words changed. This method performs no guest writes or
 extra guest allocations.
 
-OpenGL preserves the tag across flat and textured batching. While an explicitly
-tagged background is active, it renders the full wide composite instead of
-copying the canonical center over it, which would create a scale seam. Other
-scenes retain the center-copy optimization. Measure performance in the title
-and validate the visible sky at the requested aspect before release. Vulkan's
-native-wide compositor is not implemented; this API does not add one.
+OpenGL preserves the tag across flat and textured batching. Once a valid
+background has been tagged, it renders the full wide composite instead of
+copying the canonical center over it, which would create a scale seam. Packet
+freshness and displayed-pixel lifetime are separate: a slow game or held display
+can retain stretched pixels after the two-frame packet guard expires. The
+full-composite requirement therefore remains latched until GPU reset or snapshot
+restore; packet-address/content freshness is not relaxed. Sessions that have not
+tagged a background retain the center-copy optimization. Measure performance in
+the title and validate the visible sky at the requested aspect before release.
+Vulkan's native-wide compositor is not implemented; this API does not add one.
+
+### Parked validation checkpoint (2026-09-12)
+
+The focused GPU packet/tag regression passes, including expired packets,
+changed packet contents, disabled widescreen and retained composite lifetime.
+The V8 Windows runtime builds and both game CTests pass. In the oil-field
+21:9 playtest the owner reports that terrain looks fine and the background
+flickers less badly, but still flickers. This is partial improvement, not visual
+acceptance. State replay required the HLE scheduler; repeat the comparison with
+matched scheduler settings before attributing the improvement solely to this
+change. Work is parked in a draft; no release is approved.
 
 ## Earlier projection-and-stretch implementation
 

--- a/runtime/include/gpu.h
+++ b/runtime/include/gpu.h
@@ -353,6 +353,16 @@ void gpu_ws_set_nw_hud_corners(int on);
  * `prim` is the address of the PsyQ P_TAG word; the drawn command starts at
  * prim+4. anchor: -1 = left, 0 = center, +1 = right. */
 void gpu_ws_tag_hud_prim(uint32_t prim, int anchor);
+/* Stretch a trusted authored background polygon about the display center in
+ * the native-wide output only (GL/SW). prim+4 is the command address, including
+ * for a command embedded inside a longer DMA packet. Only opaque polygons are
+ * accepted; address, full packet contents, and frame freshness are guarded.
+ * Tag the complete background composite before submitting its ordering table.
+ * The caller proves background identity/coverage; no guest data is modified. */
+void gpu_ws_tag_background_prim(uint32_t prim);
+/* Renderer policy: tagged background scenes need their full wide composite;
+ * copying the canonical center over it would introduce a scale discontinuity. */
+int gpu_ws_background_stretch_active(void);
 /* Clear synthetic margins to black over an opaque 0x64/65 rectangle's Y band
  * immediately before it executes. Packet-guarded; canonical VRAM is untouched. */
 void gpu_ws_tag_black_reveal_rect(uint32_t prim);

--- a/runtime/include/gpu.h
+++ b/runtime/include/gpu.h
@@ -360,9 +360,12 @@ void gpu_ws_tag_hud_prim(uint32_t prim, int anchor);
  * Tag the complete background composite before submitting its ordering table.
  * The caller proves background identity/coverage; no guest data is modified. */
 void gpu_ws_tag_background_prim(uint32_t prim);
-/* Renderer policy: tagged background scenes need their full wide composite;
- * copying the canonical center over it would introduce a scale discontinuity. */
+/* Fresh packet tags are eligible for background classification. */
 int gpu_ws_background_stretch_active(void);
+/* A tagged background can remain in a wide surface after its packet expires.
+ * Once used, retain full compositing until GPU reset or snapshot restoration.
+ * Packet freshness must never re-enable canonical-center overwrites. */
+int gpu_ws_background_requires_full_composite(void);
 /* Clear synthetic margins to black over an opaque 0x64/65 rectangle's Y band
  * immediately before it executes. Packet-guarded; canonical VRAM is untouched. */
 void gpu_ws_tag_black_reveal_rect(uint32_t prim);

--- a/runtime/src/gpu.c
+++ b/runtime/src/gpu.c
@@ -167,6 +167,9 @@ static void ws_nw_sync_target(void);
 typedef struct { uint32_t key; uint32_t stamp; int32_t anchor_x; } WsTag;
 static WsTag    ws_tags[WS_TAG_BUCKETS];
 static WsHudAnchorTag ws_hud_anchor_tags[WS_HUD_ANCHOR_TABLE_SIZE];
+static WsHudAnchorTag ws_background_tags[WS_HUD_ANCHOR_TABLE_SIZE];
+static uint32_t ws_background_tag_frame;
+static int ws_background_tags_used;
 static WsHudAnchorTag ws_reveal_clear_tags[WS_HUD_ANCHOR_TABLE_SIZE];
 static WsRepeatRectTag ws_repeat_rect_tags[WS_REPEAT_RECT_TAG_TABLE_SIZE];
 static uint32_t ws_last_tag_stamp = (uint32_t)-1000; /* frame of newest tag */
@@ -1877,6 +1880,39 @@ void gpu_ws_tag_hud_prim(uint32_t prim, int anchor) {
                          (uint32_t)s_frame_count);
 }
 
+void gpu_ws_tag_background_prim(uint32_t prim) {
+    if (!ws_native_wide_configured() || (prim & 3u) ||
+        prim > UINT32_MAX - 4u) return;
+    uint32_t words[12], count = 0;
+    if (!ws_hud_command_words(prim + 4u, words, &count)) return;
+    uint32_t op = words[0] >> 24;
+    if (op < 0x20u || op > 0x3Fu || (op & 2u)) return;
+    WsPrepassPacketGuard guard = ws_prepass_packet_guard(words, count);
+    ws_hud_anchor_insert(ws_background_tags, WS_HUD_ANCHOR_TABLE_SIZE,
+                         (prim + 4u) & 0x1FFFFCu, 0, &guard,
+                         (uint32_t)s_frame_count);
+    ws_background_tags_used = 1;
+    ws_background_tag_frame = (uint32_t)s_frame_count;
+}
+
+int gpu_ws_background_stretch_active(void) {
+    uint32_t frame = (uint32_t)s_frame_count;
+    return ws_background_tags_used && ws_native_wide_active() &&
+           frame >= ws_background_tag_frame &&
+           frame - ws_background_tag_frame <= WS_HUD_ANCHOR_FRESH_FRAMES;
+}
+
+static int ws_nw_explicit_background(void) {
+    if (!gpu_ws_background_stretch_active() ||
+        gp0_cmd_source_addr == 0xFFFFFFFFu ||
+        gp0_words_needed <= 0 || gp0_words_needed > 12) return 0;
+    uint32_t addr = gp0_cmd_source_addr & 0x1FFFFFFFu;
+    if (addr >= 0x00200000u || (addr & 3u)) return 0;
+    return ws_hud_anchor_lookup(ws_background_tags, WS_HUD_ANCHOR_TABLE_SIZE,
+                                addr, gp0_cmd_buf, (uint32_t)gp0_words_needed,
+                                (uint32_t)s_frame_count, NULL);
+}
+
 void gpu_ws_tag_black_reveal_rect(uint32_t prim) {
     if (!ws_native_wide_configured()) return;
     if ((prim & 3u) != 0 || prim > UINT32_MAX - 4u) return;
@@ -2044,6 +2080,8 @@ static int ws_bg_phase_over(void) {
 }
 
 int psx_ws_prim_in_backdrop(void) {
+    /* Explicit title proof is independent of heuristic draw-order phases. */
+    if (ws_nw_explicit_background()) return 1;
     if (gp0_cmd_source_addr != 0xFFFFFFFFu) {
         uint32_t f = (uint32_t)s_frame_count;
         if (f != bdg_src_frame) { bdg_src_frame = f; g_bdg_src_lo = 0xFFFFFFFFu; g_bdg_src_hi = 0; }
@@ -2785,6 +2823,8 @@ static void gpu_reset_state(int clear_vram) {
     gp0_next_source_addr = 0xFFFFFFFFu;
     gp0_cmd_source_addr = 0xFFFFFFFFu;
     ws_hud_anchor_clear(ws_hud_anchor_tags, WS_HUD_ANCHOR_TABLE_SIZE);
+    ws_hud_anchor_clear(ws_background_tags, WS_HUD_ANCHOR_TABLE_SIZE);
+    ws_background_tags_used = 0;
     ws_hud_anchor_clear(ws_reveal_clear_tags, WS_HUD_ANCHOR_TABLE_SIZE);
     ws_repeat_rect_tag_clear(ws_repeat_rect_tags);
     polyline_color = 0;
@@ -6100,6 +6140,8 @@ int gpu_snapshot_read(const uint8_t *p, uint32_t len) {
     pst_r_init(&r, p, len);
     if (!gpu_snap_parse(&r)) return 0;
     ws_hud_anchor_clear(ws_hud_anchor_tags, WS_HUD_ANCHOR_TABLE_SIZE);
+    ws_hud_anchor_clear(ws_background_tags, WS_HUD_ANCHOR_TABLE_SIZE);
+    ws_background_tags_used = 0;
     ws_hud_anchor_clear(ws_reveal_clear_tags, WS_HUD_ANCHOR_TABLE_SIZE);
     ws_repeat_rect_tag_clear(ws_repeat_rect_tags);
     /* Sync renderer clip/scissor to restored GP0(E3/E4); vars alone leave GL

--- a/runtime/src/gpu.c
+++ b/runtime/src/gpu.c
@@ -1902,6 +1902,15 @@ int gpu_ws_background_stretch_active(void) {
            frame - ws_background_tag_frame <= WS_HUD_ANCHOR_FRESH_FRAMES;
 }
 
+int gpu_ws_background_requires_full_composite(void) {
+    /* Freshness governs reuse of a packet address, not the lifetime of the
+     * pixels it produced. A slow game frame or a held display buffer can keep
+     * those pixels on screen indefinitely. Conservatively keep full mirroring
+     * once a composite has been tagged; GPU reset/snapshot restore clears the
+     * latch together with the tags. Never modify the packet freshness guard. */
+    return ws_background_tags_used && ws_native_wide_configured();
+}
+
 static int ws_nw_explicit_background(void) {
     if (!gpu_ws_background_stretch_active() ||
         gp0_cmd_source_addr == 0xFFFFFFFFu ||

--- a/runtime/src/gpu_gl_renderer.c
+++ b/runtime/src/gpu_gl_renderer.c
@@ -1682,7 +1682,7 @@ static int wide_fast_center_valid(void) {
     /* An explicitly stretched sky differs inside the canonical viewport too.
      * Keep the full composite for those scenes, including later foreground
      * draws. Tags are installed before DMA, so no earlier center draws skip. */
-    return s_wide_fast && !gpu_ws_background_stretch_active();
+    return s_wide_fast && !gpu_ws_background_requires_full_composite();
 }
 static void wide_blit_center(GLuint wide_fbo, int base_x, int disp_y, int disp_h); /* def below */
 /* True if [lo,hi] (canonical draw-x) lies strictly inside the 4:3 frame, so the

--- a/runtime/src/gpu_gl_renderer.c
+++ b/runtime/src/gpu_gl_renderer.c
@@ -1678,17 +1678,23 @@ static int bd_prim_gate(const int *xs, int n, int textured) {
 static int s_wide_fast = 1;
 void gl_renderer_set_wide_fast(int on) { s_wide_fast = on ? 1 : 0; }
 int  gl_renderer_get_wide_fast(void) { return s_wide_fast; }
+static int wide_fast_center_valid(void) {
+    /* An explicitly stretched sky differs inside the canonical viewport too.
+     * Keep the full composite for those scenes, including later foreground
+     * draws. Tags are installed before DMA, so no earlier center draws skip. */
+    return s_wide_fast && !gpu_ws_background_stretch_active();
+}
 static void wide_blit_center(GLuint wide_fbo, int base_x, int disp_y, int disp_h); /* def below */
 /* True if [lo,hi] (canonical draw-x) lies strictly inside the 4:3 frame, so the
  * prim adds nothing to either reveal margin and its mirror can be skipped. */
 static int mirror_x_center_only(int lo, int hi) {
-    if (!s_wide_fast) return 0;
+    if (!wide_fast_center_valid()) return 0;
     int base = g_wide_cur_base, native_w = g_wide_w - 2 * g_wide_off;
     if (native_w <= 0) return 0;
     return (lo >= base) && (hi < base + native_w);
 }
 static int mirror_geo_center_only(const int *xs, int n) {
-    if (!s_wide_fast) return 0;
+    if (!wide_fast_center_valid()) return 0;
     int lo = xs[0], hi = xs[0];
     for (int i = 1; i < n; i++) { if (xs[i] < lo) lo = xs[i]; if (xs[i] > hi) hi = xs[i]; }
     return mirror_x_center_only(lo, hi);
@@ -1825,7 +1831,7 @@ static int    s_cw_batches = 0, s_cw_wide_sets = 0, s_cw_wide_cfgs = 0,
 /* Textured-batch variant of mirror_x_center_only: scan the queued verts' x
  * (attr 0, stride TEXV). Defined here so s_tb / TEXV are in scope. */
 static int mirror_batch_center_only(int nverts) {
-    if (!s_wide_fast || nverts <= 0) return 0;
+    if (!wide_fast_center_valid() || nverts <= 0) return 0;
     float flo = s_tb[0], fhi = s_tb[0];
     for (int i = 1; i < nverts; i++) {
         float x = s_tb[i * TEXV];
@@ -1887,9 +1893,10 @@ static float s_fb[FLATBATCH_MAXV * 6];
 static int   s_fb_n = 0;
 static int   s_fb_semi = -2;
 static int   s_fb_mask = -1;
+static int   s_fb_gate = 0;
 
 static int mirror_flat_batch_center_only(int nverts) {
-    if (!s_wide_fast || nverts <= 0) return 0;
+    if (!wide_fast_center_valid() || nverts <= 0) return 0;
     float flo = s_fb[0], fhi = s_fb[0];
     for (int i = 1; i < nverts; i++) {
         float x = s_fb[i * 6];
@@ -1917,8 +1924,7 @@ static void flush_flat_batch(void) {
     if (g_wide_cur && !s_wide_suppress && s_ws_ablate != 1 &&
         !(!g_ws_bd_stretch_on && mirror_flat_batch_center_only(nverts))) {
         int dx = wide_dx();
-        /* Batch may span many prims; use stretch gate off (flat dots/UI). */
-        s_bd_gate = 0;
+        s_bd_gate = s_fb_gate;
         gl_perf_mirror_begin();
         wide_target_begin(dx, s_geo_uXoff, s_geo_uXhalf);
         wide_set_bd_scale(s_geo_uXscale, s_geo_uXcenter);
@@ -1979,12 +1985,15 @@ static void gpu_geometry(GLenum mode, const int *xs, const int *ys,
         return;
     }
 
-    if (s_fb_n > 0 && (s_fb_semi != semi || s_fb_mask != (int)s_mask_set))
+    int gate = bd_prim_gate(xs, n, 0);
+    if (s_fb_n > 0 && (s_fb_semi != semi || s_fb_mask != (int)s_mask_set ||
+                      s_fb_gate != gate))
         flush_flat_batch();
     if (s_fb_n + n > FLATBATCH_MAXV)
         flush_flat_batch();
     s_fb_semi = semi;
     s_fb_mask = (int)s_mask_set;
+    s_fb_gate = gate;
 
     float mask_a = s_mask_set ? 1.0f : 0.0f;
     for (int i = 0; i < n; i++) {
@@ -4405,7 +4414,7 @@ void gl_renderer_present_vram(int disp_x, int disp_y, int w, int h, int linear,
  * x-translated by the reveal offset. No-op when s_wide_fast is off (then the
  * mirror drew the full surface, as before). Shared by both present paths. */
 static void wide_blit_center(GLuint wide_fbo, int base_x, int disp_y, int disp_h) {
-    if (!s_wide_fast || g_wide_w <= 0) return;
+    if (!wide_fast_center_valid() || g_wide_w <= 0) return;
     int native_w = g_wide_w - 2 * g_wide_off;
     if (native_w <= 0) return;
     int S = s_scale;

--- a/runtime/tests/test_gpu_textured_dot_nw_shift_exec.c
+++ b/runtime/tests/test_gpu_textured_dot_nw_shift_exec.c
@@ -33,6 +33,8 @@ static void reset_gpu_state_for_test(void) {
     memset(test_ram, 0, sizeof(test_ram));
     memset(&last_textured_rect, 0, sizeof(last_textured_rect));
     memset(ws_hud_anchor_tags, 0, sizeof(ws_hud_anchor_tags));
+    memset(ws_background_tags, 0, sizeof(ws_background_tags));
+    ws_background_tags_used = 0;
     memset(ws_tags, 0, sizeof(ws_tags));
 
     s_frame_count = 100;
@@ -98,6 +100,80 @@ static void configure_native_wide_16_9(void) {
     ws_full_2d = 1;
 }
 
+static void test_background_packet_tags(void) {
+    /* The second F4 is embedded in a DMA node: its preceding word need not
+     * be a P_TAG. Only the command and its complete contents are authority. */
+    const uint32_t addr = 0x1001Cu;
+    const uint32_t packet[] = {0x28020304u, 0, 320, 240u << 16,
+                               (240u << 16) | 320u};
+    reset_gpu_state_for_test();
+    memcpy(&test_ram[addr / 4u], packet, sizeof(packet));
+    gp0_cmd_source_addr = addr;
+    gp0_words_needed = 5;
+    memcpy(gp0_cmd_buf, packet, sizeof(packet));
+    gpu_ws_tag_background_prim(addr - 4u);
+    assert(!gpu_ws_background_stretch_active());
+    assert(!ws_nw_explicit_background());
+
+    configure_native_wide_16_9();
+    gpu_ws_tag_background_prim(0x80000000u | (addr - 4u));
+    assert(gpu_ws_background_stretch_active());
+    assert(ws_nw_explicit_background());
+    /* Explicit proof remains valid after a foreground phase has begun. */
+    s_bg_phase_frame = (uint32_t)s_frame_count;
+    s_bg_phase_over = 1;
+    assert(psx_ws_prim_in_backdrop() == 1);
+    assert(memcmp(&test_ram[addr / 4u], packet, sizeof(packet)) == 0);
+
+    for (unsigned i = 0; i < 5; ++i) {
+        gp0_cmd_buf[i] ^= 1u;
+        assert(!ws_nw_explicit_background());
+        gp0_cmd_buf[i] ^= 1u;
+    }
+    gp0_cmd_source_addr += 4u;
+    assert(!ws_nw_explicit_background());
+    gp0_cmd_source_addr -= 4u;
+    gp0_words_needed = 4;
+    assert(!ws_nw_explicit_background());
+    gp0_words_needed = 5;
+    s_frame_count += 2;
+    assert(ws_nw_explicit_background());
+    ++s_frame_count;
+    assert(!gpu_ws_background_stretch_active());
+    assert(!ws_nw_explicit_background());
+    s_frame_count = 99;
+    assert(!gpu_ws_background_stretch_active());
+    s_frame_count = 100;
+    ws_mode = 0;
+    assert(!gpu_ws_background_stretch_active());
+
+    /* Reject semi-transparent polygons, rectangles, misalignment and RAM
+     * overflow; a rejected tag must not even enable the full-composite path. */
+    const uint32_t bad_prim[] = {addr - 3u, 0xFFFFFFFCu, 0x801FFFFCu,
+                                 0x1F800000u};
+    reset_gpu_state_for_test();
+    configure_native_wide_16_9();
+    for (unsigned i = 0; i < sizeof(bad_prim) / sizeof(bad_prim[0]); ++i)
+        gpu_ws_tag_background_prim(bad_prim[i]);
+    assert(!gpu_ws_background_stretch_active());
+    const uint32_t bad_op[] = {0x2Au, 0x2Eu, 0x3Eu, 0x64u, 0x40u};
+    for (unsigned i = 0; i < sizeof(bad_op) / sizeof(bad_op[0]); ++i) {
+        test_ram[addr / 4u] = bad_op[i] << 24;
+        gpu_ws_tag_background_prim(addr - 4u);
+        assert(!gpu_ws_background_stretch_active());
+    }
+    /* The GTE-produced textured quad also qualifies, with all nine words
+     * covered by its guard, including the last UV word. */
+    test_ram[addr / 4u] = 0x2DFFFFFFu;
+    gpu_ws_tag_background_prim(addr - 4u);
+    gp0_cmd_source_addr = addr;
+    gp0_words_needed = 9;
+    memcpy(gp0_cmd_buf, &test_ram[addr / 4u], 9u * sizeof(uint32_t));
+    assert(ws_nw_explicit_background());
+    gp0_cmd_buf[8] ^= 0x10000u;
+    assert(!ws_nw_explicit_background());
+}
+
 int main(void) {
     reset_gpu_state_for_test();
     set_dot_packet(0x10004u, 137, 42);
@@ -120,7 +196,8 @@ int main(void) {
     draw_offset_x = 2;
     exec_dot_and_expect(54, 42);
 
-    puts("gpu_textured_dot_nw_shift_exec_test: PASS");
+    test_background_packet_tags();
+    puts("gpu_textured_dot_nw_shift_exec_test: PASS (HUD and background tags)");
     return 0;
 }
 

--- a/runtime/tests/test_gpu_textured_dot_nw_shift_exec.c
+++ b/runtime/tests/test_gpu_textured_dot_nw_shift_exec.c
@@ -113,11 +113,13 @@ static void test_background_packet_tags(void) {
     memcpy(gp0_cmd_buf, packet, sizeof(packet));
     gpu_ws_tag_background_prim(addr - 4u);
     assert(!gpu_ws_background_stretch_active());
+    assert(!gpu_ws_background_requires_full_composite());
     assert(!ws_nw_explicit_background());
 
     configure_native_wide_16_9();
     gpu_ws_tag_background_prim(0x80000000u | (addr - 4u));
     assert(gpu_ws_background_stretch_active());
+    assert(gpu_ws_background_requires_full_composite());
     assert(ws_nw_explicit_background());
     /* Explicit proof remains valid after a foreground phase has begun. */
     s_bg_phase_frame = (uint32_t)s_frame_count;
@@ -141,11 +143,19 @@ static void test_background_packet_tags(void) {
     ++s_frame_count;
     assert(!gpu_ws_background_stretch_active());
     assert(!ws_nw_explicit_background());
+    /* A held display retains its stretched pixels after packet expiry. The
+     * compositor must not paste canonical 4:3 scenery over their center. */
+    assert(gpu_ws_background_requires_full_composite());
+    s_frame_count += 120;
+    assert(gpu_ws_background_requires_full_composite());
+    assert(!ws_nw_explicit_background());
     s_frame_count = 99;
     assert(!gpu_ws_background_stretch_active());
+    assert(gpu_ws_background_requires_full_composite());
     s_frame_count = 100;
     ws_mode = 0;
     assert(!gpu_ws_background_stretch_active());
+    assert(!gpu_ws_background_requires_full_composite());
 
     /* Reject semi-transparent polygons, rectangles, misalignment and RAM
      * overflow; a rejected tag must not even enable the full-composite path. */
@@ -153,6 +163,7 @@ static void test_background_packet_tags(void) {
                                  0x1F800000u};
     reset_gpu_state_for_test();
     configure_native_wide_16_9();
+    assert(!gpu_ws_background_requires_full_composite());
     for (unsigned i = 0; i < sizeof(bad_prim) / sizeof(bad_prim[0]); ++i)
         gpu_ws_tag_background_prim(bad_prim[i]);
     assert(!gpu_ws_background_stretch_active());


### PR DESCRIPTION
## Parked work / not ready to merge

Dependency draft for Vigilante 8's widescreen checkpoint. Owner requested that
work be parked in draft PRs; this is not release acceptance.

Game draft: https://github.com/mstan/Vigilante8PSXRecomp/pull/3.
Parallel parked Crash work: https://github.com/mstan/CrashBandicootRecomp/pull/1
(Crash does not depend on this new background-tag API).

## Done

- Add guarded explicit background polygon tags for opaque, verified composites.
- Stretch only tagged backgrounds in native-wide rendering; retain canonical
  VRAM, default-off behavior, packet-content checks and two-frame tag freshness.
- Preserve tags across GL batching and keep full-width composition after a
  background tag, until GPU reset/snapshot restore. Packet expiry must not let
  canonical-center blitting overwrite still-displayed stretched pixels.
- Document the API and add focused tag/expiry/composite-lifetime regressions.

## Validation

- Focused `test_gpu_textured_dot_nw_shift_exec` compiled and passed.
- V8 Windows runtime rebuilt; 2/2 game CTests passed.
- Owner's latest refinery 21:9 observation: terrain seems fine; background
  flicker remains but is less severe. Partial improvement, not a complete fix.
- State replay required HLE scheduling; repeat A/B with matched scheduler and
  BIOS settings before attributing that improvement solely to this change.

## Outstanding / next

- Reproduce remaining oil-field background flicker over a full camera rotation;
  inspect original sky/fill submission and both wide display buffers.
- Check full-composite lifetime across held displays, reset/load and mode changes,
  and measure performance with the center-copy optimization disabled.
- Broader mod-off/default 4:3, 16:9, 21:9 and software/GL visual coverage.
- Vulkan native-wide remains unsupported; this PR does not add it.

Tracking: central Beads `beads-eio.3.144`; V8 task `beads-eio.5.2`.
No copyrighted inputs, generated code, saves, screenshots or binaries included.
