### PR TITLE
RFC: FMV IRQ batching correctness gates and counterexample

### DIFF
--- a/docs/internal/FMV_IRQ_BATCHING_RFC.md
+++ b/docs/internal/FMV_IRQ_BATCHING_RFC.md
@@ -1,0 +1,97 @@
+# Draft RFC: FMV callback overhead without guest-state changes
+
+Status: design review only. No IRQ batching implementation or runtime flag is
+added. Tracking: `beads-eio.3.150`. The contributor's actual prototype patch,
+instrumentation patch, PE capture bytes and raw measurements are not available.
+
+## What is established
+
+WO-10 correctly identifies repeated generated block callbacks. With precise
+slicing disabled, the runtime slice body returns early, but the DLL still calls
+through its callback shim. That observation does not quantify the host cost.
+WO-11's own trials did not demonstrate a repeatable batching speedup.
+
+The reported missing live CFG predecessors were independently reproduced.
+The live address-order loop heuristic also labels acyclic backward jumps as
+loops. These are separately addressed in [PR #354](https://github.com/RetroPortingToolKit/psxrecomp/pull/354).
+Even corrected static metadata does not enumerate every indirect, alias or CPS
+resume edge; it cannot prove that a block is runtime-private.
+
+## A concrete merge blocker
+
+The supplied design suppresses `psx_icache_fetch` along with IRQ checks.
+That is not simply reducing host calls. The added native test executes the real
+cache model with a header, a cold body on another line, and the header again:
+
+| State | Preserve body fetch | Omit body fetch |
+| --- | ---: | ---: |
+| Charged fetch cycles | 14 | 7 |
+| Pending selected load give-back | 0 | 99 |
+| Body cache tag | `0x80010020` | invalid (`1`) |
+
+The header executes in both cases. The effect matches the in-tree Beetle
+`PS_CPU::ReadInstruction` miss charging and `ReadAbsorb` clearing. This is a
+counterexample to the described operation, not an execution of the missing
+prototype and not certification of every detail of the current cache model.
+
+## Required invariants for any future patch
+
+1. Every executed instruction retains its guest cycle charge, including delay
+   slots and cache/memory/multiply/GTE effects. Cache tags and load give-back
+   evolve identically; removing a host callback must not remove its semantics.
+2. Devices and interrupts remain visible at required guest boundaries. One loop
+   iteration or four blocks is not a cycle/deadline bound. Account for pending
+   IRQs, COP0, nested/irreducible loops, memory effects and long blocks.
+3. Every supported CPS/alias/indirect entry remains valid, including entries
+   not represented by static predecessor edges. A single predecessor is not a
+   privacy proof and static unreachability is not permission to delete code.
+4. Unsupported analysis fails closed to the existing faithful path. No per-game
+   exclusions, generated-C edits or default-on speculative behavior.
+5. Behavior-changing flags participate in emitted-artifact/cache identity.
+   Prove cold/warm and off/on/off transitions cannot reuse the wrong DLL.
+
+Natural-loop classification requires graph structure, not address order; see
+[LLVM's loop definition](https://llvm.org/docs/LoopTerminology.html#loop-definition).
+
+## Supplemental evidence requested
+
+- Exact base revision, complete prototype patch, diagnostic schema patch and
+  the exact enabled flags/build commands. Do not reconstruct the patch from
+  prose and call it the contributor's tested implementation.
+- For PE-specific attribution: capture JSON with bytes, `game.toml`, seeds,
+  matching DLL/manifest identities and bounded raw timing records. Those assets
+  are unavailable locally and must not be invented.
+- Inclusive versus exclusive callback timing; treatment of host preemption,
+  reentrancy and CPS continuations. Unserialized RDTSC/global counters need
+  explicit validation before reporting cycles per guest iteration.
+- Repeatable content-aligned trials with every target invocation represented,
+  not only frames where it was the maximum dispatch. Include per-frame tail
+  latency, audio underruns and guest-state/event-order comparison.
+
+## Acceptance before implementation is considered mergeable
+
+- Synthetic cold/conflicting/uncached fetch, load give-back, pending IRQ,
+  deadline crossing, COP0, delay-slot, alias/CPS, nested-loop and irreducible-CFG
+  tests; explicit first-divergence comparison where state/timing can change.
+- Unmodified default-path output comparison and cache-key transition tests.
+- Regenerated Tomba/MMX6/Ape LLE boot, FMV, menus and gameplay regression with
+  screenshots and progress/state evidence; BIOS/device timing calibrated against
+  the independent Beetle oracle. A visual smoke run alone is insufficient.
+- A demonstrated benefit, measured separately from PGO/LTO/debug configuration.
+
+## Other unresolved brief items
+
+WO-8's PE decoder is a profiling lead, not proof that the guest algorithm alone
+causes the stalls. Any predecode cache or worker-thread proposal first needs
+verified input identity, memory ownership, dependencies and ordering.
+
+WO-9's mismatched DLL/manifest rejection is correct. If a longer rejection
+history is wanted, propose a bounded ring exposed over TCP, preserving pair
+validation and atomic publication. Do not add runtime stderr/file logging.
+
+Current `pgo-train` already finishes the successful profile-use/debug-OFF build.
+Its failure report and exact source revision are needed to investigate the
+claimed early stop. Runtime PGO/LTO do not automatically cover independently
+compiled overlay DLLs. Those build experiments are separate from this RFC.
+
+Nothing in this draft should be merged as an IRQ performance fix.

--- a/docs/internal/FMV_IRQ_BATCHING_RFC.md
+++ b/docs/internal/FMV_IRQ_BATCHING_RFC.md
@@ -1,4 +1,4 @@
-# Draft RFC: FMV callback overhead without guest-state changes
+# RFC: FMV callback overhead without guest-state changes
 
 Status: design review only. No IRQ batching implementation or runtime flag is
 added. Tracking: `beads-eio.3.150`. The contributor's actual prototype patch,

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -99,6 +99,13 @@ if(BUILD_TESTING)
         PSX_OVERLAY_DLL_BUILD=1)
     add_test(NAME psx_icache_fastpath_test COMMAND psx_icache_fastpath_test)
 
+    add_executable(psx_icache_elision_guard_test
+        tests/test_psx_icache_elision_guard.c src/psx_icache.c)
+    target_include_directories(psx_icache_elision_guard_test PRIVATE include)
+    target_compile_definitions(psx_icache_elision_guard_test PRIVATE
+        PSX_ENABLE_BLOCK_CYCLES=1 PSX_OVERLAY_DLL_BUILD=1)
+    add_test(NAME psx_icache_elision_guard_test COMMAND psx_icache_elision_guard_test)
+
     foreach(_ram_geometry IN ITEMS retail expanded)
         add_executable(psx_memory_geometry_${_ram_geometry}_test
             tests/test_psx_memory_geometry.c)

--- a/runtime/tests/test_psx_icache_elision_guard.c
+++ b/runtime/tests/test_psx_icache_elision_guard.c
@@ -1,0 +1,40 @@
+/* Counterexample to dropping interior fetches while retaining header fetches.
+ * This tests the existing cache model, NOT an implementation of IRQ batching.
+ */
+#include "cpu_state.h"
+#include "psx_icache.h"
+#include <stdio.h>
+#include <string.h>
+
+int g_ls_replay_active = 0;
+static uint64_t cycles;
+void psx_advance_cycles(uint32_t count) { cycles += count; }
+
+static uint64_t run(int omit_body, uint32_t *giveback, uint32_t *tag) {
+    CPUState cpu;
+    memset(&cpu, 0, sizeof(cpu));
+    psx_icache_reset();
+    g_psx_icache_active = 1;
+    cycles = 0;
+    psx_icache_fetch(&cpu, 0x80010000u); /* header */
+    cpu.read_absorb_which = 1;
+    cpu.read_absorb[1] = 99;
+    if (!omit_body) psx_icache_fetch(&cpu, 0x80010020u); /* cold body line */
+    psx_icache_fetch(&cpu, 0x80010000u); /* header again */
+    *giveback = cpu.read_absorb[1];
+    *tag = g_psx_icache_tv[8];
+    return cycles;
+}
+
+int main(void) {
+    uint32_t full_giveback, omitted_giveback, full_tag, omitted_tag;
+    uint64_t full = run(0, &full_giveback, &full_tag);
+    uint64_t omitted = run(1, &omitted_giveback, &omitted_tag);
+    if (full != 14 || omitted != 7 || full_giveback != 0 ||
+        omitted_giveback != 99 || full_tag != 0x80010020u || omitted_tag != 1) {
+        puts("FAIL: expected cold-body refill/give-back counterexample changed");
+        return 1;
+    }
+    puts("PASS: header-only fetch loses 7 guest cycles and changes cache/load state");
+    return 0;
+}


### PR DESCRIPTION
## FMV IRQ batching RFC and correctness guard

Preserves all production behavior and records the review gates for the supplied
WO-8–WO-11 FMV briefs. The actual contributor prototype/diagnostic patches and
PE capture bytes are not available, so this deliberately does not reconstruct
an unverified implementation from prose.

Adds a native counterexample against the real I-cache source: retaining header
fetches while omitting a cold interior fetch changes cycles (14 -> 7), load
give-back (0 -> 99) and the body cache tag. The native test passes. It tests the
described elision operation; it does not claim to execute the missing patch.

`docs/internal/FMV_IRQ_BATCHING_RFC.md` records guest-state/deadline/CPS/cache
invariants, synthetic and title/oracle validation requirements, and the exact
supplemental evidence needed. It also explains why decoder profiling, loader
diagnostic history and PGO attribution remain separate questions.

The confirmed structural CFG repair is #354; optional build repair is #355.
There are no experimental IRQ flags, production source modifications or
performance claims in this RFC. It is ready to merge as documentation plus a
regression guard, not as an IRQ batching implementation.

Tracking: `beads-eio.3.150`.
