### PR TITLE
fix(runtime): restore builds without optional netplay auth

### DIFF
--- a/recompiler/CMakeLists.txt
+++ b/recompiler/CMakeLists.txt
@@ -496,6 +496,10 @@ if(BUILD_TESTING)
 
     find_package(Python3 COMPONENTS Interpreter)
     if(Python3_Interpreter_FOUND)
+        add_test(NAME optional_netplay_auth
+            COMMAND ${Python3_EXECUTABLE}
+                ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_optional_netplay_auth.py
+                --cxx ${CMAKE_CXX_COMPILER})
         add_test(
             NAME cli_project_packaging
             COMMAND ${Python3_EXECUTABLE}

--- a/recompiler/tests/test_optional_netplay_auth.py
+++ b/recompiler/tests/test_optional_netplay_auth.py
@@ -1,0 +1,56 @@
+"""Preprocess actual main.cpp guards without needing SDL/UI/net dependencies.
+
+Only unrelated include directives are removed; conditionals and production
+account code stay intact. This is a feature-boundary test, not a C++ link test.
+Real no-netplay title compile/link regression is additionally required.
+"""
+import argparse
+from pathlib import Path
+import re
+import subprocess
+import tempfile
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--cxx", required=True)
+    ap.add_argument("--source", type=Path,
+                    default=Path(__file__).resolve().parents[2] / "runtime/src/main.cpp")
+    args = ap.parse_args()
+    source = args.source.read_text(encoding="utf-8")
+    lines = source.splitlines()
+    source = "\n".join(line for line in lines if not re.match(r"\s*#\s*include\b", line)
+                       or "recomp_net/" in line)
+    with tempfile.TemporaryDirectory(prefix="psx-auth-guard-") as tmp:
+        root = Path(tmp)
+        unit = root / "main-guards.cpp"
+        unit.write_text(source, encoding="utf-8")
+        is_msvc = Path(args.cxx).stem.lower() in ("cl", "clang-cl")
+        for enabled in (False, True):
+            if enabled:
+                (root / "recomp_net").mkdir()
+                (root / "recomp_net/auth.h").write_text("RNET_AUTH_HEADER_INCLUDED\n")
+                (root / "recomp_net/chat_filter.h").write_text("RNET_CHAT_HEADER_INCLUDED\n")
+            flags = ["RECOMP_LAUNCHER=1", "RECOMP_LAUNCHER_HAS_ACCOUNT=1",
+                     "SDL_VERSION_ATLEAST(x,y,z)=1", "DEFAULT_DEBUG_PORT=4370"]
+            if enabled:
+                flags += ["PSX_HAS_RECOMP_NET=1", "PSX_HAS_LOBBY_CLIENT=1"]
+            if is_msvc:
+                cmd = [args.cxx, "/nologo", "/EP", "/TP", "/I"+str(root),
+                       *["/D"+f for f in flags], str(unit)]
+            else:
+                cmd = [args.cxx, "-E", "-P", "-x", "c++", "-I", str(root),
+                       *["-D"+f for f in flags], str(unit)]
+            p = subprocess.run(cmd, capture_output=True, text=True, encoding="utf-8",
+                               errors="replace", timeout=30)
+            assert p.returncode == 0, p.stderr
+            if enabled:
+                for token in ("RNET_AUTH_HEADER_INCLUDED", "rnet_account_pump()",
+                              "ae_np_account_login_begin", "account_available = ae_np_account_available"):
+                    assert token in p.stdout, f"enabled path lost {token}"
+            else:
+                assert "rnet_account_" not in p.stdout, "offline launcher retained account linkage"
+                assert "RNET_ACCOUNT_" not in p.stdout, "offline launcher retained account state dependency"
+        print("PASS: offline launcher needs no auth headers/symbols; enabled account path retained")
+
+if __name__ == "__main__":
+    main()

--- a/recompiler/tests/test_optional_netplay_auth.py
+++ b/recompiler/tests/test_optional_netplay_auth.py
@@ -50,7 +50,20 @@ def main():
             else:
                 assert "rnet_account_" not in p.stdout, "offline launcher retained account linkage"
                 assert "RNET_ACCOUNT_" not in p.stdout, "offline launcher retained account state dependency"
-        print("PASS: offline launcher needs no auth headers/symbols; enabled account path retained")
+        # Compile the REAL offline lobby TU too: its early chat-report include
+        # used to leak an independent optional dependency before the #else.
+        lobby = args.source.parent / "psx_lobby_client.c"
+        includes = args.source.parent.parent / "include"
+        if is_msvc:
+            cmd = [args.cxx, "/nologo", "/TC", "/c", "/I"+str(includes),
+                   str(lobby), "/Fo"+str(root / "lobby.obj")]
+        else:
+            cmd = [args.cxx, "-x", "c", "-c", "-I", str(includes), str(lobby),
+                   "-o", str(root / "lobby.obj")]
+        p = subprocess.run(cmd, capture_output=True, text=True, encoding="utf-8",
+                           errors="replace", timeout=30)
+        assert p.returncode == 0, p.stderr
+        print("PASS: offline launcher/auth guards and real offline lobby compilation; enabled account path retained")
 
 if __name__ == "__main__":
     main()

--- a/runtime/src/main.cpp
+++ b/runtime/src/main.cpp
@@ -57,8 +57,8 @@ extern "C" void psx_event_step_conservative_env_init(void);
 #include "psx_netplay_rb.h"
 #include "psx_selfcheck.h"
 #include "psx_lobby_client.h"
-#include "recomp_net/auth.h"
 #if defined(PSX_HAS_RECOMP_NET)
+#include "recomp_net/auth.h"
 #include "recomp_net/chat_filter.h" /* chat profanity mask, LAN rooms too */
 #endif
 #include "spu.h"
@@ -10024,6 +10024,7 @@ namespace {
         }
         return psx_lobby_send_chat(line);
     }
+#if defined(PSX_HAS_RECOMP_NET)
     /* ---- optional Discord sign-in -------------------------------------
      * Thin adapters over psx_netplay_auth, which owns the HTTP, the worker
      * thread and the device key. Nothing here blocks a frame except the
@@ -10060,6 +10061,8 @@ namespace {
         s_auth_url = url;
         rnet_account_init(url.c_str());
     }
+
+#endif /* PSX_HAS_RECOMP_NET: account client is not linked in offline builds */
 
     /* ---- list scope --------------------------------------------------------
      * The launcher forks LAN / Direct IP from online before the browser, and
@@ -10971,6 +10974,7 @@ namespace {
     }
 
     void ae_np_pump(void*) {
+#if defined(PSX_HAS_RECOMP_NET)
         /* Redeems a stored device key on the first pump, so a machine that has
          * signed in once comes up signed in with no player action. */
         ae_np_account_sync();
@@ -10991,6 +10995,7 @@ namespace {
             if (handle && handle[0] && (!shown || std::strcmp(shown, handle) != 0))
                 psx_lobby_set_display_name(handle);
         }
+#endif
         psx_lobby_pump();
         ae_np_lan_browse_pump();
         ae_np_lan_udp_pump();

--- a/runtime/src/psx_lobby_client.c
+++ b/runtime/src/psx_lobby_client.c
@@ -1,5 +1,4 @@
 #include "psx_lobby_client.h"
-#include "recomp_net/chat_report.h"
 
 #include <ctype.h>
 #include <errno.h>
@@ -173,6 +172,7 @@ void psx_lobby_clear_launch_pending(void) {}
 #include "recomp_net/lan_beacon.h"
 #include "recomp_net/rtt_probe.h"
 #include "recomp_net/chat_filter.h"
+#include "recomp_net/chat_report.h"
 #include "recomp_net/auth.h"   /* optional Discord session for `hello` */
 #include "host_time.h"
 


### PR DESCRIPTION
## Problem

Current master fails fresh `PSX_NETPLAY=OFF` runtime builds because `main.cpp`
unconditionally includes `recomp_net/auth.h`. Launcher-enabled offline builds
also retain direct account-client references even though recomp-net is not linked.

## Change

Guard the auth include, account adapters and account-pump subsection with the
existing `PSX_HAS_RECOMP_NET` feature macro. No guest/runtime timing changes.
Also move `chat_report.h` inside the existing enabled-lobby implementation guard;
the disabled-lobby translation unit must not require recomp-net headers either.
The enabled account implementation is unchanged; absent netplay leaves its
existing optional launcher callbacks unregistered rather than inventing auth stubs.

## Validation

- Fresh baseline and fixed Tomba builds reproduced the missing header on master.
- Added a native-preprocessor test against the actual source guards: offline
  launcher has no auth header/symbol dependency; enabled account callbacks and
  pump remain present. The test fails on unmodified master and passes here.
- Compile the real disabled-lobby C translation unit without recomp-net headers.
- All six fresh no-netplay native builds compile/link: Tomba, MMX6 and Ape Escape,
  each with baseline and repaired CFG generation. Both use this same prerequisite.
- Six cold SCPH-1001 LLE runs reach 11,000 frames and exit 0. Screenshots show
  Tomba FMV and MMX6/Ape gameplay demos; all have native overlay dispatch and
  nonzero guest SPU output. These are bounded smoke runs, not full playthroughs
  or audible host-output checks (headless mode).
- All 67 enabled recompiler CTests pass on the combined validation branch;
  three pre-existing disabled tests are not counted as passes.

No GitHub checks are reported for this PR; the evidence above is local. Online
sign-in/network service behavior was not exercised. Enabled account source paths
are retained and covered by preprocessing, not an end-to-end sign-in test.

Separate from the FMV CFG/IPO experiments. Tracking: `beads-eio.3.151`.
